### PR TITLE
fix(apiary) removed state from include options in version list

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3783,7 +3783,7 @@ Marks the latest version of a configuration as published.
 Lists all versions of a component configuration.
 
 + Parameters
-    + include (optional) - Comma separated list of information to be retrieved; possible fields are `name`, `description`, `configuration`, and `state`.
+    + include (optional) - Comma separated list of information to be retrieved; possible fields are `name`, `description` and `configuration`.
         Default: `name,description`
     + limit (optional, number) - Pagination limit
         Default: 100


### PR DESCRIPTION
Updated doc due: https://github.com/keboola/connection/issues/1226#issuecomment-380484066