### PR TITLE
tests: synapse backend - table primary key drop

### DIFF
--- a/tests/Backend/Synapse/AlterTableTest.php
+++ b/tests/Backend/Synapse/AlterTableTest.php
@@ -6,10 +6,6 @@ use Keboola\Test\Backend\CommonPart1\AlterTableTest as CommonAlterTableTest;
 
 class AlterTableTest extends CommonAlterTableTest
 {
-    public function testTablePkColumnDelete()
-    {
-        $this->markTestSkipped('Modifying PK for Synapse backend is not supported yet');
-    }
 
     public function testPrimaryKeyAddRequiredParam()
     {
@@ -22,16 +18,6 @@ class AlterTableTest extends CommonAlterTableTest
     }
 
     public function testPrimaryKeyAddWithDuplicty()
-    {
-        $this->markTestSkipped('Modifying PK for Synapse backend is not supported yet');
-    }
-
-    public function testPrimaryKeyDelete()
-    {
-        $this->markTestSkipped('Modifying PK for Synapse backend is not supported yet');
-    }
-
-    public function testEmptyPrimaryKeyDelete()
     {
         $this->markTestSkipped('Modifying PK for Synapse backend is not supported yet');
     }


### PR DESCRIPTION
Alter table - enable tests for primary key drop for Synapse storage backend