### PR TITLE
Removes raw&escaped format from tests and client

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1183,7 +1183,6 @@ class Client
      *  - (timestamp | strtotime format) changedUntil
      *  - (bool) escape
      *  - (array) columns
-     *  - (string) format - rfc or json, where rfc is default
      * @return array job results
      */
     public function exportTableAsync($tableId, $options = array())

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1183,7 +1183,7 @@ class Client
      *  - (timestamp | strtotime format) changedUntil
      *  - (bool) escape
      *  - (array) columns
-     *  - (string) format - one of rfc, raw, escaped. rfc is default
+     *  - (string) format - rfc or json, where rfc is default
      * @return array job results
      */
     public function exportTableAsync($tableId, $options = array())

--- a/src/Keboola/StorageApi/TableExporter.php
+++ b/src/Keboola/StorageApi/TableExporter.php
@@ -98,26 +98,8 @@ class TableExporter
             }
 
             // Create file with header
-            $format = 'rfc';
             $delimiter = ",";
             $enclosure = '"';
-            if (isset($exportOptions['format'])) {
-                $format = $exportOptions['format'];
-            }
-            switch ($format) {
-                case 'raw':
-                    $delimiter = "\t";
-                    $enclosure = "";
-                    break;
-                case 'rfc':
-                    $delimiter = ",";
-                    $enclosure = '"';
-                    break;
-                case 'escaped':
-                    $delimiter = ",";
-                    $enclosure = '"';
-                    break;
-            }
 
             if (isset($exportOptions["columns"])) {
                 $columns = $exportOptions["columns"];

--- a/tests/Backend/CommonPart1/TableExporterTest.php
+++ b/tests/Backend/CommonPart1/TableExporterTest.php
@@ -186,10 +186,6 @@ class TableExporterTest extends StorageApiTestCase
             array([self::BACKEND_REDSHIFT, self::BACKEND_SNOWFLAKE], new CsvFile($filesBasePath . '64K.csv'), '64K.csv'),
             array([self::BACKEND_REDSHIFT, self::BACKEND_SNOWFLAKE], new CsvFile($filesBasePath . '64K.csv'), '64K.csv',  array('gzip' => true)),
 
-            array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'escaping.csv'), 'escaping.backslash.redshift.out.csv', array('format' => 'escaped')),
-            array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'escaping.csv'), 'escaping.backslash.redshift.out.csv', array('format' => 'escaped')),
-            array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'escaping.csv'), 'escaping.raw.redshift.out.csv', array('format' => 'raw')),
-            array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'escaping.csv'), 'escaping.raw.redshift.out.csv', array('gzip' => true, 'format' => 'raw')),
             array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'escaping.csv'), 'escaping.standard.out.csv', array('gzip' => true)),
             array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'numbers.csv'), 'numbers.csv', array('gzip' => true)),
             array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'numbers.csv'), 'numbers.two-cols.csv', array('gzip' => true, 'columns' => array('0', '45'))),

--- a/tests/_data/escaping.backslash.redshift.out.csv
+++ b/tests/_data/escaping.backslash.redshift.out.csv
@@ -1,8 +1,0 @@
-"col1","col2_with_space"
-"line without enclosure","second column"
-"line with enclosure","second column"
-"column with enclosure "", and comma inside text","second column enclosure in text """
-"columns with new line","columns with tab"
-"column with backshash \ inside","column with backslash and enclosure \"""
-"column with \n \t \\","second col"
-"first","something with  double new line"

--- a/tests/_data/escaping.raw.redshift.out.csv
+++ b/tests/_data/escaping.raw.redshift.out.csv
@@ -1,8 +1,0 @@
-col1	col2_with_space
-line without enclosure	second column
-line with enclosure	second column
-column with enclosure ", and comma inside text	second column enclosure in text "
-columns with new line	columns with tab
-column with backshash \ inside	column with backslash and enclosure \"
-column with \n \t \\	second col
-first	something with  double new line


### PR DESCRIPTION
Testy se mi nějak nepodařily lokálně spustit. Rozeběhlo se to a nic nedělalo. V logu apache je jenom:
```
[08/Jan/2019:12:12:34 +0000] "GET /v2/storage/jobs/8 HTTP/1.1" 200 2370 "-" "Keboola Storage API PHP Client/10.4.0" "-"
```
Pořád dokola.
