### PR TITLE
File id must a positive integer

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1483,6 +1483,9 @@ class Client
      */
     public function getFile($fileId, GetFileOptions $options = null)
     {
+        if (!is_numeric($fileId) || $fileId > 0) {
+            throw new ClientException('File id must be a positive integer');
+        }
         return $this->apiGet("storage/files/$fileId?" . http_build_query($options ? $options->toArray() : array()));
     }
 

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1483,7 +1483,7 @@ class Client
      */
     public function getFile($fileId, GetFileOptions $options = null)
     {
-        if (!is_numeric($fileId) || $fileId > 0) {
+        if (!is_numeric($fileId) || $fileId < 0) {
             throw new ClientException('File id must be a positive integer');
         }
         return $this->apiGet("storage/files/$fileId?" . http_build_query($options ? $options->toArray() : array()));

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1483,9 +1483,7 @@ class Client
      */
     public function getFile($fileId, GetFileOptions $options = null)
     {
-        if (!is_numeric($fileId) || $fileId < 0) {
-            throw new ClientException('File id must be a positive integer');
-        }
+        $this->verifyIsPositiveWholeNumber($fileId, 'File id must be a positive whole number');
         return $this->apiGet("storage/files/$fileId?" . http_build_query($options ? $options->toArray() : array()));
     }
 
@@ -2114,5 +2112,13 @@ class Client
     public function isAwsDebug()
     {
         return $this->awsDebug;
+    }
+
+    private function verifyIsPositiveWholeNumber($value, $errorMessage)
+    {
+        if (((string) (int) $value === (string) $value) && ($value > 0)) {
+            return;
+        }
+        throw new ClientException($errorMessage);
     }
 }

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1483,7 +1483,9 @@ class Client
      */
     public function getFile($fileId, GetFileOptions $options = null)
     {
-        $this->verifyIsPositiveWholeNumber($fileId, 'File id must be a positive whole number');
+        if (empty($fileId)) {
+            throw new ClientException('File id cannot be empty');
+        }
         return $this->apiGet("storage/files/$fileId?" . http_build_query($options ? $options->toArray() : array()));
     }
 
@@ -2112,13 +2114,5 @@ class Client
     public function isAwsDebug()
     {
         return $this->awsDebug;
-    }
-
-    private function verifyIsPositiveWholeNumber($value, $errorMessage)
-    {
-        if (((string) (int) $value === (string) $value) && ($value > 0)) {
-            return;
-        }
-        throw new ClientException($errorMessage);
     }
 }

--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -3,6 +3,7 @@
 namespace Keboola\Test\Common;
 
 use GuzzleHttp\Client;
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\TokenCreateOptions;
 use Keboola\StorageApi\Options\TokenUpdateOptions;
 use Keboola\Test\StorageApiTestCase;
@@ -676,5 +677,26 @@ class FilesTest extends StorageApiTestCase
         $this->_client->addFileTag($fileId, 'new');
         $file = $this->_client->getFile($fileId);
         $this->assertEquals(array('image', 'new'), $file['tags'], 'duplicate tag add is ignored');
+    }
+
+    /** @dataProvider  invalidIdDataProvider*/
+    public function testInvalidFileId($fileId)
+    {
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('File id must be a positive integer');
+        $this->_client->getFile($fileId);
+    }
+
+
+    public function invalidIdDataProvider()
+    {
+        return [
+          [null],
+          ['karel'],
+          [-123],
+          ['-123'],
+          ['-50karlu'],
+          ['karel50'],
+        ];
     }
 }

--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -683,7 +683,7 @@ class FilesTest extends StorageApiTestCase
     public function testInvalidFileId($fileId)
     {
         $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('File id must be a positive whole number');
+        $this->expectExceptionMessage('File id cannot be empty');
         $this->_client->getFile($fileId);
     }
 
@@ -691,16 +691,7 @@ class FilesTest extends StorageApiTestCase
     {
         return [
             [null],
-            ['karel'],
-            [-123],
-            ['-123'],
-            ['-50karlu'],
-            ['karel50'],
-            ['5karlu'],
-            ['5 karlu'],
-            ['12341234.1234124'],
-            ['30E343'],
-            ['34e010']
+            [''],
         ];
     }
 }

--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -683,7 +683,7 @@ class FilesTest extends StorageApiTestCase
     public function testInvalidFileId($fileId)
     {
         $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('File id must be a positive integer');
+        $this->expectExceptionMessage('File id must be a positive whole number');
         $this->_client->getFile($fileId);
     }
 
@@ -698,6 +698,9 @@ class FilesTest extends StorageApiTestCase
             ['karel50'],
             ['5karlu'],
             ['5 karlu'],
+            ['12341234.1234124'],
+            ['30E343'],
+            ['34e010']
         ];
     }
 }

--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -679,7 +679,7 @@ class FilesTest extends StorageApiTestCase
         $this->assertEquals(array('image', 'new'), $file['tags'], 'duplicate tag add is ignored');
     }
 
-    /** @dataProvider  invalidIdDataProvider*/
+    /** @dataProvider  invalidIdDataProvider */
     public function testInvalidFileId($fileId)
     {
         $this->expectException(ClientException::class);

--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -679,7 +679,7 @@ class FilesTest extends StorageApiTestCase
         $this->assertEquals(array('image', 'new'), $file['tags'], 'duplicate tag add is ignored');
     }
 
-    /** @dataProvider  invalidIdDataProvider */
+    /** @dataProvider invalidIdDataProvider */
     public function testInvalidFileId($fileId)
     {
         $this->expectException(ClientException::class);

--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -697,6 +697,7 @@ class FilesTest extends StorageApiTestCase
             ['-50karlu'],
             ['karel50'],
             ['5karlu'],
+            ['5 karlu'],
         ];
     }
 }

--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -687,16 +687,16 @@ class FilesTest extends StorageApiTestCase
         $this->_client->getFile($fileId);
     }
 
-
     public function invalidIdDataProvider()
     {
         return [
-          [null],
-          ['karel'],
-          [-123],
-          ['-123'],
-          ['-50karlu'],
-          ['karel50'],
+            [null],
+            ['karel'],
+            [-123],
+            ['-123'],
+            ['-50karlu'],
+            ['karel50'],
+            ['5karlu'],
         ];
     }
 }


### PR DESCRIPTION
Když je $fileId = null, tak se vlastně místo GET /storage/files/123/ pošle GET /storage/files/, což je metoda pro listování a vrátí se všechny soubory. 

Zkusil jsem jestli to funguje na `null`, `'karel'`, `'-5'` , `-5` a taky jestli projde `123` a `'123'`.