### PR TITLE
KBC-1273 Delete configuration when resetting to deleted configuration

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -5210,6 +5210,9 @@ Updates an existing configuration for [Development Branch](#reference/developmen
 
 
 + Response 200 (application/json)
+
+    In case the configuration exists in main branch
+
     + Body
 
             {
@@ -5243,6 +5246,12 @@ Updates an existing configuration for [Development Branch](#reference/developmen
                     "changeDescription": "Added new key"
                 }
             }
+
++ Response 204 (application/json)
+
+    In case the configuration was deleted in main branch
+
+    + Body
 
 ### Delete Configuration [DELETE]
 Deletes a configuration. When a configuration is deleted, it is only marked as deleted and remains still available in the system.

--- a/apiary.apib
+++ b/apiary.apib
@@ -5208,50 +5208,7 @@ Updates an existing configuration for [Development Branch](#reference/developmen
 
             X-StorageApi-Token: your_token
 
-
-+ Response 200 (application/json)
-
-    In case the configuration exists in main branch
-
-    + Body
-
-            {
-                "id": "236606822",
-                "name": "My new configuration",
-                "description": "",
-                "created": "2017-02-14T14:38:26+0100",
-                "creatorToken": {
-                    "id": 27978,
-                    "description": "ondrej.popelka@keboola.com"
-                },
-                "version": 2,
-                "changeDescription": "Added new key",
-                "isDeleted": false,
-                "configuration": {
-                    "key": "value",
-                    "key2": "value2",
-                    "key3": "value3"
-                },
-                "rowsSortOrder": [],
-                "rows": [],
-                "state": {
-                    "lastId": 123
-                },
-                "currentVersion": {
-                    "created": "2017-02-14T14:48:41+0100",
-                    "creatorToken": {
-                        "id": 27978,
-                        "description": "ondrej.popelka@keboola.com"
-                    },
-                    "changeDescription": "Added new key"
-                }
-            }
-
 + Response 204 (application/json)
-
-    In case the configuration was deleted in main branch
-
-    + Body
 
 ### Delete Configuration [DELETE]
 Deletes a configuration. When a configuration is deleted, it is only marked as deleted and remains still available in the system.

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -189,6 +189,20 @@ class BranchComponentTest extends StorageApiTestCase
         } catch (ClientException $e) {
             $this->assertSame('Configuration main-1 not found', $e->getMessage());
         }
+
+        // can be reset when existing default and deleted branch (new config in default scenario)
+        // first restore branch soft deleted above so that it can be reset back to branch
+        $components->restoreComponentConfiguration($componentId, $configurationId);
+        // assert does not exist in branch
+        try {
+            $branchComponents->getConfiguration($componentId, $configurationId);
+            $this->fail('Should have thrown');
+        } catch (ClientException $e) {
+            $this->assertSame('Configuration main-1 not found', $e->getMessage());
+        }
+        $branchComponents->resetToDefault($componentId, $configurationId);
+        // assert that exists in branch (won't throw 404)
+        $branchComponents->getConfiguration($componentId, $configurationId);
     }
 
     private function withoutKeysChangingInBranch($branch)

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -122,11 +122,10 @@ class BranchComponentTest extends StorageApiTestCase
 
         $this->assertCount(3, $configurationVersionsInBranch);
 
-        $resetConfigurationInBranchResult = $branchComponents->resetToDefault($componentId, $configurationId);
+        $branchComponents->resetToDefault($componentId, $configurationId);
 
         $resetConfigurationInBranch = $branchComponents->getConfiguration($componentId, $configurationId);
 
-        $this->assertSame($resetConfigurationInBranch, $resetConfigurationInBranchResult);
         $this->assertSame(1, $resetConfigurationInBranch['version']);
 
         try {
@@ -171,7 +170,9 @@ class BranchComponentTest extends StorageApiTestCase
 
         // delete row in production and reset branch version
         $components->deleteConfigurationRow($componentId, $configurationId, $rowId);
-        $configurationAfterReset = $branchComponents->resetToDefault($componentId, $configurationId);
+        $branchComponents->resetToDefault($componentId, $configurationId);
+        $configurationAfterReset = $branchComponents->getConfiguration($componentId, $configurationId);
+
         $this->assertCount(0, $configurationAfterReset['rows']);
 
         // make configuration in branch updated again and test reset to deleted production configuration

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -203,6 +203,22 @@ class BranchComponentTest extends StorageApiTestCase
         $branchComponents->resetToDefault($componentId, $configurationId);
         // assert that exists in branch (won't throw 404)
         $branchComponents->getConfiguration($componentId, $configurationId);
+
+        // purge the deleted configuration
+        // delete
+        $components->deleteConfiguration($componentId, $configurationId);
+        // purge
+        $components->deleteConfiguration($componentId, $configurationId);
+
+        // reset to purged version
+        $branchComponents->resetToDefault($componentId, $configurationId);
+
+        try {
+            $updatedConfigurationInBranch = $branchComponents->getConfiguration($componentId, $configurationId);
+            $this->fail('Should have thrown as reset to purged means deleted');
+        } catch (ClientException $e) {
+            $this->assertSame('Configuration main-1 not found', $e->getMessage());
+        }
     }
 
     private function withoutKeysChangingInBranch($branch)


### PR DESCRIPTION
Jira: KBC-1273
Code: https://github.com/keboola/connection/pull/3057

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---

There is a "bc break" of sorts - that it does not return 404 for configuration deleted in branch, but 204 instead. But the API is still in private beta, so I wouldn't sweat it. 