### PR TITLE
Update test

### DIFF
--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -2709,7 +2709,7 @@ class ComponentsTest extends StorageApiTestCase
         $this->assertEquals($createdRow["id"], $row1["id"]);
         $this->assertEquals("name", $row1["name"]);
         $this->assertEquals("description", $row1["description"]);
-        $this->assertEquals("", $row1["changeDescription"]);
+        $this->assertEquals("Row {$createdRow["id"]} changed", $row1["changeDescription"]);
         $this->assertEquals(true, $row1["isDisabled"]);
         $this->assertNotEmpty($row1['state']);
 
@@ -2730,7 +2730,7 @@ class ComponentsTest extends StorageApiTestCase
         $this->assertEquals($createdRow["id"], $row1["id"]);
         $this->assertEquals("name", $row1["name"]);
         $this->assertEquals("description", $row1["description"]);
-        $this->assertEquals("", $row1["changeDescription"]);
+        $this->assertEquals("Row {$createdRow["id"]} changed", $row1["changeDescription"]);
         $this->assertEquals(true, $row1["isDisabled"]);
         $this->assertNotEmpty($row1['state']);
 


### PR DESCRIPTION
when changedDescription not set, default message automatically set instead of ""

Jira: KBC-1143

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [ ] You declared if there is a BC break or not (will affect next release of a client)

---
Lokalne som si asi nespustil testy `ComponentsTests` ked som upravoval len rows ale po mergi padol jeden test https://travis-ci.com/github/keboola/connection/jobs/452270966#L4819 `Keboola\Test\Common\ComponentsTest::testRowChangesAfterRowCopy` vsetko v ComponentsTest (okrem toho jedneho) a ComponentsRowTest mi prechadza.

Teraz si trochu hovorim ci to nieje nejaka zasadnejsia zmena chovania ked je to aj v testoch.