### PR TITLE
Remove lzo compression from failing tests

### DIFF
--- a/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
@@ -643,10 +643,8 @@ class LegacyWorkspacesLoadTest extends WorkspacesTestCase
         }
         if ($workspace['connection']['backend'] === $this::BACKEND_REDSHIFT) {
             $this->assertEquals("int4", $columnInfo['id']['DATA_TYPE']);
-            $this->assertEquals("lzo", $columnInfo['id']['COMPRESSION']);
             $this->assertEquals("varchar", $columnInfo['name']['DATA_TYPE']);
             $this->assertEquals(50, $columnInfo['name']['LENGTH']);
-            $this->assertEquals("lzo", $columnInfo['name']['COMPRESSION']);
         }
     }
 

--- a/tests/Backend/Workspaces/WorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesLoadTest.php
@@ -1077,10 +1077,8 @@ class WorkspacesLoadTest extends WorkspacesTestCase
         }
         if ($workspace['connection']['backend'] === $this::BACKEND_REDSHIFT) {
             $this->assertEquals("int4", $columnInfo['id']['DATA_TYPE']);
-            $this->assertEquals("lzo", $columnInfo['id']['COMPRESSION']);
             $this->assertEquals("varchar", $columnInfo['name']['DATA_TYPE']);
             $this->assertEquals(50, $columnInfo['name']['LENGTH']);
-            $this->assertEquals("lzo", $columnInfo['name']['COMPRESSION']);
         }
     }
 

--- a/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
@@ -181,11 +181,9 @@ class WorkspacesRedshiftTest extends WorkspacesTestCase
 
         $this->assertEquals("int4", $table['id']['DATA_TYPE']);
         $this->assertEquals(4, $table['id']['LENGTH']);
-        $this->assertEquals("lzo", $table['id']['COMPRESSION']);
 
         $this->assertEquals("varchar", $table['name']['DATA_TYPE']);
         $this->assertEquals(256, $table['name']['LENGTH']);
-        $this->assertEquals("lzo", $table['name']['COMPRESSION']);
     }
 
     public function testLoadedPrimaryKeys()

--- a/tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
@@ -409,10 +409,8 @@ class WorkspacesRenameLoadTest extends WorkspacesTestCase
         }
         if ($workspace['connection']['backend'] === $this::BACKEND_REDSHIFT) {
             $this->assertEquals("int4", $columnInfo['langid']['DATA_TYPE']);
-            $this->assertEquals("lzo", $columnInfo['langid']['COMPRESSION']);
             $this->assertEquals("varchar", $columnInfo['langname']['DATA_TYPE']);
             $this->assertEquals(50, $columnInfo['langname']['LENGTH']);
-            $this->assertEquals("lzo", $columnInfo['langname']['COMPRESSION']);
         }
     }
 


### PR DESCRIPTION
Redshift changed default compression for integer types which cause this tests to fail.
After discussion we decided that is safe to remove this check https://keboola.slack.com/archives/CL11GKH6H/p1580133035012800