### PR TITLE
Test if _timestamps are not null after copy

### DIFF
--- a/tests/Backend/Snowflake/TimestampTest.php
+++ b/tests/Backend/Snowflake/TimestampTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Keboola\Test\Backend\Snowflake;
+
+use Keboola\Csv\CsvFile;
+use Keboola\StorageApi\Workspaces;
+use Keboola\Test\Backend\Workspaces\Backend\SnowflakeWorkspaceBackend;
+use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
+use Keboola\Test\Backend\Workspaces\WorkspacesTestCase;
+
+class TimestampTest extends WorkspacesTestCase
+{
+    /**
+     * Originally this is ImportExportCommonTest::testTableAsyncImportExport but only works in snowflake
+     */
+    public function testTimestampCSVImportAsync()
+    {
+        $importFile = new CsvFile(__DIR__ . '/../../_data/languages.csv');
+        $createTableOptions = [];
+
+        $tableId = $this->_client->createTable(
+            $this->getTestBucketId(self::STAGE_IN),
+            'languages-3',
+            $importFile,
+            $createTableOptions
+        );
+
+        $this->_client->writeTableAsync($tableId, $importFile);
+
+        $workspaces = new Workspaces($this->_client);
+        $tmpWorkspace = $workspaces->createWorkspace();
+        /** @var SnowflakeWorkspaceBackend $backend */
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
+        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
+            'input' => [
+                [
+                    'source' => $tableId,
+                    'destination' => 'timestampTestFull',
+                ],
+            ],
+        ]);
+        $data = $backend->fetchAll('timestampTestFull', \PDO::FETCH_ASSOC);
+        foreach ($data as $timestampRecord) {
+            $this->assertNotNull($timestampRecord['_timestamp']);
+        }
+
+        // incremental
+        $this->_client->writeTableAsync($tableId, $importFile, [
+            'incremental' => true,
+        ]);
+
+        $tmpWorkspace = $workspaces->createWorkspace();
+        /** @var SnowflakeWorkspaceBackend $backend */
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
+        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
+            'input' => [
+                [
+                    'source' => $tableId,
+                    'destination' => 'timestampTestInc',
+                ],
+            ],
+        ]);
+        $data = $backend->fetchAll('timestampTestInc', \PDO::FETCH_ASSOC);
+        foreach ($data as $timestampRecord) {
+            $this->assertNotNull($timestampRecord['_timestamp']);
+        }
+    }
+
+    /**
+     * Originally this is ImportExportCommonTest::testTableImportExport but only works in snowflake
+     */
+    public function testTimestampCSVImportSync()
+    {
+        $importFile = new CsvFile(__DIR__ . '/../../_data/languages.csv');
+        $createTableOptions = [];
+
+        $tableId = $this->_client->createTable(
+            $this->getTestBucketId(self::STAGE_IN),
+            'languages-2',
+            $importFile,
+            $createTableOptions
+        );
+
+        $this->_client->writeTable($tableId, $importFile);
+
+        $workspaces = new Workspaces($this->_client);
+        $tmpWorkspace = $workspaces->createWorkspace();
+        /** @var SnowflakeWorkspaceBackend $backend */
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
+        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
+            'input' => [
+                [
+                    'source' => $tableId,
+                    'destination' => 'timestampTestFull',
+                ],
+            ],
+        ]);
+        $data = $backend->fetchAll('timestampTestFull', \PDO::FETCH_ASSOC);
+        foreach ($data as $timestampRecord) {
+            $this->assertNotNull($timestampRecord['_timestamp']);
+        }
+
+        // incremental
+        $this->_client->writeTable($tableId, $importFile, [
+            'incremental' => true,
+        ]);
+
+        $tmpWorkspace = $workspaces->createWorkspace();
+        /** @var SnowflakeWorkspaceBackend $backend */
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
+        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
+            'input' => [
+                [
+                    'source' => $tableId,
+                    'destination' => 'timestampTestInc',
+                ],
+            ],
+        ]);
+        $data = $backend->fetchAll('timestampTestInc', \PDO::FETCH_ASSOC);
+        foreach ($data as $timestampRecord) {
+            $this->assertNotNull($timestampRecord['_timestamp']);
+        }
+    }
+
+    /**
+     * Originally this is SlicedImportsTest::testSlicedImportSingleFile but only works in snowflake
+     */
+    public function testTimestampSlicedImport()
+    {
+        $uploadOptions = new \Keboola\StorageApi\Options\FileUploadOptions();
+        $uploadOptions
+            ->setFileName('languages_')
+            ->setIsSliced(true)
+            ->setIsEncrypted(false);
+        $slicedFile = $this->_client->prepareFileUpload($uploadOptions);
+
+        $uploadParams = $slicedFile['uploadParams'];
+        $s3Client = new \Aws\S3\S3Client([
+            'credentials' => [
+                'key' => $uploadParams['credentials']['AccessKeyId'],
+                'secret' => $uploadParams['credentials']['SecretAccessKey'],
+                'token' => $uploadParams['credentials']['SessionToken'],
+            ],
+            'version' => 'latest',
+            'region' => $slicedFile['region'],
+        ]);
+        $s3Client->putObject([
+            'Bucket' => $uploadParams['bucket'],
+            'Key' => $uploadParams['key'] . 'part001.csv',
+            'Body' => fopen(__DIR__ . '/../../_data/languages.no-headers.csv', 'r+'),
+        ])->get('ObjectURL');
+
+        $s3Client->putObject([
+            'Bucket' => $uploadParams['bucket'],
+            'Key' => $uploadParams['key'] . 'manifest',
+            'Body' => json_encode([
+                'entries' => [
+                    [
+                        'url' => 's3://' . $uploadParams['bucket'] . '/' . $uploadParams['key'] . 'part001.csv',
+                    ],
+                ],
+            ]),
+        ])->get('ObjectURL');
+
+        $tableId = $this->_client->createTable(
+            $this->getTestBucketId(self::STAGE_IN),
+            'entries',
+            new CsvFile(__DIR__ . '/../../_data/languages.not-normalized-column-names.csv')
+        );
+        $this->_client->deleteTableRows($tableId);
+        $this->_client->writeTableAsyncDirect($tableId, [
+            'dataFileId' => $slicedFile['id'],
+            'delimiter' => ',',
+            'enclosure' => '"',
+            'escapedBy' => '',
+            'columns' => [
+                'language-id',
+                'language-name',
+            ],
+        ]);
+
+        $workspaces = new Workspaces($this->_client);
+        $tmpWorkspace = $workspaces->createWorkspace();
+        /** @var SnowflakeWorkspaceBackend $backend */
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
+        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
+            'input' => [
+                [
+                    'source' => $tableId,
+                    'destination' => 'timestampTestFull',
+                ],
+            ],
+        ]);
+        $data = $backend->fetchAll('timestampTestFull', \PDO::FETCH_ASSOC);
+        foreach ($data as $timestampRecord) {
+            $this->assertNotNull($timestampRecord['_timestamp']);
+        }
+
+        // incremental
+        $this->_client->writeTableAsyncDirect($tableId, [
+            'dataFileId' => $slicedFile['id'],
+            'incremental' => true,
+            'delimiter' => ',',
+            'enclosure' => '"',
+            'escapedBy' => '',
+            'columns' => [
+                'language-id',
+                'language-name',
+            ],
+        ]);
+
+        $tmpWorkspace = $workspaces->createWorkspace();
+        /** @var SnowflakeWorkspaceBackend $backend */
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
+        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
+            'input' => [
+                [
+                    'source' => $tableId,
+                    'destination' => 'timestampTestInc',
+                ],
+            ],
+        ]);
+        $data = $backend->fetchAll('timestampTestInc', \PDO::FETCH_ASSOC);
+        foreach ($data as $timestampRecord) {
+            $this->assertNotNull($timestampRecord['_timestamp']);
+        }
+    }
+}

