### PR TITLE
Parallet tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,15 @@
         "microsoft/azure-storage-blob": "^1.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.6",
+		"phpunit/phpunit": "^7.0",
 		"squizlabs/php_codesniffer": "^3",
 		"apigen/apigen": "4.0.0-RC4",
 		"keboola/php-csv-db-import": "^2.2",
 		"ext-pdo_pgsql": "*",
 		"phpcompatibility/php-compatibility": "*",
 		"phpstan/phpstan-shim": "^0.9.2",
-		"keboola/table-backend-utils": "^0.5"
+		"keboola/table-backend-utils": "^0.5",
+		"brianium/paratest": "2.*"
 	},
 	"scripts": {
 		"phpcs": "phpcs -n .",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,12 +6,11 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
+         stopOnFailure="true"
          stopOnError="false"
-         syntaxCheck="false"
-		 verbose="true"
+         verbose="true"
          bootstrap="tests/bootstrap.php">
-
+<testsuites>
 	<testsuite name="common">
 		<directory>tests/Common</directory>
 		<directory>tests/Options</directory>
@@ -20,7 +19,6 @@
 		<file>tests/File/CommonFileTests.php</file>
 		<file>tests/File/AwsFileTest.php</file>
 	</testsuite>
-
 	<testsuite name="file-storage-azure">
 		<file>tests/File/AzureFileTest.php</file>
 		<file>tests/File/CommonFileTest.php</file>
@@ -28,10 +26,13 @@
 
 	<testsuite name="backend-snowflake-abs-part-1">
 		<file>tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php</file>
-		<directory>tests/Backend/CommonPart1</directory>
 		<file>tests/Backend/Workspaces/ComponentsWorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-backend-snowflake-abs-part-1">
+		<directory>tests/Backend/CommonPart1</directory>
 	</testsuite>
 
 	<testsuite name="backend-snowflake-abs-part-2">
@@ -47,10 +48,13 @@
 
 	<testsuite name="backend-redshift-part-1">
 		<file>tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php</file>
-		<directory>tests/Backend/CommonPart1</directory>
 		<file>tests/Backend/Workspaces/ComponentsWorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-backend-redshift-part-1">
+		<directory>tests/Backend/CommonPart1</directory>
 	</testsuite>
 
 	<testsuite name="backend-redshift-part-2">
@@ -66,15 +70,18 @@
 
 	<testsuite name="backend-snowflake-part-1">
 		<file>tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php</file>
-		<directory>tests/Backend/CommonPart1</directory>
 		<file>tests/Backend/Workspaces/ComponentsWorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php</file>
 	</testsuite>
 
+	<testsuite name="paratest-backend-snowflake-part-1">
+		<directory>tests/Backend/CommonPart1</directory>
+	</testsuite>
+
 	<testsuite name="backend-snowflake-part-2">
 		<directory>tests/Backend/CommonPart2</directory>
-        <file>tests/Backend/Workspaces/WorkspacesSnowflakeTest.php</file>
+		<file>tests/Backend/Workspaces/WorkspacesSnowflakeTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesUnloadTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesLoadTest.php</file>
@@ -90,12 +97,15 @@
 
 	<testsuite name="backend-synapse-part-1">
 		<file>tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php</file>
-		<directory>tests/Backend/CommonPart1</directory>
-<!--	DataPreviewLimitsTest is in tests/Backend/Synapse -->
-		<exclude>tests/Backend/CommonPart1/DataPreviewLimitsTest.php</exclude>
 		<file>tests/Backend/Workspaces/ComponentsWorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-backend-synapse-part-1">
+		<directory>tests/Backend/CommonPart1</directory>
+<!--	DataPreviewLimitsTest is in tests/Backend/Synapse -->
+		<exclude>tests/Backend/CommonPart1/DataPreviewLimitsTest.php</exclude>
 	</testsuite>
 
 	<testsuite name="backend-synapse-part-2">
@@ -108,4 +118,5 @@
 		<directory>tests/Backend/Synapse</directory>
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
+</testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,7 +36,6 @@
 	</testsuite>
 
 	<testsuite name="backend-snowflake-abs-part-2">
-		<directory>tests/Backend/CommonPart2</directory>
 		<file>tests/Backend/Workspaces/WorkspacesSnowflakeTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesUnloadTest.php</file>
@@ -44,6 +43,10 @@
 		<file>tests/Backend/Workspaces/WorkspacesRenameLoadTest.php</file>
 		<directory>tests/Backend/Snowflake</directory>
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-backend-snowflake-abs-part-2">
+		<directory>tests/Backend/CommonPart2</directory>
 	</testsuite>
 
 	<testsuite name="backend-redshift-part-1">
@@ -58,7 +61,6 @@
 	</testsuite>
 
 	<testsuite name="backend-redshift-part-2">
-		<directory>tests/Backend/CommonPart2</directory>
 		<file>tests/Backend/Workspaces/WorkspacesRedshiftTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesUnloadTest.php</file>
@@ -66,6 +68,10 @@
 		<file>tests/Backend/Workspaces/WorkspacesRenameLoadTest.php</file>
 		<directory>tests/Backend/Redshift</directory>
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-backend-redshift-part-2">
+		<directory>tests/Backend/CommonPart2</directory>
 	</testsuite>
 
 	<testsuite name="backend-snowflake-part-1">
@@ -80,7 +86,6 @@
 	</testsuite>
 
 	<testsuite name="backend-snowflake-part-2">
-		<directory>tests/Backend/CommonPart2</directory>
 		<file>tests/Backend/Workspaces/WorkspacesSnowflakeTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesUnloadTest.php</file>
@@ -88,6 +93,10 @@
 		<file>tests/Backend/Workspaces/WorkspacesRenameLoadTest.php</file>
 		<directory>tests/Backend/Snowflake</directory>
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-backend-snowflake-part-2">
+		<directory>tests/Backend/CommonPart2</directory>
 	</testsuite>
 
 	<testsuite name="backend-mixed">
@@ -109,7 +118,6 @@
 	</testsuite>
 
 	<testsuite name="backend-synapse-part-2">
-		<directory>tests/Backend/CommonPart2</directory>
 		<file>tests/Backend/Workspaces/WorkspacesSynapseTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php</file>
@@ -117,6 +125,10 @@
 		<file>tests/Backend/Workspaces/WorkspacesRenameLoadTest.php</file>
 		<directory>tests/Backend/Synapse</directory>
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-backend-synapse-part-2">
+		<directory>tests/Backend/CommonPart2</directory>
 	</testsuite>
 </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -44,12 +44,18 @@
 		<file>tests/Backend/Workspaces/WorkspacesUnloadTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesLoadTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesRenameLoadTest.php</file>
-		<directory>tests/Backend/Snowflake</directory>
-		<file>tests/Backend/Export/ExportParamsTest.php</file>
+		<file>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</file>
+		<file>tests/Backend/Snowflake/TimestampTest.php</file>
+		<file>tests/Backend/Snowflake/DirectAccessTest.php</file>
 	</testsuite>
 
 	<testsuite name="paratest-backend-snowflake-abs-part-2">
 		<directory>tests/Backend/CommonPart2</directory>
+		<directory>tests/Backend/Snowflake</directory>
+		<exclude>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</exclude>
+		<exclude>tests/Backend/Snowflake/TimestampTest.php</exclude>
+		<exclude>tests/Backend/Snowflake/DirectAccessTest.php</exclude>
+		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
 
 	<testsuite name="backend-redshift-part-1">
@@ -94,12 +100,18 @@
 		<file>tests/Backend/Workspaces/WorkspacesUnloadTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesLoadTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesRenameLoadTest.php</file>
-		<directory>tests/Backend/Snowflake</directory>
-		<file>tests/Backend/Export/ExportParamsTest.php</file>
+		<file>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</file>
+		<file>tests/Backend/Snowflake/TimestampTest.php</file>
+		<file>tests/Backend/Snowflake/DirectAccessTest.php</file>
 	</testsuite>
 
 	<testsuite name="paratest-backend-snowflake-part-2">
 		<directory>tests/Backend/CommonPart2</directory>
+		<directory>tests/Backend/Snowflake</directory>
+		<exclude>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</exclude>
+		<exclude>tests/Backend/Snowflake/TimestampTest.php</exclude>
+		<exclude>tests/Backend/Snowflake/DirectAccessTest.php</exclude>
+		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
 
 	<testsuite name="backend-mixed">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,6 +36,12 @@
 
 	<testsuite name="paratest-backend-snowflake-abs-part-1">
 		<directory>tests/Backend/CommonPart1</directory>
+		<directory>tests/Backend/CommonPart2</directory>
+		<directory>tests/Backend/Snowflake</directory>
+		<exclude>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</exclude>
+		<exclude>tests/Backend/Snowflake/TimestampTest.php</exclude>
+		<exclude>tests/Backend/Snowflake/DirectAccessTest.php</exclude>
+		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
 
 	<testsuite name="backend-snowflake-abs-part-2">
@@ -49,15 +55,6 @@
 		<file>tests/Backend/Snowflake/DirectAccessTest.php</file>
 	</testsuite>
 
-	<testsuite name="paratest-backend-snowflake-abs-part-2">
-		<directory>tests/Backend/CommonPart2</directory>
-		<directory>tests/Backend/Snowflake</directory>
-		<exclude>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</exclude>
-		<exclude>tests/Backend/Snowflake/TimestampTest.php</exclude>
-		<exclude>tests/Backend/Snowflake/DirectAccessTest.php</exclude>
-		<file>tests/Backend/Export/ExportParamsTest.php</file>
-	</testsuite>
-
 	<testsuite name="backend-redshift-part-1">
 		<file>tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php</file>
 		<file>tests/Backend/Workspaces/ComponentsWorkspacesTest.php</file>
@@ -67,6 +64,7 @@
 
 	<testsuite name="paratest-backend-redshift-part-1">
 		<directory>tests/Backend/CommonPart1</directory>
+		<directory>tests/Backend/CommonPart2</directory>
 	</testsuite>
 
 	<testsuite name="backend-redshift-part-2">
@@ -79,10 +77,6 @@
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
 
-	<testsuite name="paratest-backend-redshift-part-2">
-		<directory>tests/Backend/CommonPart2</directory>
-	</testsuite>
-
 	<testsuite name="backend-snowflake-part-1">
 		<file>tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php</file>
 		<file>tests/Backend/Workspaces/ComponentsWorkspacesTest.php</file>
@@ -92,6 +86,12 @@
 
 	<testsuite name="paratest-backend-snowflake-part-1">
 		<directory>tests/Backend/CommonPart1</directory>
+		<directory>tests/Backend/CommonPart2</directory>
+		<directory>tests/Backend/Snowflake</directory>
+		<exclude>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</exclude>
+		<exclude>tests/Backend/Snowflake/TimestampTest.php</exclude>
+		<exclude>tests/Backend/Snowflake/DirectAccessTest.php</exclude>
+		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
 
 	<testsuite name="backend-snowflake-part-2">
@@ -103,15 +103,6 @@
 		<file>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</file>
 		<file>tests/Backend/Snowflake/TimestampTest.php</file>
 		<file>tests/Backend/Snowflake/DirectAccessTest.php</file>
-	</testsuite>
-
-	<testsuite name="paratest-backend-snowflake-part-2">
-		<directory>tests/Backend/CommonPart2</directory>
-		<directory>tests/Backend/Snowflake</directory>
-		<exclude>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</exclude>
-		<exclude>tests/Backend/Snowflake/TimestampTest.php</exclude>
-		<exclude>tests/Backend/Snowflake/DirectAccessTest.php</exclude>
-		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
 
 	<testsuite name="backend-mixed">
@@ -130,6 +121,7 @@
 		<directory>tests/Backend/CommonPart1</directory>
 <!--	DataPreviewLimitsTest is in tests/Backend/Synapse -->
 		<exclude>tests/Backend/CommonPart1/DataPreviewLimitsTest.php</exclude>
+		<directory>tests/Backend/CommonPart2</directory>
 	</testsuite>
 
 	<testsuite name="backend-synapse-part-2">
@@ -142,8 +134,5 @@
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
 
-	<testsuite name="paratest-backend-synapse-part-2">
-		<directory>tests/Backend/CommonPart2</directory>
-	</testsuite>
 </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,10 +13,13 @@
 <testsuites>
 	<testsuite name="common">
 		<directory>tests/Common</directory>
+		<file>tests/File/CommonFileTests.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-common">
 		<directory>tests/Options</directory>
 		<directory>tests/S3Uploader</directory>
 		<directory>tests/Downloader</directory>
-		<file>tests/File/CommonFileTests.php</file>
 		<file>tests/File/AwsFileTest.php</file>
 	</testsuite>
 	<testsuite name="file-storage-azure">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="true"
+         stopOnFailure="false"
          stopOnError="false"
          verbose="true"
          bootstrap="tests/bootstrap.php">

--- a/tests/Backend/CommonPart1/AlterTableTest.php
+++ b/tests/Backend/CommonPart1/AlterTableTest.php
@@ -27,7 +27,7 @@ class AlterTableTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testTableColumnAdd()

--- a/tests/Backend/CommonPart1/BucketsTest.php
+++ b/tests/Backend/CommonPart1/BucketsTest.php
@@ -129,9 +129,14 @@ class BucketsTest extends StorageApiTestCase
 
     public function testBucketsListWithIncludeMetadata()
     {
-        $buckets = $this->_client->listBuckets(array(
-            'include' => 'metadata',
-        ));
+        $testBucketId = $this->getTestBucketId(self::STAGE_IN);
+
+        $buckets = array_filter(
+            $this->_client->listBuckets(['include' => 'metadata']),
+            function (array $bucket) use ($testBucketId) {
+                return $bucket['id'] === $testBucketId;
+            }
+        );
 
         $firstBucket = reset($buckets);
         $this->assertArrayNotHasKey('attributes', $firstBucket);
@@ -146,9 +151,13 @@ class BucketsTest extends StorageApiTestCase
             ]
         ]);
 
