### PR TITLE
KBC-1138: Add test for increments versions of config and config rows

### DIFF
--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -113,6 +113,9 @@ class BranchComponentTest extends StorageApiTestCase
 
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
         $this->assertSame(1, $configFromMain['version']);
+        $currentVersion = $configFromMain['currentVersion'];
+        $this->assertEquals('copied', $currentVersion['changeDescription']);
+
         $rows = $branchComponents->listConfigurationRows((new ListConfigurationRowsOptions())
             ->setComponentId($componentId)
             ->setConfigurationId('main-1'));

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -259,6 +259,8 @@ class BranchComponentTest extends StorageApiTestCase
         $branchComponents->updateConfiguration($configurationOptions);
 
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
+        $this->assertEquals('Configuration updated', $configFromMain['changeDescription']);
+
         $this->assertSame(3, $configFromMain['version']);
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('Configuration updated', $currentVersion['changeDescription']);
@@ -478,7 +480,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals($newDesc, $configuration['description']);
         $this->assertEquals($config->getConfiguration(), $configuration['configuration']);
         $this->assertEquals(3, $configuration['version']);
-        $this->assertEmpty($configuration['changeDescription']);
+        $this->assertEquals('Configuration updated', $configuration['changeDescription']);
 
         $config = (new \Keboola\StorageApi\Options\Components\Configuration())
             ->setComponentId('transformation')

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -113,6 +113,11 @@ class BranchComponentTest extends StorageApiTestCase
 
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
         $this->assertSame(1, $configFromMain['version']);
+
+        // test config time created is different for branch config
+        $configMain = $components->getConfiguration($componentId, 'main-1');
+        $this->assertNotEquals($configMain['created'], $configFromMain['created']);
+
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('copied', $currentVersion['changeDescription']);
         $tokenInfo = $this->_client->verifyToken();
@@ -135,6 +140,15 @@ class BranchComponentTest extends StorageApiTestCase
 
         $this->assertEquals('main-1-row-1', $row['id']);
         $this->assertEquals(1, $row['version']);
+
+        $mainBranchRow = $components->getConfigurationRow(
+            $componentId,
+            'main-1',
+            'main-1-row-1'
+        );
+
+        // test config row time created is different for branch config
+        $this->assertNotEquals($mainBranchRow['created'], $row['created']);
 
         $branchConfigs = $branchComponents->listComponentConfigurations(
             (new ListComponentConfigurationsOptions())->setComponentId($componentId)

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -117,6 +117,7 @@ class BranchComponentTest extends StorageApiTestCase
         // test config time created is different for branch config
         $configMain = $components->getConfiguration($componentId, 'main-1');
         $this->assertNotEquals($configMain['created'], $configFromMain['created']);
+        $this->assertEquals('Copied from default branch configuration "Main 1" (main-1) version 2', $configFromMain['changeDescription']);
 
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('Copied from default branch configuration "Main 1" (main-1) version 2', $currentVersion['changeDescription']);
@@ -140,6 +141,7 @@ class BranchComponentTest extends StorageApiTestCase
 
         $this->assertEquals('main-1-row-1', $row['id']);
         $this->assertEquals(1, $row['version']);
+        $this->assertEquals('Copied from default branch configuration row "Main 1 Row 1" (main-1-row-1) version 1', $row['changeDescription']);
 
         $mainBranchRow = $components->getConfigurationRow(
             $componentId,
@@ -244,6 +246,9 @@ class BranchComponentTest extends StorageApiTestCase
         );
 
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
+        $this->assertEquals('Row dev-1-row-1 added', $configFromMain['changeDescription']);
+        $this->assertSame(2, $configFromMain['version']);
+
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('Row dev-1-row-1 added', $currentVersion['changeDescription']);
         $tokenInfo = $this->_client->verifyToken();
@@ -254,6 +259,7 @@ class BranchComponentTest extends StorageApiTestCase
         $branchComponents->updateConfiguration($configurationOptions);
 
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
+        $this->assertSame(3, $configFromMain['version']);
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('Configuration updated', $currentVersion['changeDescription']);
         $tokenInfo = $this->_client->verifyToken();
@@ -268,6 +274,8 @@ class BranchComponentTest extends StorageApiTestCase
         );
 
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
+        $this->assertEquals('Custom change desc', $configFromMain['changeDescription']);
+        $this->assertSame(4, $configFromMain['version']);
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('Custom change desc', $currentVersion['changeDescription']);
         $tokenInfo = $this->_client->verifyToken();
