### PR TITLE
[WIP?] Allow override delay method

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -63,7 +63,7 @@ class Client
 
     /**
      * If provided the client will deliver these mock responses to requests
-     * @var mixed|null
+     * @var mixed[]|null
      */
     private $mockResponses;
 
@@ -2260,5 +2260,16 @@ class Client
     public function isAwsDebug()
     {
         return $this->awsDebug;
+    }
+
+    /**
+     * @return \GuzzleHttp\Client|null
+     */
+    public function getBaseMockClient()
+    {
+        if ($this->mockResponses) {
+            return $this->client;
+        }
+        return null;
     }
 }

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -62,6 +62,12 @@ class Client
     private $retryDelay;
 
     /**
+     * If provided the client will deliver these mock responses to requests
+     * @var mixed|null
+     */
+    private $mockResponses;
+
+    /**
      * @var \GuzzleHttp\Client
      */
     private $client;
@@ -136,15 +142,25 @@ class Client
         if (isset($config['retryDelay'])) {
             $this->retryDelay = $config['retryDelay'];
         }
+
+        if (isset($config['mockResponses'])) {
+            $this->mockResponses = $config['mockResponses'];
+        }
+
         $this->initClient();
     }
 
     private function initClient()
     {
         $stackOptions = ['backoffMaxTries' => $this->backoffMaxTries];
+
         if ($this->retryDelay) {
             $stackOptions['retryDelay'] = $this->retryDelay;
         }
+        if ($this->mockResponses) {
+            $stackOptions['mockResponses'] = $this->mockResponses;
+        }
+
         $handlerStack = HandlerStack::create($stackOptions);
 
         if ($this->logger) {

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -134,7 +134,7 @@ class Client
         }
 
         if (isset($config['retryDelay'])) {
-            $this->retryDelay = $config['delayMethod'];
+            $this->retryDelay = $config['retryDelay'];
         }
         $this->initClient();
     }
@@ -143,7 +143,7 @@ class Client
     {
         $stackOptions = ['backoffMaxTries' => $this->backoffMaxTries];
         if ($this->retryDelay) {
-            $stackOptions['retryDely'] = $this->retryDelay;
+            $stackOptions['retryDelay'] = $this->retryDelay;
         }
         $handlerStack = HandlerStack::create($stackOptions);
 

--- a/src/Keboola/StorageApi/HandlerStack.php
+++ b/src/Keboola/StorageApi/HandlerStack.php
@@ -24,7 +24,7 @@ final class HandlerStack
         $handlerStack = HandlerStackBase::create();
         $handlerStack->push(Middleware::retry(
             self::createDefaultDecider(isset($options['backoffMaxTries']) ? $options['backoffMaxTries'] : 0),
-            self::createExponentialDelay()
+            isset($options['retryDelay']) ? $options['retryDelay'] : self::createExponentialDelay()
         ));
         return $handlerStack;
     }

--- a/src/Keboola/StorageApi/HandlerStack.php
+++ b/src/Keboola/StorageApi/HandlerStack.php
@@ -7,6 +7,7 @@
  */
 namespace Keboola\StorageApi;
 
+use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack as HandlerStackBase;
 use GuzzleHttp\Middleware;
 use Psr\Http\Message\RequestInterface;
@@ -21,7 +22,11 @@ final class HandlerStack
 {
     public static function create($options = [])
     {
-        $handlerStack = HandlerStackBase::create();
+        $mockHandler = null;
+        if (isset($options['mockResponses'])) {
+            $mockHandler = new MockHandler($options['mockResponses']);
+        }
+        $handlerStack = HandlerStackBase::create($mockHandler);
         $handlerStack->push(Middleware::retry(
             self::createDefaultDecider(isset($options['backoffMaxTries']) ? $options['backoffMaxTries'] : 0),
             isset($options['retryDelay']) ? $options['retryDelay'] : self::createExponentialDelay()

--- a/tests/Common/ClientRetriesTest.php
+++ b/tests/Common/ClientRetriesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Keboola\Test\Common;
+
+use GuzzleHttp\Psr7\Response;
+use Keboola\StorageApi\Client;
+use Keboola\Test\StorageApiTestCase;
+
+class ClientRetriesTest extends StorageApiTestCase
+{
+    /**
+     * @return callable
+     */
+    private static function getLinearRetryDelay()
+    {
+        return function (int $tries) : int {
+          return $tries * 1000;
+        };
+    }
+
+    public function testDefaultRetries()
+    {
+        $mockResponses = [
+            new Response(500, [], 'This should be an error'),
+            new Response(500, [], ''),
+            new Response(500, [], ''),
+            new Response(500, [], ''),
+            new Response(200, [], 'The good response')
+        ];
+
+        $client = new Client([
+            'token' => STORAGE_API_TOKEN,
+            'url' => STORAGE_API_URL,
+            'backoffMaxTries' => 4,
+            'mockResponses' => $mockResponses
+        ]);
+
+        // with 4 retries, the default exponential delay should behave like
+        // first retry delay 1 sec
+        // second retry delay 2 sec
+        // third retry delay 4 sec
+        // fourth retry delay 8 sec
+        // so in 16 seconds
+        $mockClient = $client->getBaseMockClient();
+        $start = time();
+        $response = $mockClient->request('GET', '/');
+        $duration = time() - $start;
+
+        // we'll give it +/- 1 second
+        $this->assertGreaterThan(14, $duration);
+        $this->assertLessThan(18, $duration);
+
+        $this->assertEquals('The good response', $response->getBody());
+    }
+
+    public function testLinearDelay()
+    {
+        $mockResponses = [
+            new Response(500, [], 'This should be an error'),
+            new Response(500, [], ''),
+            new Response(500, [], ''),
+            new Response(500, [], ''),
+            new Response(200, [], 'The good response')
+        ];
+
+        $client = new Client([
+            'token' => STORAGE_API_TOKEN,
+            'url' => STORAGE_API_URL,
+            'backoffMaxTries' => 4,
+            'retryDelay' => self::getLinearRetryDelay(),
+            'mockResponses' => $mockResponses
+        ]);
+
+        // with 4 retries, the default exponential delay should behave like
+        // first retry delay 1 sec
+        // second retry delay 2 sec
+        // third retry delay 3 sec
+        // fourth retry delay 4 sec
+        // so in 9 seconds
+        $mockClient = $client->getBaseMockClient();
+        $start = time();
+        $response = $mockClient->request('GET', '/');
+        $duration = time() - $start;
+
+        // we'll give it +/- 1 second
+        $this->assertGreaterThan(7, $duration);
+        $this->assertLessThan(11, $duration);
+
+        $this->assertEquals('The good response', $response->getBody());
+    }
+}


### PR DESCRIPTION
ref: https://github.com/keboola/storage-api-php-client/issues/171

ok, this is a pretty simple addition that allows the passing of a method as a options parameter to use a custom delay rule.

It may be worthwhile to add the ability to create a mock sapi client here too by using MockHandler, maybe