### PR TITLE
KBC-203 - harden timestamp test, check timestamp format a number of imported rows

### DIFF
--- a/tests/Backend/Snowflake/TimestampTest.php
+++ b/tests/Backend/Snowflake/TimestampTest.php
@@ -10,7 +10,7 @@ use Keboola\Test\Backend\Workspaces\WorkspacesTestCase;
 
 class TimestampTest extends WorkspacesTestCase
 {
-    const TIMESTAMP_FORMAT = '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/';
+    const TIMESTAMP_FORMAT = '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/';
 
     /**
      * Originally this is ImportExportCommonTest::testTableAsyncImportExport but only works in snowflake

--- a/tests/Backend/Snowflake/TimestampTest.php
+++ b/tests/Backend/Snowflake/TimestampTest.php
@@ -10,60 +10,35 @@ use Keboola\Test\Backend\Workspaces\WorkspacesTestCase;
 
 class TimestampTest extends WorkspacesTestCase
 {
+    const TIMESTAMP_FORMAT = '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/';
+
     /**
      * Originally this is ImportExportCommonTest::testTableAsyncImportExport but only works in snowflake
      */
     public function testTimestampCSVImportAsync()
     {
         $importFile = new CsvFile(__DIR__ . '/../../_data/languages.csv');
-        $createTableOptions = [];
+        // count - header
+        $count = iterator_count($importFile) - 1;
 
         $tableId = $this->_client->createTable(
             $this->getTestBucketId(self::STAGE_IN),
             'languages-3',
             $importFile,
-            $createTableOptions
+            []
         );
 
         $this->_client->writeTableAsync($tableId, $importFile);
 
         $workspaces = new Workspaces($this->_client);
-        $tmpWorkspace = $workspaces->createWorkspace();
-        /** @var SnowflakeWorkspaceBackend $backend */
-        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
-        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
-            'input' => [
-                [
-                    'source' => $tableId,
-                    'destination' => 'timestampTestFull',
-                ],
-            ],
-        ]);
-        $data = $backend->fetchAll('timestampTestFull', \PDO::FETCH_ASSOC);
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
+        $this->assertDataInTable($workspaces, $tableId, 'timestampTestFull', $count);
 
         // incremental
         $this->_client->writeTableAsync($tableId, $importFile, [
             'incremental' => true,
         ]);
 
-        $tmpWorkspace = $workspaces->createWorkspace();
-        /** @var SnowflakeWorkspaceBackend $backend */
-        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
-        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
-            'input' => [
-                [
-                    'source' => $tableId,
-                    'destination' => 'timestampTestInc',
-                ],
-            ],
-        ]);
-        $data = $backend->fetchAll('timestampTestInc', \PDO::FETCH_ASSOC);
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
+        $this->assertDataInTable($workspaces, $tableId, 'timestampTestInc', $count + $count);
     }
 
     /**
@@ -72,54 +47,27 @@ class TimestampTest extends WorkspacesTestCase
     public function testTimestampCSVImportSync()
     {
         $importFile = new CsvFile(__DIR__ . '/../../_data/languages.csv');
-        $createTableOptions = [];
+        // count - header
+        $count = iterator_count($importFile) - 1;
 
         $tableId = $this->_client->createTable(
             $this->getTestBucketId(self::STAGE_IN),
             'languages-2',
             $importFile,
-            $createTableOptions
+            []
         );
 
         $this->_client->writeTable($tableId, $importFile);
 
         $workspaces = new Workspaces($this->_client);
-        $tmpWorkspace = $workspaces->createWorkspace();
-        /** @var SnowflakeWorkspaceBackend $backend */
-        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
-        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
-            'input' => [
-                [
-                    'source' => $tableId,
-                    'destination' => 'timestampTestFull',
-                ],
-            ],
-        ]);
-        $data = $backend->fetchAll('timestampTestFull', \PDO::FETCH_ASSOC);
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
+        $this->assertDataInTable($workspaces, $tableId, 'timestampTestFull', $count);
 
         // incremental
         $this->_client->writeTable($tableId, $importFile, [
             'incremental' => true,
         ]);
 
-        $tmpWorkspace = $workspaces->createWorkspace();
-        /** @var SnowflakeWorkspaceBackend $backend */
-        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
-        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
-            'input' => [
-                [
-                    'source' => $tableId,
-                    'destination' => 'timestampTestInc',
-                ],
-            ],
-        ]);
-        $data = $backend->fetchAll('timestampTestInc', \PDO::FETCH_ASSOC);
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
+        $this->assertDataInTable($workspaces, $tableId, 'timestampTestInc', $count + $count);
     }
 
     /**
@@ -179,22 +127,10 @@ class TimestampTest extends WorkspacesTestCase
             ],
         ]);
 
+        $count = iterator_count(new CsvFile(__DIR__ . '/../../_data/languages.no-headers.csv'));
+
         $workspaces = new Workspaces($this->_client);
-        $tmpWorkspace = $workspaces->createWorkspace();
-        /** @var SnowflakeWorkspaceBackend $backend */
-        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
-        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
-            'input' => [
-                [
-                    'source' => $tableId,
-                    'destination' => 'timestampTestFull',
-                ],
-            ],
-        ]);
-        $data = $backend->fetchAll('timestampTestFull', \PDO::FETCH_ASSOC);
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
+        $this->assertDataInTable($workspaces, $tableId, 'timestampTestFull', $count);
 
         // incremental
         $this->_client->writeTableAsyncDirect($tableId, [
@@ -209,21 +145,7 @@ class TimestampTest extends WorkspacesTestCase
             ],
         ]);
 
