### PR TITLE
Configuration restore

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3339,6 +3339,7 @@ List all configs for a component including all config rows.
 #### Parameters
 
 * **component_id** - component id
+* **isDeleted** - Default filter will return only active configurations. If you want to list deleted configurations, set this parameter to `1`.
 
 + Parameters
     + component_id: id of the component
@@ -3367,6 +3368,7 @@ List all configs for a component including all config rows.
                 },
                 "version": 2,
                 "changeDescription": "Row row1 added",
+                "isDeleted": false,
                 "configuration": {
                   "key1": "val1"
                 },
@@ -3462,13 +3464,20 @@ Get component configuration
           "id": "main-1",
           "name": "My first db config",
           "description": "",
+          "isDeleted": false,
           "configuration": {},
           "state": {},
           "rows": {}
         }
 
 ### Delete config [DELETE]
-Delete configuration configuration
+Delete configuration.
+
+Configuration remains still available in system.
+You can [list deleted](#reference/component-configurations/component-configs/list-configs) configurations or [restore](#reference/component-configurations/manage-configs/restore-deleted-config) configuration.
+Other operations with configuration are restricted.
+
+Calling `delete` API call again will delete configuration permanently.
 
 + Request
     + Headers
@@ -3476,6 +3485,27 @@ Delete configuration configuration
             X-StorageApi-Token: your_token
 
 + Response 204
+
+### Restore deleted config [POST]
+
+Removes `isDeleted` flag of deleted configuration
+
++ Request
+    + Headers
+
+            X-StorageApi-Token: your_token
+
++ Response 200
+
+        {
+          "id": "main-1",
+          "name": "My first db config",
+          "description": "",
+          "isDeleted": false,
+          "configuration": {},
+          "state": {},
+          "rows": {}
+        }
 
 ### Update config [PUT]
 Update configuration

--- a/apiary.apib
+++ b/apiary.apib
@@ -3486,6 +3486,9 @@ Calling `delete` API call again will delete configuration permanently.
 
 + Response 204
 
+
+## Configuration Restore [/v2/storage/components/{component_id}/configs/{config_id}/restore]
+
 ### Restore deleted config [POST]
 
 Removes `isDeleted` flag of deleted configuration

--- a/src/Keboola/StorageApi/Components.php
+++ b/src/Keboola/StorageApi/Components.php
@@ -99,11 +99,8 @@ class Components
         return $this->client->apiGet("storage/components?" . http_build_query($options->toParamsArray()));
     }
 
-    public function listComponentConfigurations(ListComponentConfigurationsOptions $options = null)
+    public function listComponentConfigurations(ListComponentConfigurationsOptions $options)
     {
-        if (!$options) {
-            $options = new ListConfigurationVersionsOptions();
-        }
         return $this->client->apiGet("storage/components/{$options->getComponentId()}/configs?" . http_build_query($options->toParamsArray()));
     }
 
@@ -112,11 +109,8 @@ class Components
         return $this->client->apiPost("storage/components/{$componentId}/configs/{$configurationId}/restore");
     }
 
-    public function listConfigurationVersions(ListConfigurationVersionsOptions $options = null)
+    public function listConfigurationVersions(ListConfigurationVersionsOptions $options)
     {
-        if (!$options) {
-            $options = new ListConfigurationVersionsOptions();
-        }
         return $this->client->apiGet("storage/components/{$options->getComponentId()}/configs/"
             . "{$options->getConfigurationId()}/versions?" . http_build_query($options->toParamsArray()));
     }
@@ -198,12 +192,8 @@ class Components
         );
     }
 
