### PR TITLE
Fix Create Table Column endpoint in documentation

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2391,7 +2391,7 @@ attributes and information about the containing bucket.
             ]
 
 
-## Create Table Column [/v2/storage/buckets/{table_id}/columns/]
+## Create Table Column [/v2/storage/tables/{table_id}/columns/]
 
 ### Add Column to Table [POST]
 Adds a new column to an existing table. This request is [asynchronous](#introduction/synchronous-and-asynchronous-calls).


### PR DESCRIPTION
V dokumentaci je chybka 

https://github.com/keboola/storage-api-php-client/blob/f4205718f0f61751ffe29615ad3d196009c1646e/src/Keboola/StorageApi/Client.php#L1012-L1018