### PR TITLE
fix: count file size after files are compressed

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1432,13 +1432,6 @@ class Client
             $transferOptions = new FileUploadTransferOptions();
         }
 
-        $fileSize = 0;
-        foreach ($slices as $filePath) {
-            if (!is_readable($filePath)) {
-                throw new ClientException("File is not readable: " . $filePath, null, null, 'fileNotReadable');
-            }
-            $fileSize += filesize($filePath);
-        }
         $newOptions = clone $options;
         $fs = null;
         $currentUploadDir = null;
@@ -1472,6 +1465,14 @@ class Client
             }
         }
 
+        $fileSize = 0;
+        foreach ($slices as $filePath) {
+            if (!is_readable($filePath)) {
+                throw new ClientException("File is not readable: " . $filePath, null, null, 'fileNotReadable');
+            }
+            $fileSize += filesize($filePath);
+        }
+        
         $newOptions
             ->setSizeBytes($fileSize)
             ->setFederationToken(true)

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1472,7 +1472,7 @@ class Client
             }
             $fileSize += filesize($filePath);
         }
-        
+
         $newOptions
             ->setSizeBytes($fileSize)
             ->setFederationToken(true)

--- a/tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+++ b/tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
@@ -170,5 +170,8 @@ class SlicedImportsWithSlicedUploadsTest extends StorageApiTestCase
             'enclosure' => '',
             'withoutHeaders' => true,
         ));
+
+        $tableInfo = $this->_client->getTable($tableId);
+        $this->assertEquals($tableInfo['rowsCount'], 13973);
     }
 }

--- a/tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+++ b/tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
@@ -148,4 +148,27 @@ class SlicedImportsWithSlicedUploadsTest extends StorageApiTestCase
             $this->assertEquals('csvImport.columnsNotMatch', $e->getStringCode());
         }
     }
+
+    public function testSlicedImportCompress()
+    {
+        $uploadOptions = new \Keboola\StorageApi\Options\FileUploadOptions();
+        $uploadOptions
+            ->setFileName('entries_')
+            ->setIsEncrypted(true)
+            ->setIsSliced(true)
+            ->setCompress(true);
+        $slices = [
+            __DIR__ . '/../../_data/sliced/neco_0000_part_00',
+        ];
+        $slicedFileId = $this->_client->uploadSlicedFile($slices, $uploadOptions);
+
+        $headerFile = new CsvFile(__DIR__ . '/../../_data/sliced/header.csv');
+        $tableId = $this->_client->createTable($this->getTestBucketId(self::STAGE_IN), 'entries', $headerFile);
+        $this->_client->writeTableAsyncDirect($tableId, array(
+            'dataFileId' => $slicedFileId,
+            'delimiter' => '|',
+            'enclosure' => '',
+            'withoutHeaders' => true,
+        ));
+    }
 }

--- a/tests/Backend/CommonPart2/UploadSlicedFileTest.php
+++ b/tests/Backend/CommonPart2/UploadSlicedFileTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Keboola\Test\Backend\CommonPart2;
+
+use Keboola\StorageApi\ClientException;
+use Keboola\Test\StorageApiTestCase;
+
+use Keboola\Csv\CsvFile;
+
+class UploadSlicedFileTest extends StorageApiTestCase
+{
+    public function testNoCompress()
+    {
+        $uploadOptions = new \Keboola\StorageApi\Options\FileUploadOptions();
+        $uploadOptions
+            ->setFileName('entries_')
+            ->setIsEncrypted(true)
+            ->setIsSliced(true)
+            ->setCompress(false);
+        $slices = [
+            __DIR__ . '/../../_data/sliced/neco_0000_part_00',
+        ];
+        $slicedFileId = $this->_client->uploadSlicedFile($slices, $uploadOptions);
+        $slicedFile = $this->_client->getFile($slicedFileId);
+
+        $this->assertEquals(filesize(__DIR__ . '/../../_data/sliced/neco_0000_part_00'), $slicedFile['sizeBytes']);
+    }
+
+    public function testCompress()
+    {
+        $uploadOptions = new \Keboola\StorageApi\Options\FileUploadOptions();
+        $uploadOptions
+            ->setFileName('entries_')
+            ->setIsEncrypted(true)
+            ->setIsSliced(true)
+            ->setCompress(true);
+        $slices = [
+            __DIR__ . '/../../_data/sliced/neco_0000_part_00',
+        ];
+        $slicedFileId = $this->_client->uploadSlicedFile($slices, $uploadOptions);
+        $slicedFile = $this->_client->getFile($slicedFileId);
+
+        $this->assertLessThan(filesize(__DIR__ . '/../../_data/sliced/neco_0000_part_00'), $slicedFile['sizeBytes']);
+    }
+}


### PR DESCRIPTION
Fixes #234, required for https://github.com/keboola/output-mapping/issues/20

V metodě `uploadSlicedFile` se počítá souhrnná velikost souborů (součet sliců). Chybně se to počítalo před tím, než se soubory komprimovaly. Přesunul jsem počítání velilkosti až po kompresi.

Kompresi teď AFAIK nic nepoužívá, takže impact by to nemělo mít žádný.

Přidal jsem k tomu tři testy

 - `SlicedImportsWithSlicedUploadsTest::testSlicedImportCompress` testuje, zda se tabulka naimportuje správně, když se uploadu nastaví, že se má komprimovat
- `UploadSlicedFileTest::testCompress` testuje, zda komprese opravdu proběhla (velikost souboru lokálně a po uploadu), upload se neimportuje do tabulky
- `UploadSlicedFileTest::testNoCompress` ověřuje, že se uploadovaný soubor nekomprimuje (velikost souborů je stejná), upload se neimportuje do tabulky