### PR TITLE
Apib - Files are not encrypted by default

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3370,7 +3370,7 @@ For a more detailed guide on the file upload, see the corresponding part of the
     + sliced (optional, boolean) - If true, multiple chunks of a file are allowed to be uploaded. Must be used with `federationToken`.
         Default: false
     + isEncrypted (optional, boolean) - If true, the file content will be encrypted in the S3 storage.
-        Default: true
+        Default: false
 
 + Request (application/x-www-form-urlencoded)
     + Headers


### PR DESCRIPTION
Změnil jsem defaultní hodnotu `isEncrypted` u souborů na false, protože to tak ve skutečnosti je.