--- a/tests/Backend/Workspaces/WorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesUnloadTest.php
@@ -155,6 +155,21 @@ class WorkspacesUnloadTest extends WorkspacesTestCase
             'format' => 'rfc',
         )), 'imported data comparsion');
 
+        $tmpWorkspaceFull = $workspaces->createWorkspace();
+        $connection = $tmpWorkspaceFull['connection'];
+        $db = $this->getDbConnection($connection);
+        $workspaces->cloneIntoWorkspace($tmpWorkspaceFull['id'], [
+            'input' => [
+                [
+                    'source' => $table['id'],
+                    'destination' => 'timestamptestFull',
+                ],
+            ],
+        ]);
+        $data = $db->fetchAll('SELECT "_timestamp" FROM "timestamptestFull"');
+        foreach ($data as $timestampRecord) {
+            $this->assertNotNull($timestampRecord['_timestamp']);
+        }
 
         $db->query("truncate \"test.Languages3\"");
         $db->query("insert into \"test.Languages3\" values (1, 'cz', '1'), (3, 'sk', '1');");
@@ -194,5 +209,22 @@ class WorkspacesUnloadTest extends WorkspacesTestCase
         $this->assertLinesEqualsSorted(implode("\n", $expected) . "\n", $this->_client->getTableDataPreview($table['id'], array(
             'format' => 'rfc',
         )), 'new  column added');
