### PR TITLE
TableExporterTest: tests fixup for synapse backend

### DIFF
--- a/tests/Backend/CommonPart1/TableExporterTest.php
+++ b/tests/Backend/CommonPart1/TableExporterTest.php
@@ -179,7 +179,14 @@ class TableExporterTest extends StorageApiTestCase
                 'tableId' => $table1Id,
                 'destination' => $file1,
                 'exportOptions' => [
-                    'limit' => 1,
+                    'whereFilters' => [
+                        [
+                            'column' => 'id',
+                            'values' => [
+                                '0'
+                            ],
+                        ],
+                    ],
                     'columns' => ['name', 'id'],
                 ],
             ],


### PR DESCRIPTION
Predtim test spolehal na to ze se data vyexportuji ve stejnem poradi jako byly naimportovany. Coz u Synapse backendu tak nefunguje. Tak jsem pridal where filter a ten limit vyhodil.