### PR TITLE
Add BC check to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
  - docker-compose build tests
 
 script:
+ - docker run --rm -v `pwd`:/app nyholm/roave-bc-check
  - docker-compose run --rm tests composer ci
 
 deploy:


### PR DESCRIPTION
add Roave/BackwardCompatibilityCheck to CI


PoC
```
$ docker run --rm -v `pwd`:/app nyholm/roave-bc-check roave-backwards-compatibility-check:assert-backwards-compatible --from 10.6.0 --to 10.7.0
```
result:
```
[BC] CHANGED: The parameter $permissions of Keboola\StorageApi\Client#createToken() changed from no type to a non-contravariant Keboola\StorageApi\Options\TokenCreateOptions
[BC] CHANGED: The parameter $permissions of Keboola\StorageApi\Client#createToken() changed from no type to Keboola\StorageApi\Options\TokenCreateOptions
[BC] CHANGED: The parameter $tokenId of Keboola\StorageApi\Client#updateToken() changed from no type to a non-contravariant Keboola\StorageApi\Options\TokenUpdateOptions
[BC] CHANGED: The parameter $tokenId of Keboola\StorageApi\Client#updateToken() changed from no type to Keboola\StorageApi\Options\TokenUpdateOptions
```