### PR TITLE
PSR logger should not be inside dev dependecies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
 		"guzzlehttp/guzzle": "~6.0",
 		"symfony/filesystem": "^4.0||^3.0||~2.3",
 		"symfony/process": "^4.0||^3.0||~2.3",
-		"aws/aws-sdk-php": "~3.2"
+		"aws/aws-sdk-php": "~3.2",
+		"psr/log": "~1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.6",
 		"squizlabs/php_codesniffer": "^2.7",
 		"apigen/apigen": "4.0.0-RC4",
 		"keboola/php-csv-db-import": "^2.2",
-        "psr/log": "~1.0",
 		"ext-pdo_pgsql": "*",
 		"phpstan/phpstan-shim": "^0.9.2"
 	},


### PR DESCRIPTION
PSR logger je v `require-dev`, ale pak je použitý v `src/Client.php` -> https://github.com/keboola/storage-api-php-client/blob/19f8f2e4a19eee249918d140f152f1eac2ec79c1/src/Keboola/StorageApi/Client.php#L126

Teďka ho používám v MAPI klientovi a PSR NullLogger mi tam chybí, protože `require-dev` se nedistribuuje.