### PR TITLE
Tests - federation token required for credentials

### DIFF
--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -24,6 +24,7 @@ class FilesTest extends StorageApiTestCase
         $uploadedFile = reset($files);
         $this->assertEquals($fileId, $uploadedFile['id']);
         $this->assertArrayHasKey('region', $uploadedFile);
+        $this->assertArrayNotHasKey('credentials', $uploadedFile);
     }
 
     public function testFilesListFilterByTags()

--- a/tests/Common/FilesTest.php
+++ b/tests/Common/FilesTest.php
@@ -4,6 +4,7 @@ namespace Keboola\Test\Common;
 
 use GuzzleHttp\Client;
 use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\Options\GetFileOptions;
 use Keboola\StorageApi\Options\TokenCreateOptions;
 use Keboola\StorageApi\Options\TokenUpdateOptions;
 use Keboola\Test\StorageApiTestCase;
@@ -25,6 +26,13 @@ class FilesTest extends StorageApiTestCase
         $this->assertEquals($fileId, $uploadedFile['id']);
         $this->assertArrayHasKey('region', $uploadedFile);
         $this->assertArrayNotHasKey('credentials', $uploadedFile);
+    }
+
+    public function testGetFileWithoutCredentials()
+    {
+        $fileId = $this->createAndWaitForFile(__DIR__ . '/../_data/files.upload.txt', (new FileUploadOptions()));
+        $file = $this->_client->getFile($fileId, (new GetFileOptions())->setFederationToken(false));
+        $this->assertArrayNotHasKey('credentials', $file);
     }
 
     public function testFilesListFilterByTags()


### PR DESCRIPTION
Doplnil jsem do testu kontrolu, že pokud není nastavený federationToken, tak se v `getFile` nevrací credentials.

To, že se `credentials` a `s3Path` vrací při federationToken se už testuje tady:
https://github.com/keboola/storage-api-php-client/blob/59561ca7ff3b7ac1047b5a823a35ae094546aaf4/tests/Common/FilesTest.php#L612-L613