### PR TITLE
Problems using writeTable on windows

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -581,7 +581,7 @@ class Client
 		if ($this->_isUrl($csvFile->getPathname())) {
 			$options["dataUrl"] = $csvFile->getPathname();
 		} else {
-			$options["data"] = "@{$csvFile->getPathname()}";
+			$options["data"] = "@{$csvFile->getRealPath()}";
 		}
 
 		$result = $this->_apiPost("storage/tables/{$tableId}/import" , $options);


### PR DESCRIPTION
php curl likes the absolute path on windows. I does not work with getPathname only. Not sure of the implications so it's fine if you don't want that in.
