### PR TITLE
TableExporter: auto columns add to export params

### DIFF
--- a/src/Keboola/StorageApi/TableExporter.php
+++ b/src/Keboola/StorageApi/TableExporter.php
@@ -170,6 +170,11 @@ class TableExporter
             if (!isset($table['exportOptions'])) {
                 $table['exportOptions'] = array();
             }
+            if (empty($table['exportOptions']['columns'])) {
+                $tableDetail = $this->client->getTable($table['tableId']);
+                $table['exportOptions']['columns'] = $tableDetail['columns'];
+            }
+
             $jobId = $this->client->queueTableExport($table['tableId'], $table['exportOptions']);
             $exportJobs[$jobId] = $table;
         }


### PR DESCRIPTION
Automatically run table export with current list of table columns, if optional `columns` parameter in `exportOptions` is not set.

Fixes https://keboola.atlassian.net/browse/KBC-535