-    public function listConfigurationRowVersions(ListConfigurationRowVersionsOptions $options = null)
+    public function listConfigurationRowVersions(ListConfigurationRowVersionsOptions $options)
     {
-        if (!$options) {
-            $options = new ListConfigurationVersionsOptions();
-        }
-
         return $this->client->apiGet(
             sprintf(
                 "storage/components/%s/configs/%s/rows/%s/versions?%s",

--- a/src/Keboola/StorageApi/Components.php
+++ b/src/Keboola/StorageApi/Components.php
@@ -11,6 +11,7 @@ namespace Keboola\StorageApi;
 
 use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
+use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
 use Keboola\StorageApi\Options\Components\ListConfigurationRowsOptions;
 use Keboola\StorageApi\Options\Components\ListConfigurationRowVersionsOptions;
 use Keboola\StorageApi\Options\Components\ListComponentsOptions;
@@ -98,12 +99,20 @@ class Components
         return $this->client->apiGet("storage/components?" . http_build_query($options->toParamsArray()));
     }
 
-    public function listComponentConfigurations($componentId)
+    public function listComponentConfigurations(ListComponentConfigurationsOptions $options = null)
     {
-        return $this->client->apiGet("storage/components/{$componentId}/configs");
+        if (!$options) {
+            $options = new ListConfigurationVersionsOptions();
+        }
+        return $this->client->apiGet("storage/components/{$options->getComponentId()}/configs?" . http_build_query($options->toParamsArray()));
     }
 
-	public function listConfigurationVersions(ListConfigurationVersionsOptions $options = null)
+    public function restoreComponentConfiguration($componentId, $configurationId)
+    {
+        return $this->client->apiPost("storage/components/{$componentId}/configs/{$configurationId}/restore");
+    }
+
+    public function listConfigurationVersions(ListConfigurationVersionsOptions $options = null)
     {
         if (!$options) {
             $options = new ListConfigurationVersionsOptions();

--- a/src/Keboola/StorageApi/Components.php
+++ b/src/Keboola/StorageApi/Components.php
@@ -98,12 +98,12 @@ class Components
         return $this->client->apiGet("storage/components?" . http_build_query($options->toParamsArray()));
     }
 
-    public function getComponentConfigurations($componentId)
+    public function listComponentConfigurations($componentId)
     {
         return $this->client->apiGet("storage/components/{$componentId}/configs");
     }
 
-    public function listConfigurationVersions(ListConfigurationVersionsOptions $options = null)
+	public function listConfigurationVersions(ListConfigurationVersionsOptions $options = null)
     {
         if (!$options) {
             $options = new ListConfigurationVersionsOptions();

--- a/src/Keboola/StorageApi/Components.php
+++ b/src/Keboola/StorageApi/Components.php
@@ -13,7 +13,7 @@ use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApi\Options\Components\ListConfigurationRowsOptions;
 use Keboola\StorageApi\Options\Components\ListConfigurationRowVersionsOptions;
-use Keboola\StorageApi\Options\Components\ListConfigurationsOptions;
+use Keboola\StorageApi\Options\Components\ListComponentsOptions;
 use Keboola\StorageApi\Options\Components\ListConfigurationVersionsOptions;
 
 class Components
@@ -90,10 +90,10 @@ class Components
         return $this->client->apiDelete("storage/components/{$componentId}/configs/{$configurationId}");
     }
 
-    public function listComponents(ListConfigurationsOptions $options = null)
+    public function listComponents(ListComponentsOptions $options = null)
     {
         if (!$options) {
-            $options = new ListConfigurationsOptions();
+            $options = new ListComponentsOptions();
         }
         return $this->client->apiGet("storage/components?" . http_build_query($options->toParamsArray()));
     }

--- a/src/Keboola/StorageApi/Options/Components/ListComponentConfigurationsOptions.php
+++ b/src/Keboola/StorageApi/Options/Components/ListComponentConfigurationsOptions.php
@@ -1,0 +1,52 @@
+<?php
+namespace Keboola\StorageApi\Options\Components;
+
+class ListComponentConfigurationsOptions
+{
+    private $componentId;
+
+    private $isDeleted;
+
+    public function toParamsArray()
+    {
+        return array(
+            'isDeleted' => $this->getIsDeleted(),
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getComponentId()
+    {
+        return $this->componentId;
+    }
+
+    /**
+     * @param mixed $componentId
+     * @return $this
+     */
+    public function setComponentId($componentId)
+    {
+        $this->componentId = $componentId;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getIsDeleted()
+    {
+        return $this->isDeleted;
+    }
+
+    /**
+     * @param mixed $isDeleted
+     * @return $this
+     */
+    public function setIsDeleted($isDeleted)
+    {
+        $this->isDeleted = $isDeleted;
+        return $this;
+    }
+}

--- a/src/Keboola/StorageApi/Options/Components/ListComponentsOptions.php
+++ b/src/Keboola/StorageApi/Options/Components/ListComponentsOptions.php
@@ -9,7 +9,7 @@
 
 namespace Keboola\StorageApi\Options\Components;
 
-class ListConfigurationsOptions
+class ListComponentsOptions
 {
     private $componentType;
 

--- a/src/Keboola/StorageApi/Workspaces.php
+++ b/src/Keboola/StorageApi/Workspaces.php
@@ -13,7 +13,7 @@ use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApi\Options\Components\ListConfigurationRowsOptions;
 use Keboola\StorageApi\Options\Components\ListConfigurationRowVersionsOptions;
-use Keboola\StorageApi\Options\Components\ListConfigurationsOptions;
+use Keboola\StorageApi\Options\Components\ListComponentsOptions;
 use Keboola\StorageApi\Options\Components\ListConfigurationVersionsOptions;
 
 class Workspaces

--- a/src/Keboola/StorageApi/Workspaces.php
+++ b/src/Keboola/StorageApi/Workspaces.php
@@ -9,12 +9,6 @@
 
 namespace Keboola\StorageApi;
 
-use Keboola\StorageApi\Options\Components\Configuration;
-use Keboola\StorageApi\Options\Components\ConfigurationRow;
-use Keboola\StorageApi\Options\Components\ListConfigurationRowsOptions;
-use Keboola\StorageApi\Options\Components\ListConfigurationRowVersionsOptions;
-use Keboola\StorageApi\Options\Components\ListComponentsOptions;
-use Keboola\StorageApi\Options\Components\ListConfigurationVersionsOptions;
 
 class Workspaces
 {

--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -28,7 +28,7 @@ class ComponentsTest extends StorageApiTestCase
         // erase all deleted configurations
 		$index = $this->_client->indexAction();
 		foreach ($index['components'] as $component) {
-			foreach ($components->getComponentConfigurations($component['id'], ['isDeleted' => 1]) as $configuration) {
+			foreach ($components->listComponentConfigurations($component['id'], ['isDeleted' => 1]) as $configuration) {
 				$components->deleteConfiguration($component['id'], $configuration['id']);
 			}
 		}
@@ -40,8 +40,8 @@ class ComponentsTest extends StorageApiTestCase
 		$configurationId = 'main-1';
 		$components = new \Keboola\StorageApi\Components($this->_client);
 
-		$this->assertCount(0, $components->getComponentConfigurations($componentId));
-		$this->assertCount(0, $components->getComponentConfigurations($componentId, ['isDeleted' => 1]));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId, ['isDeleted' => 1]));
 
 		$components->addConfiguration((new \Keboola\StorageApi\Options\Components\Configuration())
 			->setComponentId($componentId)
@@ -61,9 +61,9 @@ class ComponentsTest extends StorageApiTestCase
 
 		$components->deleteConfiguration($componentId, $configurationId);
 
-		$this->assertCount(0, $components->getComponentConfigurations($componentId));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId));
 
-		$componentList = $components->getComponentConfigurations($componentId, ['isDeleted' => 1]);
+		$componentList = $components->listComponentConfigurations($componentId, ['isDeleted' => 1]);
 		$this->assertCount(1, $componentList);
 
 		$component = reset($componentList);
@@ -97,8 +97,8 @@ class ComponentsTest extends StorageApiTestCase
 		$configurationId = 'main-1';
 		$components = new \Keboola\StorageApi\Components($this->_client);
 
-		$this->assertCount(0, $components->getComponentConfigurations($componentId));
-		$this->assertCount(0, $components->getComponentConfigurations($componentId, ['isDeleted' => 1]));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId, ['isDeleted' => 1]));
 
 		$components->addConfiguration((new \Keboola\StorageApi\Options\Components\Configuration())
 			->setComponentId($componentId)
@@ -118,9 +118,9 @@ class ComponentsTest extends StorageApiTestCase
 
 		$components->deleteConfiguration($componentId, $configurationId);
 
-		$this->assertCount(0, $components->getComponentConfigurations($componentId));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId));
 
-		$componentList = $components->getComponentConfigurations($componentId, ['isDeleted' => 1]);
+		$componentList = $components->listComponentConfigurations($componentId, ['isDeleted' => 1]);
 		$this->assertCount(1, $componentList);
 
 		$component = reset($componentList);
@@ -135,8 +135,8 @@ class ComponentsTest extends StorageApiTestCase
 
 		$components->deleteConfiguration($componentId, $configurationId);
 
-		$this->assertCount(0, $components->getComponentConfigurations($componentId));
-		$this->assertCount(0, $components->getComponentConfigurations($componentId, ['isDeleted' => 1]));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId, ['isDeleted' => 1]));
 	}
 
     public function testComponentConfigRestore()
@@ -145,8 +145,8 @@ class ComponentsTest extends StorageApiTestCase
 		$configurationId = 'main-1';
 		$components = new \Keboola\StorageApi\Components($this->_client);
 
-		$this->assertCount(0, $components->getComponentConfigurations($componentId));
-		$this->assertCount(0, $components->getComponentConfigurations($componentId, ['isDeleted' => 1]));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId, ['isDeleted' => 1]));
 
 		$components->addConfiguration((new \Keboola\StorageApi\Options\Components\Configuration())
 			->setComponentId($componentId)
@@ -166,9 +166,9 @@ class ComponentsTest extends StorageApiTestCase
 
 		$components->deleteConfiguration($componentId, $configurationId);
 
-		$this->assertCount(0, $components->getComponentConfigurations($componentId));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId));
 
