### PR TITLE
Test for token with expiration and droping token with trigger

### DIFF
--- a/tests/Common/TriggersTest.php
+++ b/tests/Common/TriggersTest.php
@@ -265,4 +265,51 @@ class TriggersTest extends StorageApiTestCase
             'tableIds' => [''],
         ]);
     }
+
+    public function testPreventTokenDelete()
+    {
+        $table1 = $this->createTableWithRandomData("watched-1");
+        $options = (new TokenCreateOptions())
+            ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
+        ;
+        $newTokenId = $this->_client->createToken($options);
+        $trigger = $this->_client->createTrigger([
+            'component' => 'orchestrator',
+            'configurationId' => 123,
+            'coolDownPeriodMinutes' => 10,
+            'runWithTokenId' => $newTokenId,
+            'tableIds' => [
+                $table1,
+            ],
+        ]);
+        try {
+            $this->_client->dropToken($newTokenId);
+            $this->fail("Token should not be deleted");
+        } catch (ClientException $e) {
+            $this->assertEquals(403, $e->getCode());
+            $this->assertEquals('storage.tokens.cannotDeleteDueToOrchestration', $e->getStringCode());
+            $this->assertEquals(
+                'Cannot delete token, bacause it\'s used for event trigger inside component "orchestrator" with configuration id "123"',
+                $e->getMessage()
+            );
+        }
+        $this->_client->deleteTrigger($trigger['id']);
+        $this->_client->dropToken($newTokenId);
+    }
+
+    public function testTokenWithExpiration()
+    {
+        $tokenId = $this->_client->createToken(
+            (new TokenCreateOptions())->setExpiresIn(5)
+        );
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage("The 'runByToken' has expiration set. Use token without expiration.");
+        $this->_client->createTrigger([
+            'component' => 'keboola.ex-manzelka',
+            'configurationId' => 123,
+            'coolDownPeriodMinutes' => 10,
+            'runWithTokenId' => $tokenId,
+            'tableIds' => [''],
+        ]);
+    }
 }

--- a/tests/Common/TriggersTest.php
+++ b/tests/Common/TriggersTest.php
@@ -286,7 +286,7 @@ class TriggersTest extends StorageApiTestCase
             $this->_client->dropToken($newTokenId);
             $this->fail("Token should not be deleted");
         } catch (ClientException $e) {
-            $this->assertEquals(403, $e->getCode());
+            $this->assertEquals(400, $e->getCode());
             $this->assertEquals('storage.tokens.cannotDeleteDueToOrchestration', $e->getStringCode());
             $this->assertEquals(
                 'Cannot delete token, bacause it\'s used for event trigger inside component "orchestrator" with configuration id "123"',
@@ -302,6 +302,8 @@ class TriggersTest extends StorageApiTestCase
         $tokenId = $this->_client->createToken(
             (new TokenCreateOptions())->setExpiresIn(5)
         );
+
+        $this->expectExceptionCode(400);
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage("The 'runByToken' has expiration set. Use token without expiration.");
         $this->_client->createTrigger([


### PR DESCRIPTION
V https://github.com/keboola/storage-api-php-client/pull/307/ jsem se nějak zamotal v rebase a tak jsem radši udělal novou branch a překopíroval těch pár řádek.

Udělal jsem test na:
 -  mazání tokenu, který má na sobě triggery
 - že nelze přiřadit token s expirací k triggeru