### PR TITLE
/search/tables endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4589,6 +4589,155 @@ Returns all workspaces for the component configuration.
 
    + Attributes (array[Workspace])
 
+# Group Search
+## Search Tables [/v2/storage/search/tables?metadataKey={metadataKey}&metadataValue={metadataValue}&metadataProvider={metadataProvider}&include={include}]
+
+### Search Tables [GET]
+Search all tables accessible by the token by either metadataKey, metadataValue or metadataProvider. By default, all tables are returned with their
+attributes and information about the containing bucket.
+
++ Parameters
+    + include (optional, enum[string]) - Comma separated list of resources to include for each table.
+        + Members
+            + attributes
+            + buckets
+            + columns
+            + metadata
+            + columnMetadata
+        + Default: attributes,metadata
+    + metadataKey (optional, string) - string to search with exact match on one of existing metadata.key
+        + Default: NULL
+    + metadataValue (optional, string) - string to search with exact match on one of existing metadata.value
+        + Default: NULL
+    + metadataProvider (optional, string) - string to search with exact match on one of existing metadata.provider
+        + Default: NULL
++ Request
+    + Headers
+
+            X-StorageApi-Token: your_token
+
++ Response 200 (application/json)
+    + Body
+
+            [
+                {
+                    "uri": "https:\/\/connection.keboola.com\/v2\/storage\/tables\/in.c-application-testing.cashier-data",
+                    "id": "in.c-application-testing.cashier-data",
+                    "name": "cashier-data",
+                    "transactional": false,
+                    "primaryKey": [],
+                    "indexedColumns": [],
+                    "created": "2016-06-23T20:41:07+0200",
+                    "lastImportDate": "2016-07-07T11:25:32+0200",
+                    "lastChangeDate": "2016-07-07T11:25:34+0200",
+                    "rowsCount": 18,
+                    "dataSizeBytes": 12288,
+                    "isAlias": false,
+                    "isAliasable": true,
+                    "attributes": [],
+                    "columns": [
+                        "time_spent_in_shop",
+                        "number_of_items",
+                        "customer_shoe_size",
+                        "customer_age",
+                        "age_segment",
+                        "no_segment",
+                        "customer_segment",
+                        "visit_id"
+                    ],
+                    "bucket": {
+                        "uri": "https:\/\/connection.keboola.com\/v2\/storage\/buckets\/in.c-application-testing",
+                        "id": "in.c-application-testing",
+                        "name": "c-application-testing",
+                        "stage": "in",
+                        "description": "Main project storage",
+                        "tables": "https:\/\/connection.keboola.com\/v2\/storage\/buckets\/in.c-application-testing\/tables",
+                        "created": "2015-02-05T10:57:08+0100",
+                        "lastChangeDate": "2017-02-12T10:36:15+0100",
+                        "isReadOnly": false,
+                        "dataSizeBytes": 685750272,
+                        "rowsCount": 2438881,
+                        "isMaintenance": false,
+                        "backend": "snowflake",
+                        "sharing": null
+                    },
+                    "columnMetadata": {
+                        "number_of_items": [
+                            {
+                                "id": "207947778",
+                                "key": "KBC.datatype.basetype",
+                                "value": "INTEGER",
+                                "provider": "user",
+                                "timestamp": "2019-08-14T16:55:34+0200"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "uri": "https:\/\/connection.keboola.com\/v2\/storage\/tables\/in.c-application-testing.cashier-data-alias",
+                    "id": "in.c-application-testing.cashier-data-alias",
+                    "name": "cashier-data-alias",
+                    "transactional": false,
+                    "primaryKey": [],
+                    "indexedColumns": [],
+                    "created": "2016-06-23T20:41:38+0200",
+                    "lastImportDate": "2016-07-07T11:26:03+0200",
+                    "lastChangeDate": "2016-07-07T11:26:05+0200",
+                    "rowsCount": 48,
+                    "dataSizeBytes": 12288,
+                    "isAlias": true,
+                    "isAliasable": true,
+                    "sourceTable": {
+                        "id": "in.c-application-testing.cashier-data",
+                        "uri": "https:\/\/connection.keboola.com\/v2\/storage\/tables\/in.c-application-testing.cashier-data",
+                        "project": {
+                            "id": 578,
+                            "name": "Some source project"
+                        },
+                        "columnMetadata": {
+                            "number_of_items": [
+                                {
+                                    "id": "207947778",
+                                    "key": "KBC.datatype.basetype",
+                                    "value": "INTEGER",
+                                    "provider": "user",
+                                    "timestamp": "2019-08-14T16:55:34+0200"
+                                }
+                            ]
+                        }
+                    },
+                    "aliasColumnsAutoSync": true,
+                    "attributes": [],
+                    "columns": [
+                        "time_spent_in_shop",
+                        "number_of_items",
+                        "customer_shoe_size",
+                        "customer_age",
+                        "age_segment",
+                        "no_segment",
+                        "customer_segment",
+                        "visit_id"
+                    ],
+                    "bucket": {
+                        "uri": "https:\/\/connection.keboola.com\/v2\/storage\/buckets\/in.c-application-testing",
+                        "id": "in.c-application-testing",
+                        "name": "c-application-testing",
+                        "stage": "in",
+                        "description": "Main project storage",
+                        "tables": "https:\/\/connection.keboola.com\/v2\/storage\/buckets\/in.c-application-testing\/tables",
+                        "created": "2015-02-05T10:57:08+0100",
+                        "lastChangeDate": "2017-02-12T10:36:15+0100",
+                        "isReadOnly": false,
+                        "dataSizeBytes": 685750272,
+                        "rowsCount": 2438881,
+                        "isMaintenance": false,
+                        "backend": "snowflake",
+                        "sharing": null
+                    },
+                    "columnMetadata": []
+                }
+            ]
+
 
 # Group Stats
 ## RunId [/v2/storage/stats?runId={runId}]

--- a/apiary.apib
+++ b/apiary.apib
@@ -4594,7 +4594,7 @@ Returns all workspaces for the component configuration.
 
 ### Search Tables [GET]
 Search all tables accessible by the token by either metadataKey, metadataValue or metadataProvider. By default, all tables are returned with their
-attributes and information about the containing bucket.
+attributes and information about the containing bucket. At least one of parameters metadataKey|metadataValue|metadataProvider must be provided.
 
 + Parameters
     + include (optional, enum[string]) - Comma separated list of resources to include for each table.

--- a/apiary.apib
+++ b/apiary.apib
@@ -4637,13 +4637,7 @@ attributes and information about the containing bucket.
                     "attributes": [],
                     "columns": [
                         "time_spent_in_shop",
-                        "number_of_items",
-                        "customer_shoe_size",
-                        "customer_age",
-                        "age_segment",
-                        "no_segment",
-                        "customer_segment",
-                        "visit_id"
+                        "number_of_items"
                     ],
                     "bucket": {
                         "uri": "https:\/\/connection.keboola.com\/v2\/storage\/buckets\/in.c-application-testing",
@@ -4710,13 +4704,7 @@ attributes and information about the containing bucket.
                     "attributes": [],
                     "columns": [
                         "time_spent_in_shop",
-                        "number_of_items",
-                        "customer_shoe_size",
-                        "customer_age",
-                        "age_segment",
-                        "no_segment",
-                        "customer_segment",
-                        "visit_id"
+                        "number_of_items"
                     ],
                     "bucket": {
                         "uri": "https:\/\/connection.keboola.com\/v2\/storage\/buckets\/in.c-application-testing",

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -971,6 +971,15 @@ class Client
     }
 
     /**
+     * @param array $options
+     * @return array
+     */
+    public function searchTables($options = array())
+    {
+        return $this->apiGet("storage/search/tables?" . http_build_query($options));
+    }
+
+    /**
      * @param $jobId
      * @return array
      */

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Response;
 use Keboola\StorageApi\Options\FileUploadTransferOptions;
 use Keboola\StorageApi\Options\GetFileOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
+use Keboola\StorageApi\Options\SearchTablesOptions;
 use Keboola\StorageApi\Options\StatsOptions;
 use Keboola\StorageApi\Options\TokenCreateOptions;
 use Keboola\StorageApi\Options\TokenUpdateOptions;
@@ -971,12 +972,14 @@ class Client
     }
 
     /**
-     * @param array $options
+     * @param SearchTablesOptions $options
      * @return array
+     * @throws \Exception
      */
-    public function searchTables($options = array())
+    public function searchTables(SearchTablesOptions $options)
     {
-        return $this->apiGet("storage/search/tables?" . http_build_query($options));
+        $options->validate();
+        return $this->apiGet("storage/search/tables?" . http_build_query($options->toArray()));
     }
 
     /**

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -978,7 +978,6 @@ class Client
      */
     public function searchTables(SearchTablesOptions $options)
     {
-        $options->validate();
         return $this->apiGet("storage/search/tables?" . http_build_query($options->toArray()));
     }
 

--- a/src/Keboola/StorageApi/Options/SearchTablesOptions.php
+++ b/src/Keboola/StorageApi/Options/SearchTablesOptions.php
@@ -17,15 +17,12 @@ class SearchTablesOptions
      * @param string|null $metadataKey
      * @param string|null $metadataValue
      * @param string|null $metadataProvider
-     * @return SearchTablesOptions
      */
-    public static function create($metadataKey, $metadataValue, $metadataProvider)
+    public function __construct($metadataKey = null, $metadataValue = null, $metadataProvider = null)
     {
-        $self = new self();
-        $self->metadataKey = $metadataKey;
-        $self->metadataValue = $metadataValue;
-        $self->metadataProvider = $metadataProvider;
-        return $self;
+        $this->metadataKey = $metadataKey;
+        $this->metadataValue = $metadataValue;
+        $this->metadataProvider = $metadataProvider;
     }
 
     /**

--- a/src/Keboola/StorageApi/Options/SearchTablesOptions.php
+++ b/src/Keboola/StorageApi/Options/SearchTablesOptions.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Keboola\StorageApi\Options;
+
+class SearchTablesOptions
+{
+    /** @var string|null */
+    private $metadataKey;
+
+    /** @var string|null */
+    private $metadataValue;
+
+    /** @var string|null */
+    private $metadataProvider;
+
+    /**
+     * @param string|null $metadataKey
+     * @param string|null $metadataValue
+     * @param string|null $metadataProvider
+     * @return SearchTablesOptions
+     */
+    public static function create($metadataKey, $metadataValue, $metadataProvider)
+    {
+        $self = new self();
+        $self->metadataKey = $metadataKey;
+        $self->metadataValue = $metadataValue;
+        $self->metadataProvider = $metadataProvider;
+        return $self;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMetadataKey()
+    {
+        return $this->metadataKey;
+    }
+
+    /**
+     * @param string|null $metadataKey
+     * @return SearchTablesOptions
+     */
+    public function setMetadataKey($metadataKey)
+    {
+        $this->metadataKey = $metadataKey;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMetadataValue()
+    {
+        return $this->metadataValue;
+    }
+
+    /**
+     * @param string|null $metadataValue
+     * @return SearchTablesOptions
+     */
+    public function setMetadataValue($metadataValue)
+    {
+        $this->metadataValue = $metadataValue;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMetadataProvider()
+    {
+        return $this->metadataProvider;
+    }
+
+    /**
+     * @param string|null $metadataProvider
+     * @return SearchTablesOptions
+     */
+    public function setMetadataProvider($metadataProvider)
+    {
+        $this->metadataProvider = $metadataProvider;
+        return $this;
+    }
+
+    public function validate()
+    {
+        foreach ($this->toArray() as $option) {
+            if (!empty($option)) {
+                return;
+            }
+        }
+
+        throw new \Exception('At least one option must be set');
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'metadataKey' => $this->metadataKey,
+            'metadataValue' => $this->metadataValue,
+            'metadataProvider' => $this->metadataProvider,
+        ];
+    }
+}

--- a/src/Keboola/StorageApi/Options/SearchTablesOptions.php
+++ b/src/Keboola/StorageApi/Options/SearchTablesOptions.php
@@ -29,14 +29,6 @@ class SearchTablesOptions
     }
 
     /**
-     * @return string|null
-     */
-    public function getMetadataKey()
-    {
-        return $this->metadataKey;
-    }
-
-    /**
      * @param string|null $metadataKey
      * @return SearchTablesOptions
      */
@@ -44,14 +36,6 @@ class SearchTablesOptions
     {
         $this->metadataKey = $metadataKey;
         return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getMetadataValue()
-    {
-        return $this->metadataValue;
     }
 
     /**
@@ -65,14 +49,6 @@ class SearchTablesOptions
     }
 
     /**
-     * @return string|null
-     */
-    public function getMetadataProvider()
-    {
-        return $this->metadataProvider;
-    }
-
-    /**
      * @param string|null $metadataProvider
      * @return SearchTablesOptions
      */
@@ -80,17 +56,6 @@ class SearchTablesOptions
     {
         $this->metadataProvider = $metadataProvider;
         return $this;
-    }
-
-    public function validate()
-    {
-        foreach ($this->toArray() as $option) {
-            if (!empty($option)) {
-                return;
-            }
-        }
-
-        throw new \Exception('At least one option must be set');
     }
 
     /**

--- a/tests/Common/SearchTablesTest.php
+++ b/tests/Common/SearchTablesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Keboola\Test\Common;
+
+use Keboola\StorageApi\Metadata;
+use Keboola\Test\StorageApiTestCase;
+use Keboola\Csv\CsvFile;
+
+class SearchTablesTest extends StorageApiTestCase
+{
+    const TEST_PROVIDER = "keboola.sapi_client_tests";
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->_initEmptyTestBuckets();
+    }
+
+    public function testSearchTablesNoResult()
+    {
+        $result = $this->_client->searchTables([
+            'metadataKey' => 'nonexisting.key',
+        ]);
+        $this->assertCount(0, $result);
+    }
+
+    public function testSearchTables()
+    {
+        $this->_initTable('table1', [
+            [
+                "key" => "testkey",
+                "value" => "testValue",
+            ],
+        ]);
+
+        $result = $this->_client->searchTables([
+            'metadataKey' => 'testkey',
+        ]);
+        $this->assertCount(1, $result);
+
+        $result = $this->_client->searchTables([
+            'metadataValue' => 'testValue',
+        ]);
+        $this->assertCount(1, $result);
+
+        $result = $this->_client->searchTables([
+            'metadataProvider' => self::TEST_PROVIDER,
+        ]);
+        $this->assertCount(1, $result);
+
+        $result = $this->_client->searchTables([
+            'metadataKey' => 'testkey',
+            'metadataValue' => 'testValue',
+            'metadataProvider' => self::TEST_PROVIDER,
+        ]);
+        $this->assertCount(1, $result);
+    }
+
+    private function _initTable(string $tableName, array $metadata)
+    {
+        $metadataApi = new Metadata($this->_client);
+        $tableId = $this->_client->createTable($this->getTestBucketId(), $tableName, new CsvFile(__DIR__ . '/../_data/languages.csv'));
+
+        $metadataApi->postTableMetadata(
+            $tableId,
+            self::TEST_PROVIDER,
+            $metadata
+        );
+    }
+}

--- a/tests/Common/SearchTablesTest.php
+++ b/tests/Common/SearchTablesTest.php
@@ -57,10 +57,6 @@ class SearchTablesTest extends StorageApiTestCase
             SearchTablesOptions::create('testkey', 'testValue', self::TEST_PROVIDER)
         );
         $this->assertCount(1, $result);
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('At least one option must be set');
-        $this->_client->searchTables(new SearchTablesOptions());
     }
 
     private function _initTable($tableName, array $metadata)

--- a/tests/Common/SearchTablesTest.php
+++ b/tests/Common/SearchTablesTest.php
@@ -37,6 +37,10 @@ class SearchTablesTest extends StorageApiTestCase
                 "value" => "differentValue",
             ],
         ]);
+        $this->_initTable('table-nometa', []);
+
+        $result = $this->_client->searchTables(SearchTablesOptions::create(null, null, null));
+        $this->assertCount(3, $result);
 
         $result = $this->_client->searchTables(
             SearchTablesOptions::create('testkey', null, null)
@@ -64,10 +68,12 @@ class SearchTablesTest extends StorageApiTestCase
         $metadataApi = new Metadata($this->_client);
         $tableId = $this->_client->createTable($this->getTestBucketId(), $tableName, new CsvFile(__DIR__ . '/../_data/languages.csv'));
 
-        $metadataApi->postTableMetadata(
-            $tableId,
-            self::TEST_PROVIDER,
-            $metadata
-        );
+        if (!empty($metadata)) {
+            $metadataApi->postTableMetadata(
+                $tableId,
+                self::TEST_PROVIDER,
+                $metadata
+            );
+        }
     }
 }

--- a/tests/Common/SearchTablesTest.php
+++ b/tests/Common/SearchTablesTest.php
@@ -32,6 +32,12 @@ class SearchTablesTest extends StorageApiTestCase
                 "value" => "testValue",
             ],
         ]);
+        $this->_initTable('table2', [
+            [
+                "key" => "differentkey",
+                "value" => "differentValue",
+            ],
+        ]);
 
         $result = $this->_client->searchTables([
             'metadataKey' => 'testkey',
@@ -46,7 +52,7 @@ class SearchTablesTest extends StorageApiTestCase
         $result = $this->_client->searchTables([
             'metadataProvider' => self::TEST_PROVIDER,
         ]);
-        $this->assertCount(1, $result);
+        $this->assertCount(2, $result);
 
         $result = $this->_client->searchTables([
             'metadataKey' => 'testkey',
@@ -54,6 +60,9 @@ class SearchTablesTest extends StorageApiTestCase
             'metadataProvider' => self::TEST_PROVIDER,
         ]);
         $this->assertCount(1, $result);
+
+        $result = $this->_client->searchTables([]);
+        $this->assertCount(2, $result);
     }
 
     private function _initTable(string $tableName, array $metadata)

--- a/tests/Common/SearchTablesTest.php
+++ b/tests/Common/SearchTablesTest.php
@@ -3,6 +3,7 @@
 namespace Keboola\Test\Common;
 
 use Keboola\StorageApi\Metadata;
+use Keboola\StorageApi\Options\SearchTablesOptions;
 use Keboola\Test\StorageApiTestCase;
 use Keboola\Csv\CsvFile;
 
@@ -18,9 +19,7 @@ class SearchTablesTest extends StorageApiTestCase
 
     public function testSearchTablesNoResult()
     {
-        $result = $this->_client->searchTables([
-            'metadataKey' => 'nonexisting.key',
-        ]);
+        $result = $this->_client->searchTables(SearchTablesOptions::create('nonexisting.key', null, null));
         $this->assertCount(0, $result);
     }
 
@@ -39,33 +38,32 @@ class SearchTablesTest extends StorageApiTestCase
             ],
         ]);
 
-        $result = $this->_client->searchTables([
-            'metadataKey' => 'testkey',
-        ]);
+        $result = $this->_client->searchTables(
+            SearchTablesOptions::create('testkey', null, null)
+        );
         $this->assertCount(1, $result);
 
-        $result = $this->_client->searchTables([
-            'metadataValue' => 'testValue',
-        ]);
+        $result = $this->_client->searchTables(
+            SearchTablesOptions::create(null, 'testValue', null)
+        );
         $this->assertCount(1, $result);
 
-        $result = $this->_client->searchTables([
-            'metadataProvider' => self::TEST_PROVIDER,
-        ]);
+        $result = $this->_client->searchTables(
+            SearchTablesOptions::create(null, null, self::TEST_PROVIDER)
+        );
         $this->assertCount(2, $result);
 
-        $result = $this->_client->searchTables([
-            'metadataKey' => 'testkey',
-            'metadataValue' => 'testValue',
-            'metadataProvider' => self::TEST_PROVIDER,
-        ]);
+        $result = $this->_client->searchTables(
+            SearchTablesOptions::create('testkey', 'testValue', self::TEST_PROVIDER)
+        );
         $this->assertCount(1, $result);
 
-        $result = $this->_client->searchTables([]);
-        $this->assertCount(2, $result);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('At least one option must be set');
+        $this->_client->searchTables(new SearchTablesOptions());
     }
 
-    private function _initTable(string $tableName, array $metadata)
+    private function _initTable($tableName, array $metadata)
     {
         $metadataApi = new Metadata($this->_client);
         $tableId = $this->_client->createTable($this->getTestBucketId(), $tableName, new CsvFile(__DIR__ . '/../_data/languages.csv'));

--- a/tests/Options/SearchTablesOptionsTest.php
+++ b/tests/Options/SearchTablesOptionsTest.php
@@ -20,7 +20,6 @@ class SearchTablesOptionsTest extends StorageApiTestCase
     public function testCreate()
     {
         $options = new SearchTablesOptions;
-        $this->assertInstanceOf(SearchTablesOptions::class, $options);
         $this->assertSame([
             'metadataKey' => null,
             'metadataValue' => null,
@@ -28,7 +27,6 @@ class SearchTablesOptionsTest extends StorageApiTestCase
         ], $options->toArray());
 
         $options = new SearchTablesOptions('key', 'value', 'provider');
-        $this->assertInstanceOf(SearchTablesOptions::class, $options);
 
         $this->assertSame([
             'metadataKey' => 'key',

--- a/tests/Options/SearchTablesOptionsTest.php
+++ b/tests/Options/SearchTablesOptionsTest.php
@@ -10,30 +10,25 @@ class SearchTablesOptionsTest extends StorageApiTestCase
     public function testGetDefaults()
     {
         $options = new SearchTablesOptions();
-        $this->assertEquals(null, $options->getMetadataKey());
-        $this->assertEquals(null, $options->getMetadataValue());
-        $this->assertEquals(null, $options->getMetadataProvider());
+        $this->assertSame([
+            'metadataKey' => null,
+            'metadataValue' => null,
+            'metadataProvider' => null,
+        ], $options->toArray());
     }
 
     public function testCreate()
     {
         $options = SearchTablesOptions::create(null, null, null);
         $this->assertInstanceOf(SearchTablesOptions::class, $options);
-        $this->assertEquals(null, $options->getMetadataKey());
-        $this->assertEquals(null, $options->getMetadataValue());
-        $this->assertEquals(null, $options->getMetadataProvider());
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('At least one option must be set');
-        $options->validate();
+        $this->assertSame([
+            'metadataKey' => null,
+            'metadataValue' => null,
+            'metadataProvider' => null,
+        ], $options->toArray());
 
         $options = SearchTablesOptions::create('key', 'value', 'provider');
         $this->assertInstanceOf(SearchTablesOptions::class, $options);
-        $this->assertEquals('key', $options->getMetadataKey());
-        $this->assertEquals('value', $options->getMetadataValue());
-        $this->assertEquals('provider', $options->getMetadataProvider());
-
-        $options->validate(); // should not throw exception
 
         $this->assertSame([
             'metadataKey' => 'key',
@@ -46,10 +41,13 @@ class SearchTablesOptionsTest extends StorageApiTestCase
     {
         $options = new SearchTablesOptions();
         $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataKey('key'));
-        $this->assertEquals('key', $options->getMetadataKey());
         $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataValue('value'));
-        $this->assertEquals('value', $options->getMetadataValue());
         $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataProvider('provider'));
-        $this->assertEquals('provider', $options->getMetadataProvider());
+
+        $this->assertSame([
+            'metadataKey' => 'key',
+            'metadataValue' => 'value',
+            'metadataProvider' => 'provider',
+        ], $options->toArray());
     }
 }

--- a/tests/Options/SearchTablesOptionsTest.php
+++ b/tests/Options/SearchTablesOptionsTest.php
@@ -9,7 +9,7 @@ class SearchTablesOptionsTest extends StorageApiTestCase
 {
     public function testGetDefaults()
     {
-        $options = new SearchTablesOptions();
+        $options = new SearchTablesOptions;
         $this->assertSame([
             'metadataKey' => null,
             'metadataValue' => null,
@@ -19,7 +19,7 @@ class SearchTablesOptionsTest extends StorageApiTestCase
 
     public function testCreate()
     {
-        $options = SearchTablesOptions::create(null, null, null);
+        $options = new SearchTablesOptions;
         $this->assertInstanceOf(SearchTablesOptions::class, $options);
         $this->assertSame([
             'metadataKey' => null,
@@ -27,7 +27,7 @@ class SearchTablesOptionsTest extends StorageApiTestCase
             'metadataProvider' => null,
         ], $options->toArray());
 
-        $options = SearchTablesOptions::create('key', 'value', 'provider');
+        $options = new SearchTablesOptions('key', 'value', 'provider');
         $this->assertInstanceOf(SearchTablesOptions::class, $options);
 
         $this->assertSame([
@@ -39,7 +39,7 @@ class SearchTablesOptionsTest extends StorageApiTestCase
 
     public function testFluentInterface()
     {
-        $options = new SearchTablesOptions();
+        $options = new SearchTablesOptions;
         $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataKey('key'));
         $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataValue('value'));
         $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataProvider('provider'));

--- a/tests/Options/SearchTablesOptionsTest.php
+++ b/tests/Options/SearchTablesOptionsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Keboola\Test\Options;
+
+use Keboola\StorageApi\Options\SearchTablesOptions;
+use Keboola\Test\StorageApiTestCase;
+
+class SearchTablesOptionsTest extends StorageApiTestCase
+{
+    public function testGetDefaults()
+    {
+        $options = new SearchTablesOptions();
+        $this->assertEquals(null, $options->getMetadataKey());
+        $this->assertEquals(null, $options->getMetadataValue());
+        $this->assertEquals(null, $options->getMetadataProvider());
+    }
+
+    public function testCreate()
+    {
+        $options = SearchTablesOptions::create(null, null, null);
+        $this->assertInstanceOf(SearchTablesOptions::class, $options);
+        $this->assertEquals(null, $options->getMetadataKey());
+        $this->assertEquals(null, $options->getMetadataValue());
+        $this->assertEquals(null, $options->getMetadataProvider());
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('At least one option must be set');
+        $options->validate();
+
+        $options = SearchTablesOptions::create('key', 'value', 'provider');
+        $this->assertInstanceOf(SearchTablesOptions::class, $options);
+        $this->assertEquals('key', $options->getMetadataKey());
+        $this->assertEquals('value', $options->getMetadataValue());
+        $this->assertEquals('provider', $options->getMetadataProvider());
+
+        $options->validate(); // should not throw exception
+
+        $this->assertSame([
+            'metadataKey' => 'key',
+            'metadataValue' => 'value',
+            'metadataProvider' => 'provider',
+        ], $options->toArray());
+    }
+
+    public function testFluentInterface()
+    {
+        $options = new SearchTablesOptions();
+        $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataKey('key'));
+        $this->assertEquals('key', $options->getMetadataKey());
+        $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataValue('value'));
+        $this->assertEquals('value', $options->getMetadataValue());
+        $this->assertInstanceOf(SearchTablesOptions::class, $options->setMetadataProvider('provider'));
+        $this->assertEquals('provider', $options->getMetadataProvider());
+    }
+}


### PR DESCRIPTION
implementation of https://github.com/keboola/connection/issues/2184 (private)

I kept the test simple only with count of returned tables. It's for discussion if return full table output like `/storage/tables` with `include` or simple like only id,name.