-        $buckets = $this->_client->listBuckets(array(
-            'include' => 'metadata',
-        ));
+        $buckets = array_filter(
+            $this->_client->listBuckets(['include' => 'metadata']),
+            function (array $bucket) use ($testBucketId) {
+                return $bucket['id'] === $testBucketId;
+            }
+        );
+
         $firstBucket = reset($buckets);
         $this->assertArrayHasKey('metadata', $firstBucket);
         $this->assertCount(1, $firstBucket['metadata']);

--- a/tests/Backend/CommonPart1/BucketsTest.php
+++ b/tests/Backend/CommonPart1/BucketsTest.php
@@ -19,7 +19,7 @@ class BucketsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testBucketsList()

--- a/tests/Backend/CommonPart1/CreateTableTest.php
+++ b/tests/Backend/CommonPart1/CreateTableTest.php
@@ -21,7 +21,7 @@ class CreateTableTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testSyntheticPrimaryKey()

--- a/tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+++ b/tests/Backend/CommonPart1/DataPreviewLimitsTest.php
@@ -21,7 +21,7 @@ class DataPreviewLimitsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
 

--- a/tests/Backend/CommonPart1/DeleteRowsTest.php
+++ b/tests/Backend/CommonPart1/DeleteRowsTest.php
@@ -19,7 +19,7 @@ class DeleteRowsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     /**

--- a/tests/Backend/CommonPart1/DeleteTableTest.php
+++ b/tests/Backend/CommonPart1/DeleteTableTest.php
@@ -18,7 +18,7 @@ class DeleteTableTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testTableDelete()

--- a/tests/Backend/CommonPart1/ExportParamsTest.php
+++ b/tests/Backend/CommonPart1/ExportParamsTest.php
@@ -22,7 +22,7 @@ class ExportParamsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testInvalidExportFormat()

--- a/tests/Backend/CommonPart1/ImportExportCommonTest.php
+++ b/tests/Backend/CommonPart1/ImportExportCommonTest.php
@@ -19,7 +19,7 @@ class ImportExportCommonTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     /**

--- a/tests/Backend/CommonPart1/LegacyIndexedColumnsTest.php
+++ b/tests/Backend/CommonPart1/LegacyIndexedColumnsTest.php
@@ -11,7 +11,7 @@ class LegacyIndexedColumnsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets([self::STAGE_SYS, self::STAGE_IN, self::STAGE_OUT]);
+        $this->initEmptyTestBucketsForParallelTests([self::STAGE_SYS, self::STAGE_IN, self::STAGE_OUT]);
     }
 
 

--- a/tests/Backend/CommonPart1/TableExporterTest.php
+++ b/tests/Backend/CommonPart1/TableExporterTest.php
@@ -28,7 +28,7 @@ class TableExporterTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
         $this->downloadPath = __DIR__ . '/../../_tmp/languages.sliced.csv';
         $this->downloadPathGZip = __DIR__ . '/../../_tmp/languages.sliced.csv.gz';
     }

--- a/tests/Backend/CommonPart1/TableExporterTest.php
+++ b/tests/Backend/CommonPart1/TableExporterTest.php
@@ -82,7 +82,7 @@ class TableExporterTest extends StorageApiTestCase
         $this->assertLinesEqualsSorted(file_get_contents($expectationsFile), file_get_contents($this->downloadPath), 'imported data comparison');
 
         // check that columns has been set in export job params
-        $jobs = $this->_client->listJobs(['limit' => 1]);
+        $jobs = $this->loadJobsByRunId($runId);
         $job = reset($jobs);
 
         $this->assertSame($runId, $job['runId']);
@@ -146,7 +146,9 @@ class TableExporterTest extends StorageApiTestCase
         // check that columns has been set in export job params
         $table1Job = null;
         $table2Job = null;
-        foreach ($this->_client->listJobs(['limit' => 2]) as $job) {
+
+        $jobs = $this->loadJobsByRunId($runId);
+        foreach ($jobs as $job) {
             $this->assertSame($runId, $job['runId']);
             $this->assertSame('tableExport', $job['operationName']);
 
@@ -204,7 +206,7 @@ class TableExporterTest extends StorageApiTestCase
         $this->assertEquals(['- unchecked -', '0'], $csvFile->current());
 
         // check that columns has been set in export job params
-        $jobs = $this->_client->listJobs(['limit' => 1]);
+        $jobs = $this->loadJobsByRunId($runId);
         $table1Job = reset($jobs);
 
         $this->assertSame($runId, $table1Job['runId']);
@@ -289,6 +291,16 @@ class TableExporterTest extends StorageApiTestCase
             array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'escaping.csv'), 'escaping.standard.out.csv', array('gzip' => true)),
             array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'numbers.csv'), 'numbers.csv', array('gzip' => true)),
             array([self::BACKEND_REDSHIFT], new CsvFile($filesBasePath . 'numbers.csv'), 'numbers.two-cols.csv', array('gzip' => true, 'columns' => array('0', '45'))),
+        );
+    }
+
+    private function loadJobsByRunId($runId)
+    {
+        return array_filter(
+            $this->_client->listJobs(['limit' => 100]),
+            function (array $job) use ($runId) {
+                return $job['runId'] === $runId;
+            }
         );
     }
 }

--- a/tests/Backend/CommonPart2/MetricsTest.php
+++ b/tests/Backend/CommonPart2/MetricsTest.php
@@ -19,7 +19,7 @@ class MetricsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     /**

--- a/tests/Backend/CommonPart2/SimpleAliasTest.php
+++ b/tests/Backend/CommonPart2/SimpleAliasTest.php
@@ -110,7 +110,7 @@ class SimpleAliasTest extends StorageApiTestCase
 
         // alias data preview and async export
         $exporter = new TableExporter($this->_client);
-        $downloadPath = __DIR__ . '/../../_tmp/languages.sliced.csv';
+        $downloadPath = $this->getExportFilePathForTest('languages.sliced.csv');
 
         $this->assertArrayEqualsSorted($expectedData, Client::parseCsv($this->_client->getTableDataPreview($aliasTable['id'])), 'id', 'data are exported from source table');
 
@@ -550,7 +550,7 @@ class SimpleAliasTest extends StorageApiTestCase
 
         // async export
         $exporter = new TableExporter($this->_client);
-        $downloadPath = __DIR__ . '/../../_tmp/languages.sliced.csv';
+        $downloadPath = $this->getExportFilePathForTest('languages.sliced.csv');
         $exporter->exportTable($aliasTableId, $downloadPath, []);
         $parsedData = Client::parseCsv(file_get_contents($downloadPath), false);
         array_shift($parsedData); // remove header
@@ -612,7 +612,7 @@ class SimpleAliasTest extends StorageApiTestCase
 
         // async export
         $exporter = new TableExporter($this->_client);
-        $downloadPath = __DIR__ . '/../../_tmp/languages.sliced.csv';
+        $downloadPath = $this->getExportFilePathForTest('languages.sliced.csv');
         $exporter->exportTable($aliasTableId, $downloadPath, []);
         $parsedData = Client::parseCsv(file_get_contents($downloadPath), false);
         array_shift($parsedData); // remove header
@@ -661,7 +661,7 @@ class SimpleAliasTest extends StorageApiTestCase
 
         // async export
         $exporter = new TableExporter($this->_client);
-        $downloadPath = __DIR__ . '/../../_tmp/languages.sliced.csv';
+        $downloadPath = $this->getExportFilePathForTest('languages.sliced.csv');
         $exporter->exportTable($aliasTableId, $downloadPath, [
             'whereColumn' => 'sex',
             'whereValues' => array('male'),
@@ -681,7 +681,7 @@ class SimpleAliasTest extends StorageApiTestCase
 
         // async export
         $exporter = new TableExporter($this->_client);
-        $downloadPath = __DIR__ . '/../../_tmp/languages.sliced.csv';
+        $downloadPath = $this->getExportFilePathForTest('languages.sliced.csv');
         $exporter->exportTable($aliasTableId, $downloadPath, [
             'whereColumn' => 'city',
             'whereValues' => array('VAN'),

--- a/tests/Backend/CommonPart2/SimpleAliasTest.php
+++ b/tests/Backend/CommonPart2/SimpleAliasTest.php
@@ -18,7 +18,7 @@ class SimpleAliasTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testTableAlias()

--- a/tests/Backend/CommonPart2/SlicedImportsTest.php
+++ b/tests/Backend/CommonPart2/SlicedImportsTest.php
@@ -21,7 +21,7 @@ class SlicedImportsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testSlicedImportGzipped()

--- a/tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+++ b/tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
@@ -18,7 +18,7 @@ class SlicedImportsWithSlicedUploadsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testSlicedImportGzipped()

--- a/tests/Backend/CommonPart2/SnapshottingTest.php
+++ b/tests/Backend/CommonPart2/SnapshottingTest.php
@@ -17,7 +17,7 @@ class SnapshottingTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testTableSnapshotCreate()

--- a/tests/Backend/CommonPart2/SystemColumnsTest.php
+++ b/tests/Backend/CommonPart2/SystemColumnsTest.php
@@ -15,7 +15,7 @@ class SystemColumnsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testSystemColumnsConversionOnTableCreate()

--- a/tests/Backend/Export/ExportParamsTest.php
+++ b/tests/Backend/Export/ExportParamsTest.php
@@ -18,7 +18,7 @@ class ExportParamsTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     /**

--- a/tests/Backend/Snowflake/FulltextSearchTest.php
+++ b/tests/Backend/Snowflake/FulltextSearchTest.php
@@ -14,7 +14,7 @@ class FulltextSearchTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testFindDataByFulltext()

--- a/tests/Backend/Snowflake/OrderByTest.php
+++ b/tests/Backend/Snowflake/OrderByTest.php
@@ -16,7 +16,7 @@ class OrderByTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testSimpleSort()

--- a/tests/Backend/Snowflake/TableExportTest.php
+++ b/tests/Backend/Snowflake/TableExportTest.php
@@ -16,7 +16,7 @@ class TableExportTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testSyncExportShouldReturnErrorForLargeNumberOfCols()

--- a/tests/Backend/Snowflake/TimeTravelTest.php
+++ b/tests/Backend/Snowflake/TimeTravelTest.php
@@ -18,7 +18,7 @@ class TimeTravelTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
         $this->downloadPath = __DIR__ . '/../../_tmp/';
     }
 

--- a/tests/Backend/Snowflake/WhereFilterTest.php
+++ b/tests/Backend/Snowflake/WhereFilterTest.php
@@ -16,7 +16,7 @@ class WhereFilterTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testSimpleWhereConditions()

--- a/tests/Backend/Workspaces/WorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/WorkspacesTestCase.php
@@ -17,7 +17,7 @@ abstract class WorkspacesTestCase extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_legacyInitEmptyTestBuckets();
+        $this->_initEmptyTestBuckets();
         $this->deleteAllWorkspaces();
     }
 

--- a/tests/Backend/Workspaces/WorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/WorkspacesTestCase.php
@@ -17,7 +17,7 @@ abstract class WorkspacesTestCase extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->_legacyInitEmptyTestBuckets();
         $this->deleteAllWorkspaces();
     }
 

--- a/tests/Downloader/AbsUrlParserTest.php
+++ b/tests/Downloader/AbsUrlParserTest.php
@@ -3,8 +3,9 @@
 namespace Keboola\Test\Downloader;
 
 use Keboola\StorageApi\Downloader\AbsUrlParser;
+use PHPUnit\Framework\TestCase;
 
-class AbsUrlParserTest extends \PHPUnit_Framework_TestCase
+class AbsUrlParserTest extends TestCase
 {
     public function testParseAbsUrlAzure()
     {

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -457,4 +457,11 @@ abstract class StorageApiTestCase extends TestCase
             $client->dropBucket($testBucketId, ['force' => true, 'async' => $async]);
         }
     }
+
+    protected function getExportFilePathForTest($fileName)
+    {
+        $testName = get_class($this) . '\\' . $this->getName();
+        return __DIR__ . '/_tmp/' . sha1($testName) . '.' . $fileName;
+    }
+
 }

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -16,8 +16,9 @@ use Keboola\StorageApi\Event;
 use Keboola\StorageApi\Metadata;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
+use PHPUnit\Framework\TestCase;
 
-abstract class StorageApiTestCase extends \PHPUnit_Framework_TestCase
+abstract class StorageApiTestCase extends TestCase
 {
     const BACKEND_REDSHIFT = 'redshift';
     const BACKEND_SNOWFLAKE = 'snowflake';

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -463,5 +463,4 @@ abstract class StorageApiTestCase extends TestCase
         $testName = get_class($this) . '\\' . $this->getName();
         return __DIR__ . '/_tmp/' . sha1($testName) . '.' . $fileName;
     }
-
 }

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -89,14 +89,14 @@ abstract class StorageApiTestCase extends TestCase
         ));
     }
 
-    protected function _legacyInitEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
+    protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
     {
         foreach ($stages as $stage) {
             $this->_bucketIds[$stage] = $this->initEmptyBucket('API-tests', $stage, 'API-tests');
         }
     }
 
-    protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
+    protected function initEmptyTestBucketsForParallelTests($stages = [self::STAGE_OUT, self::STAGE_IN])
     {
         $description = get_class($this) . '\\' . $this->getName();
         $bucketName = sprintf('API-tests-' . sha1($description));

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -177,7 +177,7 @@ abstract class StorageApiTestCase extends TestCase
         };
         usort($expected, $comparsion);
         usort($actual, $comparsion);
-        return $this->assertEquals($expected, $actual, $message);
+        $this->assertEquals($expected, $actual, $message);
     }
 
     public function tableExportFiltersData()

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -92,8 +92,10 @@ abstract class StorageApiTestCase extends TestCase
 
     protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
     {
+        $description = get_class($this) . '\\' . $this->getName();
+        $bucketName = sprintf('API-tests-' . sha1($description));
         foreach ($stages as $stage) {
-            $this->_bucketIds[$stage] = $this->initEmptyBucket('API-tests', $stage);
+            $this->_bucketIds[$stage] = $this->initEmptyBucket($bucketName, $stage, $description);
         }
     }
 
@@ -103,7 +105,7 @@ abstract class StorageApiTestCase extends TestCase
      * @param $stage
      * @return bool|string
      */