-        $tmpWorkspace = $workspaces->createWorkspace();
-        /** @var SnowflakeWorkspaceBackend $backend */
-        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
-        $workspaces->cloneIntoWorkspace($tmpWorkspace['id'], [
-            'input' => [
-                [
-                    'source' => $tableId,
-                    'destination' => 'timestampTestInc',
-                ],
-            ],
-        ]);
-        $data = $backend->fetchAll('timestampTestInc', \PDO::FETCH_ASSOC);
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
+        $this->assertDataInTable($workspaces, $tableId, 'timestampTestInc', $count + $count);
     }
 
     /**
@@ -248,27 +170,14 @@ class TimestampTest extends WorkspacesTestCase
 			\"update\" varchar
 		);");
         $db->query("insert into \"test.Languages3\" (\"Id\", \"Name\") values (1, 'cz'), (2, 'en');");
+        // copy data from workspace
         $this->_client->writeTableAsyncDirect($table['id'], array(
             'dataWorkspaceId' => $workspace['id'],
             'dataTableName' => 'test.Languages3',
         ));
         unset($db);
         // test timestamp
-        $tmpWorkspaceFull = $workspaces->createWorkspace();
-        $tmpWorkspaceDb = $this->getDbConnection($tmpWorkspaceFull['connection']);
-        $workspaces->cloneIntoWorkspace($tmpWorkspaceFull['id'], [
-            'input' => [
-                [
-                    'source' => $table['id'],
-                    'destination' => 'timestamptestFull',
-                ],
-            ],
-        ]);
-        $data = $tmpWorkspaceDb->fetchAll('SELECT "_timestamp" FROM "timestamptestFull"');
-        foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
-        }
-        unset($tmpWorkspaceDb);
+        $this->assertDataInTable($workspaces, $table['id'], 'timestamptestFull', 2);
 
         $db = $this->getDbConnection($connection);
         $db->query("truncate \"test.Languages3\"");
@@ -291,20 +200,32 @@ class TimestampTest extends WorkspacesTestCase
         ));
         unset($db);
 
-        $tmpWorkspaceInc = $workspaces->createWorkspace();
-        $tmpWorkspaceDb = $this->getDbConnection($tmpWorkspaceInc['connection']);
-        $workspaces->cloneIntoWorkspace($tmpWorkspaceInc['id'], [
+        $this->assertDataInTable($workspaces, $table['id'], 'timestamptestInc', 3);
+    }
+
+    /**
+     * @param Workspaces $workspaceApi
+     * @param string $tableId
+     * @param string $workspaceTableName
+     * @param int $expectedRows
+     */
+    private function assertDataInTable($workspaceApi, $tableId, $workspaceTableName, $expectedRows)
+    {
+        $tmpWorkspace = $workspaceApi->createWorkspace();
+        /** @var SnowflakeWorkspaceBackend $backend */
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($tmpWorkspace);
+        $workspaceApi->cloneIntoWorkspace($tmpWorkspace['id'], [
             'input' => [
                 [
-                    'source' => $table['id'],
-                    'destination' => 'timestamptestInc',
+                    'source' => $tableId,
+                    'destination' => $workspaceTableName,
                 ],
             ],
         ]);
-        $data = $tmpWorkspaceDb->fetchAll('SELECT "_timestamp" FROM "timestamptestInc"');
+        $data = $backend->fetchAll($workspaceTableName, \PDO::FETCH_ASSOC);
+        $this->assertCount($expectedRows, $data);
         foreach ($data as $timestampRecord) {
-            $this->assertNotNull($timestampRecord['_timestamp']);
+            $this->assertRegExp(self::TIMESTAMP_FORMAT, $timestampRecord['_timestamp']);
         }
-        unset($tmpWorkspaceDb);
     }
 }

--- a/tests/Backend/Snowflake/TimestampTest.php
+++ b/tests/Backend/Snowflake/TimestampTest.php
@@ -225,7 +225,15 @@ class TimestampTest extends WorkspacesTestCase
         $data = $backend->fetchAll($workspaceTableName, \PDO::FETCH_ASSOC);
         $this->assertCount($expectedRows, $data);
         foreach ($data as $timestampRecord) {
-            $this->assertRegExp(self::TIMESTAMP_FORMAT, $timestampRecord['_timestamp']);
+            $this->assertNotNull(
+                $timestampRecord['_timestamp'],
+                '_timestamp field must not be a null.'
+            );
+            $this->assertRegExp(
+                self::TIMESTAMP_FORMAT,
+                $timestampRecord['_timestamp'],
+                '_timestamp has wrong pattern.'
+            );
         }
     }
 }


### PR DESCRIPTION
extends: https://github.com/keboola/storage-api-php-client/pull/370
jira: https://keboola.atlassian.net/browse/KBC-203

Test sem refaktoroval, timestamp sa checkuje ne na null, ale na formát a přidal sem check importovaných řádků.