### PR TITLE
tests: paygo info in token details

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -368,7 +368,7 @@ bucket permissions, don't forget to specify the previous permissions.
 ## Token Verification [/v2/storage/tokens/verify]
 ### Token verification [GET]
 Checks the token privileges and returns information about the project to which the token belongs (`owner`)
-and the associated administrator (`admin`). This call can be executed by all tokens.
+and the associated administrator (`admin`). If the project is configured with pay as you go billing, `payAsYouGo` section with details is available under `owner` info. This call can be executed by all tokens.
 
 + Request
     + Headers
@@ -469,6 +469,9 @@ and the associated administrator (`admin`). This call can be executed by all tok
                                 "name": "storage.rowsCount",
                                 "value": 3316230
                             }
+                        },
+                        "payAsYouGo": {
+                            "purchasedCredits": 123
                         }
                 }
             }

--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -148,6 +148,24 @@ class TokensTest extends StorageApiTestCase
         $this->assertTrue($tokenFound);
     }
 
+    public function testPayGoTokenProperties()
+    {
+        $currentToken = $this->_client->verifyToken();
+
+        $this->assertArrayHasKey('owner', $currentToken);
+
+        if (!in_array('pay-as-you-go', $currentToken['owner']['features'])) {
+            $this->assertArrayNotHasKey('payAsYouGo', $currentToken['owner']);
+            $this->markTestSkipped('Project is not Pay As You Go project');
+            return;
+        } else {
+            $this->assertArrayHasKey('payAsYouGo', $currentToken['owner']);
+
+            $payAsYouGo = $currentToken['owner']['payAsYouGo'];
+            $this->assertInternalType('integer', $payAsYouGo['purchasedCredits']);
+        }
+    }
+
     public function testKeenReadTokensRetrieve()
     {
         $this->expectException(\Keboola\StorageApi\ClientException::class);


### PR DESCRIPTION
Pay As You Go info in owner details if the project is configured as paygo

```json
{
    "payAsYouGo": {
        "purchasedCredits": 123
    }
}
```