### PR TITLE
feat: queue table export

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -756,11 +756,22 @@ class Client
     /**
      * @param $tableId
      * @param array $options
-     * @return mixed|string
+     * @return int
      */
     public function queueTableImport($tableId, $options = array())
     {
         $job = $this->apiPost("storage/tables/{$tableId}/import-async", $this->writeTableOptionsPrepare($options), false);
+        return $job["id"];
+    }
+
+    /**
+     * @param $tableId
+     * @param $options
+     * @return int
+     */
+    public function queueTableExport($tableId, $options = array())
+    {
+        $job = $this->apiPost("storage/tables/{$tableId}/export-async", $this->prepareExportOptions($options), false);
         return $job["id"];
     }
 

--- a/src/Keboola/StorageApi/TableExporter.php
+++ b/src/Keboola/StorageApi/TableExporter.php
@@ -195,7 +195,7 @@ class TableExporter
      * @param array $tables
      * @throws Exception
      */
-    public function exportTables($tables = array())
+    public function exportTables(array $tables = array())
     {
         $exportJobs = [];
         foreach ($tables as $table) {

--- a/src/Keboola/StorageApi/TableExporter.php
+++ b/src/Keboola/StorageApi/TableExporter.php
@@ -199,10 +199,10 @@ class TableExporter
     {
         $exportJobs = [];
         foreach ($tables as $table) {
-            if (!isset($table['tableId'])) {
+            if (empty($table['tableId'])) {
                 throw new Exception('Missing tableId');
             }
-            if (!isset($table['destination'])) {
+            if (empty($table['destination'])) {
                 throw new Exception('Missing destination');
             }
             if (!isset($table['exportOptions'])) {

--- a/src/Keboola/StorageApi/TableExporter.php
+++ b/src/Keboola/StorageApi/TableExporter.php
@@ -184,4 +184,21 @@ class TableExporter
 
         return;
     }
+
+    public function exportTables($tables = array())
+    {
+        foreach ($tables as $table) {
+            if (!isset($table['tableId'])) {
+                throw new Exception('Missing tableId');
+            }
+            if (!isset($table['destination'])) {
+                throw new Exception('Missing destination');
+            }
+            if (!isset($table['exportOptions'])) {
+                $table['exportOptions'] = array();
+            }
+
+            $this->exportTable($table['tableId'], $table['destination'], $table['exportOptions']);
+        }
+    }
 }

--- a/tests/Backend/CommonPart1/TableExporterTest.php
+++ b/tests/Backend/CommonPart1/TableExporterTest.php
@@ -10,6 +10,7 @@
 
 namespace Keboola\Test\Backend\CommonPart1;
 
+use Keboola\StorageApi\Exception;
 use Keboola\Test\StorageApiTestCase;
 use Keboola\StorageApi\Client;
 use Keboola\Csv\CsvFile;
@@ -65,7 +66,7 @@ class TableExporterTest extends StorageApiTestCase
 
         // compare data
         $this->assertTrue(file_exists($this->downloadPath));
-        $this->assertLinesEqualsSorted(file_get_contents($expectationsFile), file_get_contents($this->downloadPath), 'imported data comparsion');
+        $this->assertLinesEqualsSorted(file_get_contents($expectationsFile), file_get_contents($this->downloadPath), 'imported data comparison');
     }
 
     public function testLimitParameter()
@@ -82,6 +83,56 @@ class TableExporterTest extends StorageApiTestCase
         $this->assertTrue(file_exists($this->downloadPath));
         $parsed = Client::parseCsv(file_get_contents($this->downloadPath));
         $this->assertCount($exportOptions['limit'], $parsed);
+    }
+
+
+    public function testExportTables()
+    {
+        $filesBasePath = __DIR__ . '/../../_data/';
+        $table1Id = $this->_client->createTableAsync($this->getTestBucketId(self::STAGE_IN), 'languages1', new CsvFile($filesBasePath . 'languages.csv'));
+        $table2Id = $this->_client->createTableAsync($this->getTestBucketId(self::STAGE_IN), 'languages2', new CsvFile($filesBasePath . 'languages.csv'));
+        $exporter = new TableExporter($this->_client);
+        $file1 = __DIR__ . '/../../_tmp/languages1.csv';
+        $file2 = __DIR__ . '/../../_tmp/languages2.csv';
+        $exports = array(
+            array(
+                'tableId' => $table1Id,
+                'destination' => $file1
+            ),
+            array(
+                'tableId' => $table2Id,
+                'destination' => $file2
+            )
+
+        );
+        $exporter->exportTables($exports);
+        // compare data
+        $this->assertTrue(file_exists($file1));
+        $this->assertTrue(file_exists($file2));
+        $this->assertLinesEqualsSorted(file_get_contents($filesBasePath . 'languages.csv'), file_get_contents($file1), 'imported data comparison');
+        $this->assertLinesEqualsSorted(file_get_contents($filesBasePath . 'languages.csv'), file_get_contents($file2), 'imported data comparison');
+    }
+
+    public function testExportTablesMissingTableId()
+    {
+        $exporter = new TableExporter($this->_client);
+        try {
+            $exporter->exportTables(array(array()));
+            $this->fail('Missing exception');
+        } catch (Exception $e) {
+            $this->assertEquals('Missing tableId', $e->getMessage());
+        }
+    }
+
+    public function testExportTablesMissingDestination()
+    {
+        $exporter = new TableExporter($this->_client);
+        try {
+            $exporter->exportTables(array(array('tableId' => 'dummy')));
+            $this->fail('Missing exception');
+        } catch (Exception $e) {
+            $this->assertEquals('Missing destination', $e->getMessage());
+        }
     }
 
     public function tableImportData()

--- a/tests/Backend/CommonPart1/TableExporterTest.php
+++ b/tests/Backend/CommonPart1/TableExporterTest.php
@@ -124,6 +124,17 @@ class TableExporterTest extends StorageApiTestCase
         }
     }
 
+    public function testExportTablesEmptyTableId()
+    {
+        $exporter = new TableExporter($this->_client);
+        try {
+            $exporter->exportTables(array(array('tableId' => '')));
+            $this->fail('Missing exception');
+        } catch (Exception $e) {
+            $this->assertEquals('Missing tableId', $e->getMessage());
+        }
+    }
+
     public function testExportTablesMissingDestination()
     {
         $exporter = new TableExporter($this->_client);
@@ -135,6 +146,17 @@ class TableExporterTest extends StorageApiTestCase
         }
     }
 
