### PR TITLE
Testing last run is not null

### DIFF
--- a/tests/Common/TriggersTest.php
+++ b/tests/Common/TriggersTest.php
@@ -49,7 +49,8 @@ class TriggersTest extends StorageApiTestCase
         $this->assertEquals(123, $trigger['configurationId']);
         $this->assertEquals(10, $trigger['coolDownPeriodMinutes']);
         $this->assertEquals($newTokenId, $trigger['runWithTokenId']);
-        $this->assertEquals(null, $trigger['lastRun']);
+        $this->assertNotNull($trigger['lastRun']);
+        $this->assertLessThan((new \DateTime()), (new \DateTime($trigger['lastRun'])));
         $this->assertEquals(
             [
                 ['tableId' => 'in.c-API-tests.watched-1'],


### PR DESCRIPTION
Přidal jsem test, že last run není `null` a je menší než `NOW()`. Nemáme bohužel žádný čas, kterýho bych se chytil a porovnal to jako equal něco ... 