### PR TITLE
Fix WorkspacesRedshiftTest::testLoadedDist

### DIFF
--- a/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
@@ -159,7 +159,10 @@ class WorkspacesRedshiftTest extends WorkspacesTestCase
             $this->assertEquals(1, (int)$row['distkey']);
         }
 
-        $statement = $db->prepare("select relname, reldiststyle from pg_class where relname = 'languages';");
+        $statement = $db->prepare(sprintf(
+            'SELECT TRIM(nspname) AS schemaname,TRIM(relname) AS tablename,reldiststyle FROM pg_class_info a LEFT JOIN pg_namespace b ON a.relnamespace=b.oid WHERE schemaname LIKE \'%s\'',
+            $workspace['connection']['schema']
+        ));
         $statement->execute();
         $row = $statement->fetch();
         if (is_array($dist)) {


### PR DESCRIPTION
Jira: KBC-1188

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
Test nebyl stabilní selectoval všechny tabulky `languages` v databázi. Teď je omezený na schéma.

Zkusil sem pustit testy proti testingu aj vlastní db.