### PR TITLE
Tests for exclude=componentDetails

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -547,16 +547,23 @@ This method can be executed by all tokens.
             }
 
 # Group Miscellaneous
+
 ## API Index [/v2/storage]
+
 ### Component List [GET /v2/storage?exclude={exclude}]
+
 Use this API call to obtain definitions of all components, services and stack features available in KBC. For more information about
 the KBC Component architecture, see the [Developers documentation](https://developers.keboola.com/overview/).
 
+- `?exclude=components` - the `components` field won't be present in a response
+- `?exclude=componentDetails` - the `components` field will include only `id`, `name`, `type` and
+`ico64` properties for each component
+
 + Parameters
-    + exclude (optional, enum[string]) - Comma-separated list of resources to exclude from response
+    + exclude (optional, enum[string]) - Comma-separated list of resources or parts to exclude from response
         + Members
             + components
-        + Default: ''
+            + componentDetails
 
 + Response 200 (application/json)
     + Body

--- a/tests/Common/IndexTest.php
+++ b/tests/Common/IndexTest.php
@@ -55,14 +55,11 @@ class IndexTest extends StorageApiTestCase
         // exclude=componentDetails
         $indexWithoutComponentDetails = $this->_client->indexAction((new IndexOptions())->setExclude(['componentDetails']));
         $this->assertArrayHasKey('components', $indexWithoutComponentDetails);
-        $this->assertIsArray($indexWithoutComponentDetails['components']);
 
         $componentsWithoutDetails = $indexWithoutComponentDetails['components'];
-        $this->assertIsArray($componentsWithoutDetails);
         $this->assertArrayHasKey(0, $componentsWithoutDetails);
 
         $firstComponent = $componentsWithoutDetails[0];
-        $this->assertIsArray($firstComponent);
         $this->assertSame(4, count($firstComponent));
         $this->assertArrayHasKey('id', $firstComponent);
         $this->assertArrayHasKey('name', $firstComponent);

--- a/tests/Common/IndexTest.php
+++ b/tests/Common/IndexTest.php
@@ -38,6 +38,7 @@ class IndexTest extends StorageApiTestCase
 
     public function testIndexExclude()
     {
+        // exclude=components
         $index = $this->_client->indexAction((new IndexOptions())->setExclude(['components']));
         $this->assertEquals('storage', $index['api']);
         $this->assertEquals('v2', $index['version']);
@@ -50,6 +51,27 @@ class IndexTest extends StorageApiTestCase
 
         $urlTemplates = $index['urlTemplates'];
         $this->assertArrayHasKey('orchestrationJob', $urlTemplates);
+
+        // exclude=componentDetails
+        $indexWithoutComponentDetails = $this->_client->indexAction((new IndexOptions())->setExclude(['componentDetails']));
+        $this->assertArrayHasKey('components', $indexWithoutComponentDetails);
+        $this->assertIsArray($indexWithoutComponentDetails['components']);
+
+        $componentsWithoutDetails = $indexWithoutComponentDetails['components'];
+        $this->assertIsArray($componentsWithoutDetails);
+        $this->assertArrayHasKey(0, $componentsWithoutDetails);
+
+        $firstComponent = $componentsWithoutDetails[0];
+        $this->assertIsArray($firstComponent);
+        $this->assertSame(4, count($firstComponent));
+        $this->assertArrayHasKey('id', $firstComponent);
+        $this->assertArrayHasKey('name', $firstComponent);
+        $this->assertArrayHasKey('type', $firstComponent);
+        $this->assertArrayHasKey('ico64', $firstComponent);
+
+        // exclude=components,componentDetails
+        $indexWithoutComponents = $this->_client->indexAction((new IndexOptions())->setExclude(['components', 'componentDetails']));
+        $this->assertArrayNotHasKey('components', $indexWithoutComponents);
     }
 
     public function testSuccessfullyWebalizeDisplayName()


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/KBC-1127

Before asking for review:

- [x] New client method has tests
- [x] Apiary file is updated
- [x] There is no BC break (with merge I will create new MINOR release)

Changes:

- Tests for `exclude=componentDetails`

---

V tych novych castiach som uplne vyhodil testy na tie `keys` co sa uz testuju, nech je tam len to podstatne.

Testujem 2 nove pripady:

- `?exclude=componentDetails`
- `?exclude=components,componentDetails` -> ma odignorovat `componentDetails`, pretoze tam ziadne nebudu