### PR TITLE
KBC-1070: Fix apiary include parameter allowed value for list conponents

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4295,7 +4295,7 @@ KBC Component architecture, see the [Developers documentation](https://developer
 
 + Parameters
     + componentType (optional) - Component type - `extractor`, `writer`, `application`, etc.
-    + include (optional) - Comma separated list of resources to include. Available resources: `configuration` and `rows`.
+    + include (optional) - Comma separated list of resources to include. Available resources: `configuration` and `state`.
     + isDeleted (optional, boolean) - If true, it returns only components with deleted configurations.
         Default: false
 
@@ -4401,7 +4401,7 @@ KBC Component architecture, see the [Developers documentation](https://developer
 + Parameters
     + branch_id (required) - Id of the development branch
     + componentType (optional) - Component type - `extractor`, `writer`, `application`, etc.
-    + include (optional) - Comma separated list of resources to include. Available resources: `configuration` and `rows`.
+    + include (optional) - Comma separated list of resources to include. Available resources: `configuration` and `state`.
     + isDeleted (optional, boolean) - If true, it returns only components with deleted configurations.
         Default: false
 


### PR DESCRIPTION
Main PR: https://github.com/keboola/connection/pull/2878