-		$componentList = $components->getComponentConfigurations($componentId, ['isDeleted' => 1]);
+		$componentList = $components->listComponentConfigurations($componentId, ['isDeleted' => 1]);
 		$this->assertCount(1, $componentList);
 
 		$component = reset($componentList);
@@ -183,9 +183,9 @@ class ComponentsTest extends StorageApiTestCase
 
 		$components->restoreComponentConfiguration($componentId, $configurationId);
 
-		$this->assertCount(0, $components->getComponentConfigurations($componentId, ['isDeleted' => 1]));
+		$this->assertCount(0, $components->listComponentConfigurations($componentId, ['isDeleted' => 1]));
 
-		$componentList = $components->getComponentConfigurations($componentId);
+		$componentList = $components->listComponentConfigurations($componentId);
 		$this->assertCount(1, $componentList);
 
 		$component = reset($componentList);
@@ -1717,7 +1717,7 @@ class ComponentsTest extends StorageApiTestCase
     {
         $components = new \Keboola\StorageApi\Components($this->_client);
 
-        $configs = $components->getComponentConfigurations('transformation');
+        $configs = $components->listComponentConfigurations('transformation');
         $this->assertEmpty($configs);
 
         $components->addConfiguration((new \Keboola\StorageApi\Options\Components\Configuration())
@@ -1729,7 +1729,7 @@ class ComponentsTest extends StorageApiTestCase
             ->setConfigurationId('main-2')
             ->setName('Main 2'));
 
-        $configs = $components->getComponentConfigurations('transformation');
+        $configs = $components->listComponentConfigurations('transformation');
         $this->assertCount(2, $configs);
     }
 
