### PR TITLE
KBC-1029 file workspace create/drop

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3102,6 +3102,9 @@ Creates a new workspace and return its credentials.
             + redshift
             + snowflake
     the system. Supported only for Snowflake workspaces.
+            + synapse
+            + abs
+    Azure blob storage file workspace
 
 + Request (application/x-www-form-urlencoded)
     + Headers
@@ -3379,6 +3382,7 @@ Generates new password for the given workspace
 
 + id: 234 (number)
 + name: `boring_wozniak` (string) - working schema name
++ type: `file|table` (string) - workspace type
 + component: `wr-db` (string) - name of the [registered component](#reference/miscellaneous/api-index/component-list) that created the workspace
 + configurationId: `aws-1` (string) - id of a [configuration](#reference/component-configurations/component-list) used to create workspace
 + created: `2016-05-17T11:11:20+0200` (string)
@@ -3389,6 +3393,7 @@ Generates new password for the given workspace
     + schema:  `boring_wozniak` (string)
     + warehouse: `SAPI_PROD` (string)
     + user: `xzy` (string)
+    + container: file workspace containerName (string) - Only for file workspaces
 + creatorToken
     + id: 234 (number)
     + description: `martin@keboola.com` (string)
@@ -3406,6 +3411,8 @@ Generates new password for the given workspace
     + warehouse: SAPI_PROD (string)
     + user: xzy (string)
     + password: abc (string) - Password is not stored and is returned only after workspace creation
+    + connectionString: `BlobEndpoint=https://<account>.blob.core.windows.net;SharedAccessSignature=sv=2017-11-09&sr=c&st=2020-11-03T10:31:36Z&se=2020-11-04T10:31:36Z&sp=rwl&sig=<SAS signature>` (string) only for file workspaces
+    + container: file workspace containerName (string) - Only for file workspaces
 
 # Group Events
 Virtually every interaction of the client (an API call) creates an Event. Apart from that, external events may

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,6 +34,7 @@
 	<testsuite name="backend-snowflake-abs-part-1">
 		<file>tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php</file>
 		<directory>tests/Backend/CommonPart1</directory>
+		<file>tests/Backend/FileWorkspace/WorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/ComponentsWorkspacesTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php</file>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php</file>
@@ -114,6 +115,7 @@
 	<testsuite name="backend-synapse-part-1">
 		<file>tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php</file>
 		<directory>tests/Backend/CommonPart1</directory>
+		<file>tests/Backend/FileWorkspace/WorkspacesTest.php</file>
 <!--	DataPreviewLimitsTest is in tests/Backend/Synapse -->
 		<exclude>tests/Backend/CommonPart1/DataPreviewLimitsTest.php</exclude>
 		<file>tests/Backend/Workspaces/ComponentsWorkspacesTest.php</file>

--- a/tests/Backend/FileWorkspace/Backend/Abs.php
+++ b/tests/Backend/FileWorkspace/Backend/Abs.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Keboola\Test\Backend\FileWorkspace\Backend;
+
+use MicrosoftAzure\Storage\Blob\BlobRestProxy;
+use MicrosoftAzure\Storage\Blob\Models\Blob;
+
+class Abs
+{
+    /** @var string */
+    private $connectionString;
+
+    /** @var mixed */
+    private $container;
+
+    public function __construct(array $connection)
+    {
+        $this->connectionString = $connection['connectionString'];
+        $this->container = $connection['container'];
+    }
+
+    /**
+     * @return Blob[]
+     */
+    public function listFiles()
+    {
+        $blobs = $this->getClient()->listBlobs($this->container);
+        return $blobs->getBlobs();
+    }
+
+    /**
+     * @return BlobRestProxy
+     */
+    public function getClient()
+    {
+        return BlobRestProxy::createBlobService($this->connectionString);
+    }
+
+    /**
+     * @return string
+     */
+    public function uploadTestingFile()
+    {
+        $filePath = tempnam(sys_get_temp_dir(), 'abs-file-upload');
+        file_put_contents($filePath, 'We fight for data');
+        $content = fopen($filePath, "rb");
+        $this->getClient()->createBlockBlob($this->container, basename($filePath), $content);
+
+        return basename($filePath);
+    }
+}

--- a/tests/Backend/FileWorkspace/WorkspacesTest.php
+++ b/tests/Backend/FileWorkspace/WorkspacesTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Keboola\Test\Backend\FileWorkspace;
+
+use Keboola\StorageApi\Workspaces;
+use Keboola\Test\Backend\FileWorkspace\Backend\Abs;
+use Keboola\Test\Backend\Workspaces\WorkspacesTestCase;
+use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
+
+class WorkspacesTest extends WorkspacesTestCase
+{
+    public function testWorkspaceCreate()
+    {
+        $workspaces = new Workspaces($this->_client);
+
+        $runId = $this->_client->generateRunId();
+        $this->_client->setRunId($runId);
+
+        $backend = $this->resolveFileWorkspaceBackend();
+
+        $workspace = $workspaces->createWorkspace([
+            'backend' => $backend,
+        ]);
+
+        $this->assertEquals($backend, $workspace['connection']['backend']);
+
+        $connection = $workspace['connection'];
+        $backend = new Abs($workspace['connection']);
+        $this->assertCount(0, $backend->listFiles());
+
+        $fileName = $backend->uploadTestingFile();
+
+        $files = $backend->listFiles();
+        $this->assertCount(1, $files);
+        $this->assertEquals($files[0]->getName(), $fileName);
+
+        // get workspace
+        $workspace = $workspaces->getWorkspace($workspace['id']);
+        $this->assertArrayNotHasKey('password', $workspace['connection']);
+
+        // list workspaces
+        $workspacesIds = array_map(function ($workspace) {
+            return $workspace['id'];
+        }, $workspaces->listWorkspaces());
+
+        $this->assertArrayHasKey($workspace['id'], array_flip($workspacesIds));
+
+        $workspaces->deleteWorkspace($workspace['id']);
+
+        // block until async events are processed, processing in order is not guaranteed but it should work most of time
+        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
+
+        $events = $this->_client->listEvents([
+            'runId' => $runId,
+        ]);
+
+        $workspaceCreatedEvent = array_pop($events);
+        $this->assertSame($runId, $workspaceCreatedEvent['runId']);
+        $this->assertSame('storage.workspaceCreated', $workspaceCreatedEvent['event']);
+        $this->assertSame('storage', $workspaceCreatedEvent['component']);
+
+        $workspaceDeletedEvent = array_pop($events);
+        $this->assertSame($runId, $workspaceDeletedEvent['runId']);
+        $this->assertSame('storage.workspaceDeleted', $workspaceDeletedEvent['event']);
+        $this->assertSame('storage', $workspaceDeletedEvent['component']);
+        $backend = new Abs($connection);
+        $this->expectException(ServiceException::class);
+        $backend->listFiles();
+    }
+
+    /**
+     * @param array $connection
+     * @throws \Exception
+     */
+    private function assertCredentialsShouldNotWork($connection)
+    {
+        $this->markTestIncomplete('TODO add test');
+    }
+
+    public function testWorkspacePasswordReset()
+    {
+        $this->markTestIncomplete('TODO add test');
+    }
+
+    /**
+     * @dataProvider  dropOptions
+     * @param $dropOptions
+     */
+    public function testDropWorkspace($dropOptions)
+    {
+        $workspaces = new Workspaces($this->_client);
+
+        $backend = $this->resolveFileWorkspaceBackend();
+        $workspace = $workspaces->createWorkspace([
+            'backend' => $backend,
+        ]);
+        $backend = new Abs($workspace['connection']);
+        // sync delete
+        $workspaces->deleteWorkspace($workspace['id'], $dropOptions);
+        try {
+            $backend->listFiles();
+        } catch (ServiceException $e) {
+            $this->assertEquals(404, $e->getCode(), $e->getMessage());
+        }
+
+        if (!empty($dropOptions['async'])) {
+            $job = $this->_client->listJobs()[0];
+            $this->assertEquals('workspaceDrop', $job['operationName']);
+            $this->assertEquals($workspace['id'], $job['operationParams']['workspaceId']);
+        }
+    }
+
+    /**
+     * @dataProvider dropOptions
+     * @param $dropOptions
+     */
+    public function testDropNonExistingWorkspace($dropOptions)
+    {
+        $this->markTestIncomplete('TODO add test');
+    }
+
+    public function dropOptions()
+    {
+        return [
+            [
+                [],
+            ],
+            [
+                [
+                    'async' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    private function resolveFileWorkspaceBackend()
+    {
+        $tokenInfo = $this->_client->verifyToken();
+
+        switch ($tokenInfo['owner']['fileStorageProvider']) {
+            case 'azure':
+                return 'abs';
+            case 'aws':
+            default:
+                $this->markTestIncomplete(sprintf('Other file workspace provider than abs not supported'));
+        }
+    }
+}

--- a/tests/Backend/FileWorkspace/WorkspacesTest.php
+++ b/tests/Backend/FileWorkspace/WorkspacesTest.php
@@ -65,16 +65,8 @@ class WorkspacesTest extends WorkspacesTestCase
         $this->assertSame('storage', $workspaceDeletedEvent['component']);
         $backend = new Abs($connection);
         $this->expectException(ServiceException::class);
+        $this->expectExceptionMessage('The specified container does not exist');
         $backend->listFiles();
-    }
-
-    /**
-     * @param array $connection
-     * @throws \Exception
-     */
-    private function assertCredentialsShouldNotWork($connection)
-    {
-        $this->markTestIncomplete('TODO add test');
     }
 
     public function testWorkspacePasswordReset()

--- a/tests/Backend/FileWorkspace/WorkspacesTest.php
+++ b/tests/Backend/FileWorkspace/WorkspacesTest.php
@@ -2,6 +2,7 @@
 
 namespace Keboola\Test\Backend\FileWorkspace;
 
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\FileWorkspace\Backend\Abs;
 use Keboola\Test\Backend\Workspaces\WorkspacesTestCase;
@@ -100,15 +101,6 @@ class WorkspacesTest extends WorkspacesTestCase
             $this->assertEquals('workspaceDrop', $job['operationName']);
             $this->assertEquals($workspace['id'], $job['operationParams']['workspaceId']);
         }
-    }
-
-    /**
-     * @dataProvider dropOptions
-     * @param $dropOptions
-     */
-    public function testDropNonExistingWorkspace($dropOptions)
-    {
-        $this->markTestIncomplete('TODO add test');
     }
 
     public function dropOptions()


### PR DESCRIPTION
JIRA: KBC-1029 přidal sem ještě drop KBC-1030 bez toho je to docela na nic.

KBC: https://github.com/keboola/connection/pull/2854

- podobně jako normální workspacy sem přihodil ABS class, která dělá abstrakci nad tím file workspacem https://github.com/keboola/storage-api-php-client/commit/26ae23c0c1ca68b71e232cbacb3f1e3cd8088efa
- přidal sem to do {synapse,snowflake-abs}-part-1 test suite, měl  by fičat load z obou asi https://github.com/keboola/storage-api-php-client/commit/c3ac6f40ece07e4da3bd69d768626cb8c4829489
- update api doc https://github.com/keboola/storage-api-php-client/commit/9eafd5ea7b7eb5e9776fc8c1906d33ddb202052f