### PR TITLE
detecting non-maintenance 503 status code (missing reason in response)

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1215,7 +1215,7 @@ class Client
 			$response = $e->getResponse();
 			$body = $response->json();
 
-			if ($response->getStatusCode() == 503) {
+			if ($response->getStatusCode() == 503 && isset($body["reason"])) {
 				throw new MaintenanceException($body['reason'], (string) $response->getHeader('Retry-After'), $body);
 			}
 


### PR DESCRIPTION
Fixing this exception:

https://s3.amazonaws.com/keboola-logs/debug-files/2013/11/2013-11-30-20-12-30-529a389e8f581-exception

Storage API returned a non-maintenance 503 response.
