### PR TITLE
KBC-680 branch support for list configuration

### DIFF
--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Keboola\Test\Common;
+
+use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\DevBranches;
+use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
+use Keboola\StorageApi\Options\Components\ListComponentsOptions;
+use Keboola\Test\StorageApiTestCase;
+
+class BranchComponentTest extends StorageApiTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $components = new \Keboola\StorageApi\Components($this->_client);
+        foreach ($components->listComponents() as $component) {
+            foreach ($component['configurations'] as $configuration) {
+                $components->deleteConfiguration($component['id'], $configuration['id']);
+            }
+        }
+
+        // erase all deleted configurations
+        foreach ($components->listComponents((new ListComponentsOptions())->setIsDeleted(true)) as $component) {
+            foreach ($component['configurations'] as $configuration) {
+                $components->deleteConfiguration($component['id'], $configuration['id']);
+            }
+        }
+    }
+
+    public function testGetComponentConfigurations()
+    {
+        $providedToken = $this->_client->verifyToken();
+        $devBranch = new DevBranches($this->_client);
+        // cleanup
+        $branchesList = $devBranch->listBranches();
+        $branchName = __CLASS__ . '\\' . $this->getName() . '\\' . $providedToken['id'];
+        $branchesCreatedByThisTestMethod = array_filter(
+            $branchesList,
+            function ($branch) use ($branchName) {
+                return strpos($branch['name'], $branchName) === 0;
+            }
+        );
+        foreach ($branchesCreatedByThisTestMethod as $branch) {
+            $devBranch->deleteBranch($branch['id']);
+        }
+
+        $branch = $devBranch->createBranch($branchName);
+
+        $branchComponents = new \Keboola\StorageApi\Components($this->getBranchAwareDefaultClient($branch['id']));
+        $componentId = 'transformation';
+        $configs = $branchComponents->listComponentConfigurations(
+            (new ListComponentConfigurationsOptions())->setComponentId($componentId)
+        );
+        $this->assertEmpty($configs);
+
+        $components = new \Keboola\StorageApi\Components($this->_client);
+        $components->addConfiguration((new \Keboola\StorageApi\Options\Components\Configuration())
+            ->setComponentId($componentId)
+            ->setConfigurationId('main-1')
+            ->setName('Main 1'));
+        $components->addConfiguration((new \Keboola\StorageApi\Options\Components\Configuration())
+            ->setComponentId($componentId)
+            ->setConfigurationId('main-2')
+            ->setName('Main 2'));
+
+        $configs = $components->listComponentConfigurations(
+            (new ListComponentConfigurationsOptions())->setComponentId($componentId)
+        );
+        $this->assertCount(2, $configs);
+
+        $configs = $branchComponents->listComponentConfigurations(
+            (new ListComponentConfigurationsOptions())->setComponentId($componentId)
+        );
+        $this->assertEmpty($configs);
+
+        $mainComponentDetail = $components->getConfiguration($componentId, 'main-1');
+        $this->assertNotEmpty($mainComponentDetail);
+
+        try {
+            $branchComponents->getConfiguration($componentId, 'main-1');
+            $this->fail('Components API POST request should be restricted for readOnly user');
+        } catch (ClientException $e) {
+            $this->assertSame(404, $e->getCode());
+            $this->assertSame('notFound', $e->getStringCode());
+            $this->assertContains('Configuration main-1 not found', $e->getMessage());
+        }
+
+        $mainComponentDetail  = $components->getConfiguration($componentId, 'main-1');
+        $this->assertSame('main-1', $mainComponentDetail['id']);
+    }
+}


### PR DESCRIPTION
Main PR: https://github.com/keboola/connection/pull/2842

Tie testy som pridal zatial len tak ako su v ComponentsTest.php a neriesil som nejaku paralelizovatelnost imho je potreba to potom supnut do jedneho filu spolu s ComponentsTest.php aby sa testovali vsetky veci jak pre dev branch tak pre main a to pojde az ked to bude cele hotove.