@@ -283,7 +291,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals('dev-1-row-3', $rows[2]['id']);
         $this->assertCount(3, $rows);
 
-        $this->assertEquals('Row main-1-row-1 added', $rows[0]['changeDescription']);
+        $this->assertEquals('Copied from default branch configuration row "Main 1 Row 1" (main-1-row-1) version 1', $rows[0]['changeDescription']);
         $this->assertEquals(1, $rows[0]['version']);
         $this->assertEquals(1, $rows[1]['version']);
         $this->assertEquals('Row dev-1-row-1 added', $rows[1]['changeDescription']);
@@ -420,6 +428,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals('Dev Branch 1', $branchComponentDetail['name']);
         $this->assertEmpty($branchComponentDetail['configuration']);
         $this->assertSame('Test configuration created', $branchComponentDetail['description']);
+        $this->assertEquals('Configuration created', $branchComponentDetail['changeDescription']);
         $this->assertEquals(1, $branchComponentDetail['version']);
         $this->assertIsInt($branchComponentDetail['version']);
         $this->assertIsInt($branchComponentDetail['creatorToken']['id']);
@@ -455,7 +464,7 @@ class BranchComponentTest extends StorageApiTestCase
         $config->setRowsSortOrder([]);
         $branchComponents->updateConfiguration($config);
 
-        // test update version is increment
+        // if updated twice, the version is incremented each time by 1
         $newName = 'neco-nove';
         $config->setName($newName)
             ->setDescription($newDesc)
@@ -538,6 +547,8 @@ class BranchComponentTest extends StorageApiTestCase
             ->setName('Dev Branch'));
 
         $configurationCustomDesc = $branchComponents->getConfiguration('wr-db', 'branch-1');
