### PR TITLE
fixup tests: tokens list and get

### DIFF
--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -579,10 +579,12 @@ class TokensTest extends StorageApiTestCase
 
     public function testTokenWithoutTokensManagePermissionCanListAndViewOnlySelf()
     {
+        $initialTokens = $this->_client->listTokens();
+
         $tokenId = $this->_client->createToken([], 'Token without canManageTokens permission');
 
         $tokens = $this->_client->listTokens();
-        $this->assertGreaterThan(1, count($tokens));
+        $this->assertCount(count($initialTokens) + 1, $tokens);
 
         $token = $this->_client->getToken($tokenId);
         $this->assertFalse($token['canManageTokens']);

--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -582,7 +582,7 @@ class TokensTest extends StorageApiTestCase
         $tokenId = $this->_client->createToken([], 'Token without canManageTokens permission');
 
         $tokens = $this->_client->listTokens();
-        $this->assertCount(2, $tokens);
+        $this->assertGreaterThan(1, count($tokens));
 
         $token = $this->_client->getToken($tokenId);
         $this->assertFalse($token['canManageTokens']);


### PR DESCRIPTION
Drobny fix pro predchozi PR:

https://github.com/keboola/storage-api-php-client/pull/290

Na testingu test padal, protoze v testovacim projektu je zrejme vic uzivatelu s master tokenem.
Udelal jsem teda test nezavislej na poctu tokenu.