-    private function initEmptyBucket($name, $stage)
+    private function initEmptyBucket($name, $stage, $description)
     {
         try {
             $bucket = $this->_client->getBucket("$stage.c-$name");
@@ -136,7 +138,7 @@ abstract class StorageApiTestCase extends TestCase
             }
             return $bucket['id'];
         } catch (\Keboola\StorageApi\ClientException $e) {
-            return $this->_client->createBucket($name, $stage, 'Api tests');
+            return $this->_client->createBucket($name, $stage, $description);
         }
     }
 

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -89,6 +89,12 @@ abstract class StorageApiTestCase extends TestCase
         ));
     }
 
+    protected function _legacyInitEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
+    {
+        foreach ($stages as $stage) {
+            $this->_bucketIds[$stage] = $this->initEmptyBucket('API-tests', $stage, 'API-tests');
+        }
+    }
 
     protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
     {


### PR DESCRIPTION
Update PHPunitu + pridani paratestu

Kazda testsuite ma svoji kopii s prefixem `paratest` kam se presunuly testy co jsou poustet paralelne.

Vyzkouset se da pomoci

```
docker-compose run --rm -e STORAGE_API_URL=$STORAGE_API_URL -e STORAGE_API_TOKEN=$STORAGE_API_TOKEN dev php ./vendor/bin/paratest --verbose=1 --processes=8 --colors -f --testsuite=paratest-common
```

