### PR TITLE
Fixes remaining usage of hardcoded region

### DIFF
--- a/tests/Keboola/StorageApi/FilesTest.php
+++ b/tests/Keboola/StorageApi/FilesTest.php
@@ -194,7 +194,7 @@ class Keboola_StorageApi_FilesTest extends StorageApiTestCase
 
 		$s3Client = new \Aws\S3\S3Client([
 			'version'     => 'latest',
-			'region'      => 'us-east-1',
+			'region'      => $result['region'],
 			'credentials' => [
 				'key' => $uploadParams['credentials']['AccessKeyId'],
 				'secret' => $uploadParams['credentials']['SecretAccessKey'],
@@ -253,7 +253,7 @@ class Keboola_StorageApi_FilesTest extends StorageApiTestCase
 
 		$s3Client = new \Aws\S3\S3Client([
 			'version'     => 'latest',
-			'region'      => 'us-east-1',
+			'region'      => $slicedFile['region'],
 			'credentials' => [
 				'key' => $uploadParams['credentials']['AccessKeyId'],
 				'secret' => $uploadParams['credentials']['SecretAccessKey'],
@@ -335,7 +335,7 @@ class Keboola_StorageApi_FilesTest extends StorageApiTestCase
 
 		$s3Client = new \Aws\S3\S3Client([
 			'version'     => 'latest',
-			'region'      => 'us-east-1',
+			'region'      => $result['region'],
 			'credentials' => [
 				'key' => $uploadParams['credentials']['AccessKeyId'],
 				'secret' => $uploadParams['credentials']['SecretAccessKey'],
@@ -376,7 +376,7 @@ class Keboola_StorageApi_FilesTest extends StorageApiTestCase
 
 		$s3Client = new \Aws\S3\S3Client([
 			'version'     => 'latest',
-			'region'      => 'us-east-1',
+			'region'      => $preparedFile['region'],
 			'credentials' => [
 				'key' => $uploadParams['credentials']['AccessKeyId'],
 				'secret' => $uploadParams['credentials']['SecretAccessKey'],
@@ -420,7 +420,7 @@ class Keboola_StorageApi_FilesTest extends StorageApiTestCase
 
 		$s3Client = new \Aws\S3\S3Client([
 			'version'     => 'latest',
-			'region'      => 'us-east-1',
+			'region'      => $file['region'],
 			'credentials' => [
 				'key' => $file['credentials']['AccessKeyId'],
 				'secret' => $file['credentials']['SecretAccessKey'],
@@ -632,7 +632,7 @@ class Keboola_StorageApi_FilesTest extends StorageApiTestCase
 
 		$s3Client = new \Aws\S3\S3Client([
 			'version'     => 'latest',
-			'region'      => 'us-east-1',
+			'region'      => $file['region'],
 			'credentials' => [
 				'key' => $file['credentials']['AccessKeyId'],
 				'secret' => $file['credentials']['SecretAccessKey'],

--- a/tests/Keboola/StorageApi/Tables/SlicedImportsTest.php
+++ b/tests/Keboola/StorageApi/Tables/SlicedImportsTest.php
@@ -43,7 +43,8 @@ class Keboola_StorageApi_Tables_SlicedImportsTest extends StorageApiTestCase
 				'token' => $uploadParams['credentials']['SessionToken'],
 			],
 			'version' => 'latest',
-			'region' => 'us-east-1'
+			'region' => $slicedFile['region'],
+
 		]);
 		$s3Client->putObject(array(
 			'Bucket' => $uploadParams['bucket'],
@@ -106,7 +107,7 @@ class Keboola_StorageApi_Tables_SlicedImportsTest extends StorageApiTestCase
 				'token' => $uploadParams['credentials']['SessionToken'],
 			],
 			'version' => 'latest',
-			'region' => 'us-east-1'
+			'region' => $slicedFile['region'],
 		]);
 		$part1URL = $s3Client->putObject(array(
 			'Bucket' => $uploadParams['bucket'],
@@ -208,7 +209,7 @@ class Keboola_StorageApi_Tables_SlicedImportsTest extends StorageApiTestCase
 				'token' => $uploadParams['credentials']['SessionToken'],
 			],
 			'version' => 'latest',
-			'region' => 'us-east-1'
+			'region' => $slicedFile['region'],
 		]);
 		$part1URL = $s3Client->putObject(array(
 			'Bucket' => $uploadParams['bucket'],
@@ -268,7 +269,7 @@ class Keboola_StorageApi_Tables_SlicedImportsTest extends StorageApiTestCase
 				'token' => $uploadParams['credentials']['SessionToken'],
 			],
 			'version' => 'latest',
-			'region' => 'us-east-1'
+			'region' => $slicedFile['region'],
 		]);
 		$part1URL = $s3Client->putObject(array(
 			'Bucket' => $uploadParams['bucket'],
@@ -287,7 +288,7 @@ class Keboola_StorageApi_Tables_SlicedImportsTest extends StorageApiTestCase
 				'token' => $uploadParams['credentials']['SessionToken'],
 			],
 			'version' => 'latest',
-			'region' => 'us-east-1'
+			'region' => $slicedFile['region'],
 		]);
 
 		$s3Client->putObject(array(


### PR DESCRIPTION
Also, there were problem with `testEncryptionMustBeSetWhenEnabled` in `eu-central-1` region.

Setting another signature version should fix it:
```
AWS.config(
  region: 'eu-central-1',
  s3_signature_version: :v4
)
```