### PR TITLE
Fix for Gzip and tempfile error

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1059,8 +1059,10 @@ class Client
 
 				// gzip file and preserve it's base name
 				$gzFilePath = $currentUploadDir . '/'. basename($fileName) . '.gz';
-				exec(sprintf("gzip -c %s > %s", escapeshellarg($fileName), escapeshellarg($gzFilePath)));
-
+				exec(sprintf("gzip -c %s > %s", escapeshellarg($fileName), escapeshellarg($gzFilePath)), $output, $ret);
+                if ($ret !== 0) {
+                    throw new ClientException("Failed to gzip file, command return code: " . $ret);
+                }
 				$fileName = $gzFilePath;
 			}
 		}

--- a/src/Keboola/StorageApi/Table.php
+++ b/src/Keboola/StorageApi/Table.php
@@ -345,6 +345,8 @@ class Table
 			foreach ($this->_data as $row) {
 				$file->writeRow($row);
 			}
+            // Close the file
+            unset($file);
 		}
 
 		if (!$this->_client->tableExists($this->_id)) {


### PR DESCRIPTION
- Added check if gzip compression succeded. If failed, then the resulting error message was "File sizeBytes must be set" because gziped file was zero size.
- Forced closing of temporary file in Table::save(), otherwise unlink($tempfile); may fail because the file is still open (caused error: unlink(Temp\sapCC7D.tmp): Permission denied)