+        $this->assertEquals('create custom desc', $configurationCustomDesc['changeDescription']);
+
         $currentVersion = $configurationCustomDesc['currentVersion'];
         $this->assertEquals('create custom desc', $currentVersion['changeDescription']);
         $tokenInfo = $this->_client->verifyToken();

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -115,6 +115,9 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertSame(1, $configFromMain['version']);
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('copied', $currentVersion['changeDescription']);
+        $tokenInfo = $this->_client->verifyToken();
+        $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
+        $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
 
         $rows = $branchComponents->listConfigurationRows((new ListConfigurationRowsOptions())
             ->setComponentId($componentId)
@@ -229,6 +232,9 @@ class BranchComponentTest extends StorageApiTestCase
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('Row dev-1-row-1 added', $currentVersion['changeDescription']);
+        $tokenInfo = $this->_client->verifyToken();
+        $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
+        $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
 
         $configurationOptions->setRowsSortOrder(['main-1-row-1', 'dev-1-row-1']);
         $branchComponents->updateConfiguration($configurationOptions);
@@ -236,6 +242,9 @@ class BranchComponentTest extends StorageApiTestCase
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('updated', $currentVersion['changeDescription']);
+        $tokenInfo = $this->_client->verifyToken();
+        $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
+        $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
 
         $branchComponents->addConfigurationRow(
             (new ConfigurationRow($configurationOptions))
@@ -247,6 +256,9 @@ class BranchComponentTest extends StorageApiTestCase
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('Custom change desc', $currentVersion['changeDescription']);
+        $tokenInfo = $this->_client->verifyToken();
+        $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
+        $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
 
         $rows = $branchComponents->listConfigurationRows((new ListConfigurationRowsOptions())
             ->setComponentId($componentId)
@@ -290,6 +302,9 @@ class BranchComponentTest extends StorageApiTestCase
 
         $currentVersion = $configurationAssociatedWithUpdatedRow['currentVersion'];
         $this->assertEquals('Test change dev-1-row-1', $currentVersion['changeDescription']);
+        $tokenInfo = $this->_client->verifyToken();
+        $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
+        $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
 
         $branchComponents->updateConfigurationRow(
             (new ConfigurationRow($configurationOptions))
@@ -398,6 +413,9 @@ class BranchComponentTest extends StorageApiTestCase
 
         $currentVersion = $branchComponentDetail['currentVersion'];
         $this->assertEquals('created', $currentVersion['changeDescription']);
+        $tokenInfo = $this->_client->verifyToken();
+        $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
+        $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
 
         $configs = $branchComponents->listComponentConfigurations(
             (new ListComponentConfigurationsOptions())->setComponentId($componentId)
@@ -465,6 +483,9 @@ class BranchComponentTest extends StorageApiTestCase
         $configFromMain = $branchComponents->getConfiguration('transformation', 'dev-branch-1');
         $currentVersion = $configFromMain['currentVersion'];
         $this->assertEquals('Custom change desc', $currentVersion['changeDescription']);
+        $tokenInfo = $this->_client->verifyToken();
+        $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
+        $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
 
         $state = [
             'cache' => false,
@@ -506,6 +527,9 @@ class BranchComponentTest extends StorageApiTestCase
         $configurationCustomDesc = $branchComponents->getConfiguration('wr-db', 'branch-1');
         $currentVersion = $configurationCustomDesc['currentVersion'];
         $this->assertEquals('create custom desc', $currentVersion['changeDescription']);
+        $tokenInfo = $this->_client->verifyToken();
+        $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
+        $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
 
         $branchComponents->addConfiguration((new \Keboola\StorageApi\Options\Components\Configuration())
             ->setComponentId('wr-db')

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -269,12 +269,11 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals('dev-1-row-3', $rows[2]['id']);
         $this->assertCount(3, $rows);
 
-        // updated rows should have version 2, if rows weren't updated version should be 1
         $this->assertEquals('Row main-1-row-1 added', $rows[0]['changeDescription']);
         $this->assertEquals(1, $rows[0]['version']);
-        $this->assertEquals(2, $rows[1]['version']);
+        $this->assertEquals(1, $rows[1]['version']);
         $this->assertEquals('Row dev-1-row-1 added', $rows[1]['changeDescription']);
-        $this->assertEquals(2, $rows[2]['version']);
+        $this->assertEquals(1, $rows[2]['version']);
         $this->assertEquals('Custom change desc', $rows[2]['changeDescription']);
         $devBranchConfiguration = $branchComponents->getConfiguration($componentId, 'main-1');
         $this->assertEquals(4, $devBranchConfiguration['version']); // add rows should update config version
@@ -298,7 +297,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals('Test change dev-1-row-1', $updatedRow['changeDescription']);
         $this->assertEquals('Test change dev-1-row-1', $configurationAssociatedWithUpdatedRow['changeDescription']);
         $this->assertEquals('{"id":"10","stuff":"true"}', $updatedRow['configuration'][0]);
-        $this->assertEquals(3, $updatedRow['version']);
+        $this->assertEquals(2, $updatedRow['version']);
 
         $currentVersion = $configurationAssociatedWithUpdatedRow['currentVersion'];
         $this->assertEquals('Test change dev-1-row-1', $currentVersion['changeDescription']);
@@ -324,7 +323,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals('Row dev-1-row-1 changed', $updatedRow['changeDescription']);
         $this->assertEquals('Row dev-1-row-1 changed', $configurationAssociatedWithUpdatedRow['changeDescription']);
         $this->assertEquals('{"id":"10","stuff":"true"}', $updatedRow['configuration'][0]);
-        $this->assertEquals(4, $updatedRow['version']); // update row should update version for row
+        $this->assertEquals(3, $updatedRow['version']); // update row should update version for row
 
         $currentVersion = $configurationAssociatedWithUpdatedRow['currentVersion'];
         $this->assertEquals('Row dev-1-row-1 changed', $currentVersion['changeDescription']);
@@ -371,7 +370,7 @@ class BranchComponentTest extends StorageApiTestCase
         );
 
         $this->assertEquals($state, $row['state']);
-        $this->assertEquals(4, $row['version']); // update state shouldn't update version
+        $this->assertEquals(3, $row['version']); // update state shouldn't update version
 
         $updatedConfiguration = $branchComponents->getConfiguration(
             $componentId,
@@ -407,7 +406,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals('Dev Branch 1', $branchComponentDetail['name']);
         $this->assertEmpty($branchComponentDetail['configuration']);
         $this->assertSame('Configuration created', $branchComponentDetail['description']);
-        $this->assertEquals(2, $branchComponentDetail['version']); // create new config set version to 2
+        $this->assertEquals(1, $branchComponentDetail['version']);
         $this->assertIsInt($branchComponentDetail['version']);
         $this->assertIsInt($branchComponentDetail['creatorToken']['id']);
 
@@ -455,7 +454,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals($newName, $configuration['name']);
         $this->assertEquals($newDesc, $configuration['description']);
         $this->assertEquals($config->getConfiguration(), $configuration['configuration']);
-        $this->assertEquals(4, $configuration['version']);
+        $this->assertEquals(3, $configuration['version']);
         $this->assertEmpty($configuration['changeDescription']);
 
         $config = (new \Keboola\StorageApi\Options\Components\Configuration())
@@ -478,7 +477,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertEquals($configurationData, $configuration['configuration']);
         $this->assertEquals([], $configuration['state']);
         $this->assertSame('Custom change desc', $configuration['changeDescription']);
-        $this->assertEquals(5, $configuration['version']);
+        $this->assertEquals(4, $configuration['version']);
 
         $configFromMain = $branchComponents->getConfiguration('transformation', 'dev-branch-1');
         $currentVersion = $configFromMain['currentVersion'];
@@ -502,7 +501,7 @@ class BranchComponentTest extends StorageApiTestCase
 
         $configuration = $branchComponents->getConfiguration($config->getComponentId(), $config->getConfigurationId());
         $this->assertEquals($state, $configuration['state']);
-        $this->assertEquals(5, $configuration['version']); // update state shouldn't change version
+        $this->assertEquals(4, $configuration['version']); // update state shouldn't change version
 
         $config = (new \Keboola\StorageApi\Options\Components\Configuration())
             ->setComponentId('transformation')
@@ -512,7 +511,7 @@ class BranchComponentTest extends StorageApiTestCase
         $branchComponents->updateConfiguration($config);
         $configuration = $branchComponents->getConfiguration($config->getComponentId(), $config->getConfigurationId());
         $this->assertEquals('', $configuration['description'], 'Description can be set empty');
-        $this->assertEquals(6, $configuration['version']);
+        $this->assertEquals(5, $configuration['version']);
 
         // List components test
         $configs = $branchComponents->listComponents();

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -119,7 +119,7 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertNotEquals($configMain['created'], $configFromMain['created']);
 
         $currentVersion = $configFromMain['currentVersion'];
-        $this->assertEquals('copied', $currentVersion['changeDescription']);
+        $this->assertEquals('Copied from default branch configuration "Main 1" (main-1) version 2', $currentVersion['changeDescription']);
         $tokenInfo = $this->_client->verifyToken();
         $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
         $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
@@ -255,7 +255,7 @@ class BranchComponentTest extends StorageApiTestCase
 
         $configFromMain = $branchComponents->getConfiguration($componentId, 'main-1');
         $currentVersion = $configFromMain['currentVersion'];
-        $this->assertEquals('updated', $currentVersion['changeDescription']);
+        $this->assertEquals('Configuration updated', $currentVersion['changeDescription']);
         $tokenInfo = $this->_client->verifyToken();
         $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
         $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);
@@ -410,7 +410,7 @@ class BranchComponentTest extends StorageApiTestCase
             ->setComponentId('transformation')
             ->setConfigurationId('dev-branch-1')
             ->setName('Dev Branch 1')
-            ->setDescription('Configuration created');
+            ->setDescription('Test configuration created');
 
         // create new configuration in dev branch
         $branchComponents->addConfiguration($config);
@@ -419,13 +419,13 @@ class BranchComponentTest extends StorageApiTestCase
         $branchComponentDetail = $branchComponents->getConfiguration('transformation', 'dev-branch-1');
         $this->assertEquals('Dev Branch 1', $branchComponentDetail['name']);
         $this->assertEmpty($branchComponentDetail['configuration']);
-        $this->assertSame('Configuration created', $branchComponentDetail['description']);
+        $this->assertSame('Test configuration created', $branchComponentDetail['description']);
         $this->assertEquals(1, $branchComponentDetail['version']);
         $this->assertIsInt($branchComponentDetail['version']);
         $this->assertIsInt($branchComponentDetail['creatorToken']['id']);
 
         $currentVersion = $branchComponentDetail['currentVersion'];
-        $this->assertEquals('created', $currentVersion['changeDescription']);
+        $this->assertEquals('Configuration created', $currentVersion['changeDescription']);
         $tokenInfo = $this->_client->verifyToken();
         $this->assertEquals($tokenInfo['id'], $currentVersion['creatorToken']['id']);
         $this->assertEquals($tokenInfo['description'], $currentVersion['creatorToken']['description']);


### PR DESCRIPTION
Jira: KBC-1138
Main PR: https://github.com/keboola/connection/pull/2934
Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
