### PR TITLE
dont throw exception if initEmptyBucket deleting resource receive 404

### DIFF
--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -114,7 +114,7 @@ abstract class StorageApiTestCase extends ClientTestCase
                         try {
                             $this->_client->dropBucket($linkedBucket['id'], ['force' => true]);
                         } catch (\Keboola\StorageApi\ClientException $e) {
-                            $this->throwExceptionIfDeleted($e);
+                            $this->throwExceptionIfNotDeleted($e);
                         }
                     }
                 }
@@ -134,7 +134,7 @@ abstract class StorageApiTestCase extends ClientTestCase
                 try {
                     $this->_client->dropTable($table['id']);
                 } catch (\Keboola\StorageApi\ClientException $e) {
-                    $this->throwExceptionIfDeleted($e);
+                    $this->throwExceptionIfNotDeleted($e);
                 }
             }
             $metadataApi = new Metadata($this->_client);
@@ -143,7 +143,7 @@ abstract class StorageApiTestCase extends ClientTestCase
                 try {
                     $metadataApi->deleteBucketMetadata($bucket['id'], $md['id']);
                 } catch (\Keboola\StorageApi\ClientException $e) {
-                    $this->throwExceptionIfDeleted($e);
+                    $this->throwExceptionIfNotDeleted($e);
                 }
             }
             return $bucket['id'];
@@ -492,7 +492,7 @@ abstract class StorageApiTestCase extends ClientTestCase
     /**
      * @throws \Keboola\StorageApi\ClientException
      */
-    private function throwExceptionIfDeleted(\Keboola\StorageApi\ClientException $e)
+    private function throwExceptionIfNotDeleted(\Keboola\StorageApi\ClientException $e)
     {
         // this could take backoff and second run will be 404
         // we don't care is table dont exists

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -111,7 +111,11 @@ abstract class StorageApiTestCase extends ClientTestCase
             if ($this->_client->isSharedBucket($bucket['id'])) {
                 if (array_key_exists('linkedBy', $bucket)) {
                     foreach ($bucket['linkedBy'] as $linkedBucket) {
-                        $this->_client->dropBucket($linkedBucket['id'], ['force' => true]);
+                        try {
+                            $this->_client->dropBucket($linkedBucket['id'], ['force' => true]);
+                        } catch (\Keboola\StorageApi\ClientException $e) {
+                            $this->throwExceptionIfDeleted($e);
+                        }
                     }
                 }
                 $this->_client->unshareBucket($bucket['id']);
@@ -127,12 +131,20 @@ abstract class StorageApiTestCase extends ClientTestCase
                 return ($timestamp1 < $timestamp2) ? -1 : 1;
             });
             foreach (array_reverse($tables) as $table) {
-                $this->_client->dropTable($table['id']);
+                try {
+                    $this->_client->dropTable($table['id']);
+                } catch (\Keboola\StorageApi\ClientException $e) {
+                    $this->throwExceptionIfDeleted($e);
+                }
             }
             $metadataApi = new Metadata($this->_client);
             $metadata = $metadataApi->listBucketMetadata($bucket['id']);
             foreach ($metadata as $md) {
-                $metadataApi->deleteBucketMetadata($bucket['id'], $md['id']);
+                try {
+                    $metadataApi->deleteBucketMetadata($bucket['id'], $md['id']);
+                } catch (\Keboola\StorageApi\ClientException $e) {
+                    $this->throwExceptionIfDeleted($e);
+                }
             }
             return $bucket['id'];
         } catch (\Keboola\StorageApi\ClientException $e) {
@@ -475,5 +487,17 @@ abstract class StorageApiTestCase extends ClientTestCase
             return $event;
         }
         $this->fail(sprintf('Event for filter "%s" does not exist', (string) json_encode($filter)));
+    }
+
+    /**
+     * @throws \Keboola\StorageApi\ClientException
+     */
+    private function throwExceptionIfDeleted(\Keboola\StorageApi\ClientException $e)
+    {
+        // this could take backoff and second run will be 404
+        // we don't care is table dont exists
+        if ($e->getCode() !== 404) {
+            throw $e;
+        }
     }
 }


### PR DESCRIPTION
SLACK: https://keboola.slack.com/archives/CFVRE56UA/p1600948517029700?thread_ts=1600944572.025800&cid=CFVRE56UA

Stane se že mazání resource vrátí 500 kvůli nečekané chybě, jenže to vezme backoff takže se pustí request znova, ten pak vrátí 404 protože tam už resource není, ale to skončí failem protože 404 je exception a pokusí se to založit nový bucket ikdyž ten starý tam pořád je.

Druhá možnost je zrušit backoff, ale třeba tady by to zbytečně failnulo https://my.papertrailapp.com/groups/4231582/events?focus=1245745233677926403&q=WorkspacesSnowflakeTest%3A%3AtestLoadedPrimaryKeys%20backend-snowflake-part-2