+
+
+        $tmpWorkspaceInc = $workspaces->createWorkspace();
+        $connection = $tmpWorkspaceInc['connection'];
+        $db = $this->getDbConnection($connection);
+        $workspaces->cloneIntoWorkspace($tmpWorkspaceInc['id'], [
+            'input' => [
+                [
+                    'source' => $table['id'],
+                    'destination' => 'timestamptestInc',
+                ],
+            ],
+        ]);
+        $data = $db->fetchAll('SELECT "_timestamp" FROM "timestamptestInc"');
+        foreach ($data as $timestampRecord) {
+            $this->assertNotNull($timestampRecord['_timestamp']);
+        }
     }
 }

--- a/tests/Backend/Workspaces/WorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesUnloadTest.php
@@ -155,21 +155,6 @@ class WorkspacesUnloadTest extends WorkspacesTestCase
             'format' => 'rfc',
         )), 'imported data comparsion');
 
-        $tmpWorkspaceFull = $workspaces->createWorkspace();
-        $connection = $tmpWorkspaceFull['connection'];
-        $db = $this->getDbConnection($connection);
-        $workspaces->cloneIntoWorkspace($tmpWorkspaceFull['id'], [
-            'input' => [
-                [
-                    'source' => $table['id'],
-                    'destination' => 'timestamptestFull',
-                ],
-            ],
-        ]);
-        $data = $db->fetchAll('SELECT "_timestamp" FROM "timestamptestFull"');
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
 
         $db->query("truncate \"test.Languages3\"");
         $db->query("insert into \"test.Languages3\" values (1, 'cz', '1'), (3, 'sk', '1');");
@@ -209,22 +194,5 @@ class WorkspacesUnloadTest extends WorkspacesTestCase
         $this->assertLinesEqualsSorted(implode("\n", $expected) . "\n", $this->_client->getTableDataPreview($table['id'], array(
             'format' => 'rfc',
         )), 'new  column added');
-
-
-        $tmpWorkspaceInc = $workspaces->createWorkspace();
-        $connection = $tmpWorkspaceInc['connection'];
-        $db = $this->getDbConnection($connection);
-        $workspaces->cloneIntoWorkspace($tmpWorkspaceInc['id'], [
-            'input' => [
-                [
-                    'source' => $table['id'],
-                    'destination' => 'timestamptestInc',
-                ],
-            ],
-        ]);
-        $data = $db->fetchAll('SELECT "_timestamp" FROM "timestamptestInc"');
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
     }
 }


### PR DESCRIPTION
testuje se jestli není _timestamp null

**TimestampTest**
- testy importů přes db-import lib typ importy `csv` `manifest/sliced` `copy`
- joby: 
 `TableImport `
 `TableCreate`
- endpointy: 
 `Storage_BucketsController::postTablesAction`
 `Storage_TablesController::postImportAction`
nad kbc-50 failne test `testTimestampCopyImport` protože chybí timestamp


TODO:
- [x] WorkspaceLoad - nepřidává timestamp, používá custom implementaci db-import `Storage_Service_Backend_SnowflakeImport` `Storage_Service_Backend_SnowflakeCopyImport` v případě, že se kopírují tabulky mezi backendy, tak se používá s3 jako staging a db-import lib - // nepoužívá ale timestamp 