### PR TITLE
Paratest part1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,15 @@
         "microsoft/azure-storage-blob": "^1.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.6",
+		"phpunit/phpunit": "^7.0",
 		"squizlabs/php_codesniffer": "^3",
 		"apigen/apigen": "4.0.0-RC4",
 		"keboola/php-csv-db-import": "^2.2",
 		"ext-pdo_pgsql": "*",
 		"phpcompatibility/php-compatibility": "*",
 		"phpstan/phpstan-shim": "^0.9.2",
-		"keboola/table-backend-utils": "^0.5"
+		"keboola/table-backend-utils": "^0.5",
+		"brianium/paratest": "2.*"
 	},
 	"scripts": {
 		"phpcs": "phpcs -n .",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,14 +14,14 @@
 
 	<testsuite name="common">
 		<directory>tests/Common</directory>
+		<directory>tests/S3Uploader</directory>
+		<directory>tests/Downloader</directory>
+		<file>tests/File/AwsFileTest.php</file>
 		<file>tests/File/CommonFileTests.php</file>
 	</testsuite>
 
 	<testsuite name="paratest-common">
 		<directory>tests/Options</directory>
-		<directory>tests/S3Uploader</directory>
-		<directory>tests/Downloader</directory>
-		<file>tests/File/AwsFileTest.php</file>
 	</testsuite>
 
 	<testsuite name="file-storage-azure">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
 		 verbose="true"
          bootstrap="tests/bootstrap.php">
 
+<testsuites>
 	<testsuite name="common">
 		<directory>tests/Common</directory>
 		<directory>tests/S3Uploader</directory>
@@ -116,4 +117,5 @@
 		<directory>tests/Backend/Synapse</directory>
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
+</testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,10 +14,13 @@
 
 	<testsuite name="common">
 		<directory>tests/Common</directory>
+		<file>tests/File/CommonFileTests.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-common">
 		<directory>tests/Options</directory>
 		<directory>tests/S3Uploader</directory>
 		<directory>tests/Downloader</directory>
-		<file>tests/File/CommonFileTests.php</file>
 		<file>tests/File/AwsFileTest.php</file>
 	</testsuite>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -83,7 +83,12 @@
 		<file>tests/Backend/Workspaces/WorkspacesLoadTest.php</file>
 		<file>tests/Backend/Workspaces/WorkspacesRenameLoadTest.php</file>
 		<directory>tests/Backend/Snowflake</directory>
+		<exclude>tests/Backend/Snowflake/OrderByTest.php</exclude>
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
+	</testsuite>
+
+	<testsuite name="paratest-backend-snowflake-part-2">
+		<file>tests/Backend/Snowflake/OrderByTest.php</file>
 	</testsuite>
 
 	<testsuite name="backend-mixed">

--- a/tests/Backend/Snowflake/OrderByTest.php
+++ b/tests/Backend/Snowflake/OrderByTest.php
@@ -16,7 +16,7 @@ class OrderByTest extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->initEmptyTestBucketsForParallelTests();
     }
 
     public function testSimpleSort()

--- a/tests/Backend/Workspaces/WorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/WorkspacesTestCase.php
@@ -17,7 +17,7 @@ abstract class WorkspacesTestCase extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_legacyInitEmptyTestBuckets();
+        $this->_initEmptyTestBuckets();
         $this->deleteAllWorkspaces();
     }
 

--- a/tests/Backend/Workspaces/WorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/WorkspacesTestCase.php
@@ -17,7 +17,7 @@ abstract class WorkspacesTestCase extends StorageApiTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_initEmptyTestBuckets();
+        $this->_legacyInitEmptyTestBuckets();
         $this->deleteAllWorkspaces();
     }
 

--- a/tests/Downloader/AbsUrlParserTest.php
+++ b/tests/Downloader/AbsUrlParserTest.php
@@ -3,8 +3,9 @@
 namespace Keboola\Test\Downloader;
 
 use Keboola\StorageApi\Downloader\AbsUrlParser;