@@ -1737,7 +1737,7 @@ class ComponentsTest extends StorageApiTestCase
     {
         $components = new \Keboola\StorageApi\Components($this->_client);
 
-        $configs = $components->getComponentConfigurations('transformation');
+        $configs = $components->listComponentConfigurations('transformation');
         $this->assertEmpty($configs);
 
         $configData1 = ['key1' => 'val1'];
@@ -1753,7 +1753,7 @@ class ComponentsTest extends StorageApiTestCase
         $components->addConfigurationRow((new \Keboola\StorageApi\Options\Components\ConfigurationRow($configuration))
             ->setRowId('row1')
             ->setConfiguration($configData2));
-        $configs = $components->getComponentConfigurations('transformation');
+        $configs = $components->listComponentConfigurations('transformation');
         $this->assertCount(1, $configs);
         $this->assertEquals($configData1, $configs[0]['configuration']);
         $this->assertEquals($configData2, $configs[0]['rows'][0]['configuration']);

--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -841,7 +841,7 @@ class ComponentsTest extends StorageApiTestCase
 
         $components->addConfigurationRow($configurationRow);
 
-        $listOptions = new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions();
+        $listOptions = new \Keboola\StorageApi\Options\Components\ListComponentsOptions();
         $listOptions->setInclude(array('rows'));
         $components = $components->listComponents($listOptions);
 
@@ -875,7 +875,7 @@ class ComponentsTest extends StorageApiTestCase
         $result = $components->listConfigurationVersions($config);
         $this->assertCount(5, $result);
 
-        $listOptions = new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions();
+        $listOptions = new \Keboola\StorageApi\Options\Components\ListComponentsOptions();
         $listOptions->setInclude(array('rows'));
         $components = $components->listComponents($listOptions);
 
@@ -979,7 +979,7 @@ class ComponentsTest extends StorageApiTestCase
         $configs = $components->listComponents();
         $this->assertCount(2, $configs);
 
-        $configs = $components->listComponents((new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions())
+        $configs = $components->listComponents((new \Keboola\StorageApi\Options\Components\ListComponentsOptions())
             ->setComponentType('writer'));
 
         $this->assertCount(2, $configs[0]['configurations']);
@@ -989,7 +989,7 @@ class ComponentsTest extends StorageApiTestCase
         $this->assertArrayNotHasKey('configuration', $configuration);
 
         // list with configuration body
-        $configs = $components->listComponents((new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions())
+        $configs = $components->listComponents((new \Keboola\StorageApi\Options\Components\ListComponentsOptions())
             ->setComponentType('writer')
             ->setInclude(array('configuration')));
 
@@ -1118,7 +1118,7 @@ class ComponentsTest extends StorageApiTestCase
 
         $components->addConfigurationRow($configurationRow);
 
-        $listOptions = new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions();
+        $listOptions = new \Keboola\StorageApi\Options\Components\ListComponentsOptions();
         $listOptions->setInclude(array('rows'));
         $components = $components->listComponents($listOptions);
 
@@ -1186,7 +1186,7 @@ class ComponentsTest extends StorageApiTestCase
 
         $components->addConfigurationRow($configurationRow);
 
-        $listOptions = new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions();
+        $listOptions = new \Keboola\StorageApi\Options\Components\ListComponentsOptions();
         $listOptions->setInclude(array('rows'));
         $components = $components->listComponents($listOptions);
 
@@ -1291,7 +1291,7 @@ class ComponentsTest extends StorageApiTestCase
 
         $components->addConfigurationRow($configurationRow);
 
-        $listOptions = new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions();
+        $listOptions = new \Keboola\StorageApi\Options\Components\ListComponentsOptions();
         $listOptions->setInclude(array('rows'));
         $components = $components->listComponents($listOptions);
 
@@ -1403,7 +1403,7 @@ class ComponentsTest extends StorageApiTestCase
 
         $components->addConfigurationRow($configurationRow);
 
-        $listOptions = new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions();
+        $listOptions = new \Keboola\StorageApi\Options\Components\ListComponentsOptions();
         $listOptions->setInclude(array('rows'));
         $components = $components->listComponents($listOptions);
 
@@ -1543,7 +1543,7 @@ class ComponentsTest extends StorageApiTestCase
 
         $components->addConfigurationRow($configurationRow);
 
-        $listOptions = new \Keboola\StorageApi\Options\Components\ListConfigurationsOptions();
+        $listOptions = new \Keboola\StorageApi\Options\Components\ListComponentsOptions();
         $listOptions->setInclude(array('rows'));
         $components = $components->listComponents($listOptions);
 


### PR DESCRIPTION
Allows list and restore deleted configs

BC breaks:
- `ListConfigOptions` class renamed to `ListComponentsOptions`
- `Components::getComponentConfigurations` method renamed to `Components::getComponentConfigurations` and accept only one param (object of `ListComponentConfigurationsOptions`)