+    public function testExportTablesEmptyDestination()
+    {
+        $exporter = new TableExporter($this->_client);
+        try {
+            $exporter->exportTables(array(array('tableId' => 'dummy', 'destination' => '')));
+            $this->fail('Missing exception');
+        } catch (Exception $e) {
+            $this->assertEquals('Missing destination', $e->getMessage());
+        }
+    }
+    
     public function tableImportData()
     {
         $filesBasePath = __DIR__ . '/../../_data/';

--- a/tests/Backend/CommonPart1/TableExporterTest.php
+++ b/tests/Backend/CommonPart1/TableExporterTest.php
@@ -10,6 +10,7 @@
 
 namespace Keboola\Test\Backend\CommonPart1;
 
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Exception;
 use Keboola\Test\StorageApiTestCase;
 use Keboola\StorageApi\Client;
@@ -156,7 +157,18 @@ class TableExporterTest extends StorageApiTestCase
             $this->assertEquals('Missing destination', $e->getMessage());
         }
     }
-    
+
+    public function testExportTablesInvalidTable()
+    {
+        $exporter = new TableExporter($this->_client);
+        try {
+            $exporter->exportTables(array(array('tableId' => 'in.c-dummy.dummy', 'destination' => 'dummy')));
+            $this->fail('Missing exception');
+        } catch (ClientException $e) {
+            $this->assertContains('The table "dummy" was not found in the bucket "in.c-dummy"', $e->getMessage());
+        }
+    }
+
     public function tableImportData()
     {
         $filesBasePath = __DIR__ . '/../../_data/';

--- a/tests/Common/QueueJobsTest.php
+++ b/tests/Common/QueueJobsTest.php
@@ -48,4 +48,12 @@ class QueueJobsTest extends StorageApiTestCase
         $this->assertEquals('myTable', $job['operationParams']['source']['tableName']);
         $this->assertEquals('workspace', $job['operationParams']['source']['type']);
     }
+
+    public function testQueueTableExport()
+    {
+        $jobId = $this->_client->queueTableExport('in.c-test.table1', []);
+        $job = $this->_client->getJob($jobId);
+        $this->assertEquals('in.c-test.table1', $job['tableId']);
+        $this->assertEquals('tableExport', $job['operationName']);
+    }
 }


### PR DESCRIPTION
FIXES #236 

- nová fce `Client::queueTableExport`, která založí exportní job (tabulka -> s3) a vrátí `jobId`
- přeházený kód v `TableExporter` a nová metoda `TableExporter::exportTables`, která přijímá pole asociativích polí argumentů (dřívější) metody `TableExporter::exportTable`
- `TableExporter::exportTable` nyní zabalí argumenty do pole a zavolá `TableExporter::exportTables` (takže se existujícími testy pokryje nová funkcionalita)
- v testech se navíc testuje, že se provedou exporty dvou souborů (`testExportTables`) 