### PR TITLE
fix - unstable test

### DIFF
--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -879,6 +879,9 @@ class ComponentsTest extends StorageApiTestCase
         // update config
         $componentsApi->updateConfiguration($configuration->setConfiguration(['d' => 'b']));
 
+        // wait a moment, rollbacked version should have different created date
+        sleep(2);
+
         // rollback to version 2
         // second row should be missing, and first row should be rolled back to first version
         $componentsApi->rollbackConfiguration('wr-db', $newConfiguration['id'], 2);


### PR DESCRIPTION
FIXES:
```
common                   -	1) Keboola\Test\Common\ComponentsTest::testConfigurationRollback
common                   -	Failed asserting that '2018-04-13T09:34:52+0200' is not equal to <string:2018-04-13T09:34:52+0200>.
common                   -	
common                   -	/code/tests/StorageApiTestCase.php:45
common                   -	/code/tests/Common/ComponentsTest.php:894
```