+use PHPUnit\Framework\TestCase;
 
-class AbsUrlParserTest extends \PHPUnit_Framework_TestCase
+class AbsUrlParserTest extends TestCase
 {
     public function testParseAbsUrlAzure()
     {

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -16,8 +16,9 @@ use Keboola\StorageApi\Event;
 use Keboola\StorageApi\Metadata;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
+use PHPUnit\Framework\TestCase;
 
-abstract class StorageApiTestCase extends \PHPUnit_Framework_TestCase
+abstract class StorageApiTestCase extends TestCase
 {
     const BACKEND_REDSHIFT = 'redshift';
     const BACKEND_SNOWFLAKE = 'snowflake';

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -89,14 +89,14 @@ abstract class StorageApiTestCase extends TestCase
         ));
     }
 
-    protected function _legacyInitEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
+    protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
     {
         foreach ($stages as $stage) {
             $this->_bucketIds[$stage] = $this->initEmptyBucket('API-tests', $stage, 'API-tests');
         }
     }
 
-    protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
+    protected function initEmptyTestBucketsForParallelTests($stages = [self::STAGE_OUT, self::STAGE_IN])
     {
         $description = get_class($this) . '\\' . $this->getName();
         $bucketName = sprintf('API-tests-' . sha1($description));

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -177,7 +177,7 @@ abstract class StorageApiTestCase extends TestCase
         };
         usort($expected, $comparsion);
         usort($actual, $comparsion);
-        return $this->assertEquals($expected, $actual, $message);
+        $this->assertEquals($expected, $actual, $message);
     }
 
     public function tableExportFiltersData()

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -92,8 +92,10 @@ abstract class StorageApiTestCase extends TestCase
 
     protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
     {
+        $description = get_class($this) . '\\' . $this->getName();
+        $bucketName = sprintf('API-tests-' . sha1($description));
         foreach ($stages as $stage) {
-            $this->_bucketIds[$stage] = $this->initEmptyBucket('API-tests', $stage);
+            $this->_bucketIds[$stage] = $this->initEmptyBucket($bucketName, $stage, $description);
         }
     }
 
@@ -103,7 +105,7 @@ abstract class StorageApiTestCase extends TestCase
      * @param $stage
      * @return bool|string
      */
-    private function initEmptyBucket($name, $stage)
+    private function initEmptyBucket($name, $stage, $description)
     {
         try {
             $bucket = $this->_client->getBucket("$stage.c-$name");
@@ -136,7 +138,7 @@ abstract class StorageApiTestCase extends TestCase
             }
             return $bucket['id'];
         } catch (\Keboola\StorageApi\ClientException $e) {
-            return $this->_client->createBucket($name, $stage, 'Api tests');
+            return $this->_client->createBucket($name, $stage, $description);
         }
     }
 

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -89,6 +89,12 @@ abstract class StorageApiTestCase extends TestCase
         ));
     }
 
+    protected function _legacyInitEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
+    {
+        foreach ($stages as $stage) {
+            $this->_bucketIds[$stage] = $this->initEmptyBucket('API-tests', $stage, 'API-tests');
+        }
+    }
 
     protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])
     {


### PR DESCRIPTION
Update PHPunitu + pridani paratestu

Kazda testsuite ma svoji kopii s prefixem `paratest` kam se presunuly testy co jsou poustet paralelne.

Vyzkouset se da pomoci

```
docker-compose run --rm -e STORAGE_API_URL=$STORAGE_API_URL -e STORAGE_API_TOKEN=$STORAGE_API_TOKEN dev php ./vendor/bin/paratest --verbose=1 --processes=3 --colors -f --testsuite=paratest-common
```

```
docker-compose run --rm -e STORAGE_API_URL=$STORAGE_API_URL -e STORAGE_API_TOKEN=$STORAGE_API_TOKEN dev php ./vendor/bin/paratest --verbose=1 --processes=3 --colors -f --testsuite=paratest-backend-snowflake-part-2
```

