### PR TITLE
Copy "row versions" related tests

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -5410,11 +5410,93 @@ Lists all versions of a component configuration.
                 }
             ]
 
+### Versions list for Development Branch [GET /v2/storage/branch/{branch_id}/components/{component_id}/configs/{config_id}/versions?include={include}&limit={limit}&offset={offset}]
+
+Lists all versions of a component configuration for [Development Branch](#reference/development-branches).
+
++ Parameters
+    + branch_id (required) - Id of the development branch
+    + include (optional) - Comma separated list of information to be retrieved; possible fields are `name`, `description` and `configuration`.
+        Default: `name,description`
+    + limit (optional, number) - Pagination limit
+        Default: 100
+    + offset (optional, number) - Pagination offset
+        Default: 0
+
++ Request
+    + Headers
+
+            X-StorageApi-Token: your_token
+
++ Response 200 (application/json)
+    + Body
+
+            [
+                {
+                    "version": 2,
+                    "created": "2017-02-09T21:11:02+0100",
+                    "creatorToken": {
+                        "id": 27978,
+                        "description": "ondrej.popelka@keboola.com"
+                    },
+                    "changeDescription": "Add input table in.c-afnhk.tree-test",
+                    "isDeleted": false,
+                    "name": "test",
+                    "description": ""
+                },
+                {
+                    "version": 1,
+                    "created": "2017-02-09T21:10:31+0100",
+                    "creatorToken": {
+                        "id": 27978,
+                        "description": "ondrej.popelka@keboola.com"
+                    },
+                    "changeDescription": "",
+                    "isDeleted": false,
+                    "name": "test",
+                    "description": ""
+                }
+            ]
+
 ## Manage Configuration Versions [/v2/storage/components/{component_id}/configs/{config_id}/versions/{version_id}]
 ### Version Detail [GET]
 Gets configuration version.
 
 + Parameters
+    + component_id (required) - Id of the component - e.g. `keboola.ex-db-mysql`
+    + config_id (required) - Id of the configuration
+    + version_id (required, string) - Version number or `latestPublished` to retrieve the latest published version
+
++ Request
+    + Headers
+
+            X-StorageApi-Token: your_token
+
++ Response 200 (application/json)
+    + Body
+
+            {
+                "version": 1,
+                "created": "2017-02-09T21:10:31+0100",
+                "creatorToken": {
+                    "id": 27978,
+                    "description": "ondrej.popelka@keboola.com"
+                },
+                "changeDescription": "",
+                "isDeleted": false,
+                "name": "test",
+                "description": "",
+                "configuration": {},
+                "rowsSortOrder": [],
+                "rows": []
+            }
+
+### Version Detail for Development Branch [GET /v2/storage/branch/{branch_id}/components/{component_id}/configs/{config_id}/versions/{version_id}]
+
+Gets configuration version for [Development Branch](#reference/development-branches).
+
++ Parameters
+    + branch_id (required) - Id of the development branch
     + component_id (required) - Id of the component - e.g. `keboola.ex-db-mysql`
     + config_id (required) - Id of the configuration
     + version_id (required, string) - Version number or `latestPublished` to retrieve the latest published version
@@ -6013,6 +6095,60 @@ List versions of a given configuration Row of a given Configuration.
                 }
             ]
 
+### Versions list for Development Branch [GET /v2/storage/branch/{branch_id}/components/{component_id}/configs/{config_id}/rows/{row_id}/versions?include={include}&limit={limit}&offset={offset}]
+List versions of a given configuration Row of a given Configuration for [Development Branch](#reference/development-branches)
+
++ Parameters
+    + branch_id (required) - Id of the development branch
+    + component_id (required) - Id of the component - e.g. `keboola.ex-db-mysql`
+    + config_id (required) - Id of the configuration
+    + row_id (required) - Id of the configuration row
+    + include (optional) - Comma separated list of information to retrieve; it may contain: `configuration`
+        Default: `configuration`
+    + limit (optional, number) - Pagination limit
+        Default: 100
+    + offset (optional, number) - Pagination offset
+        Default: 0
+
++ Request
+    + Headers
+
+            X-StorageApi-Token: your_token
+
++ Response 200
+    + Headers
+
+            Content-type: application/json
+
+    + Body
+
+            [
+                {
+                    "version": 2,
+                    "name": "",
+                    "description": "",
+                    "isDisabled": false,
+                    "created": "2015-08-12T12:33:04+0200",
+                    "creatorToken": {
+                        "id": 1392,
+                        "description": "martin@keboola.com"
+                    },
+                    "changeDescription": "Cause of the change"
+                },
+                {
+                    "version": 1,
+                    "name": "",
+                    "description": "",
+                    "isDisabled": false,
+                    "created": "2015-08-10T22:00:55+0200",
+                    "creatorToken": {
+                        "id": 1392,
+                        "description": "martin@keboola.com"
+                    },
+                    "changeDescription": "Some other cause of the change"
+                }
+            ]
+
 ## Manage Configuration Row Versions [/v2/storage/components/{component_id}/configs/{config_id}/rows/{row_id}/versions/{version_id}]
 ### Version detail [GET]
 Gets details about the Configuration Row version.
@@ -6045,6 +6181,37 @@ Gets details about the Configuration Row version.
                 "configuration": {}
             }
 
+### Version detail for Development Branch [GET /v2/storage/branch/{branch_id}/components/{component_id}/configs/{config_id}/rows/{row_id}/versions/{version_id}]
+Gets details about the Configuration Row version.
+
++ Parameters
+    + branch_id (required) - Id of the development branch
+    + component_id (required) - Id of the component - e.g. `keboola.ex-db-mysql`
+    + config_id (required) - Id of the configuration
+    + row_id (required) - Id of the configuration row
+    + version_id (required) - Id of the configuration row version
+
++ Request
+    + Headers
+
+            X-StorageApi-Token: your_token
+
++ Response 200 (application/json)
+    + Body
+
+            {
+                "name": "",
+                "description": "",
+                "isDisabled": false,
+                "version": 1,
+                "created": "2015-08-10T22:00:55+0200",
+                "creatorToken": {
+                    "id": 1392,
+                    "description": "martin@keboola.com"
+                },
+                "changeDescription": "Some other cause of the change"
+                "configuration": {}
+            }
 
 ## Rollback Configuration Row Version [/v2/storage/components/{component_id}/configs/{config_id}/rows/{row_id}/versions/{version_id}/rollback]
 ### Rollback Version [POST]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - REDSHIFT_PASSWORD
       - SUITE_NAME
       - TRAVIS_BUILD_ID
-      - IS_VERSIONS_LIST_IMPLEMENTED_FOR_DEV_BRANCH
   dev: &dev
     <<: *base
     volumes:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,5 @@ parameters:
         - '#Constant STORAGE_API_[_A-Z0-9]+ not found.#'
         - '#Constant SUITE_NAME not found.#'
         - '#Constant TRAVIS_BUILD_ID not found.#'
-        - '#Constant IS_VERSIONS_LIST_IMPLEMENTED_FOR_DEV_BRANCH not found.#'
     excludes_analyse:
         - vendor

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -948,11 +948,7 @@ class BranchComponentTest extends StorageApiTestCase
         $providedToken = $this->_client->verifyToken();
         $devBranch = new DevBranches($this->_client);
         $branchName = __CLASS__ . '\\' . $this->getName() . '\\' . $providedToken['id'];
-        $dummyBranchName = $branchName . '-dummy';
-        $this->deleteBranchesByPrefix($devBranch, $dummyBranchName);
         $this->deleteBranchesByPrefix($devBranch, $branchName);
-        // dummy branch to highlight potentially forgotten where on branch
-        $devBranch->createBranch($dummyBranchName);
         $branch = $devBranch->createBranch($branchName);
 
         $componentsApi = new \Keboola\StorageApi\Components($this->getBranchAwareDefaultClient($branch['id']));
@@ -988,11 +984,7 @@ class BranchComponentTest extends StorageApiTestCase
         $providedToken = $this->_client->verifyToken();
         $devBranch = new DevBranches($this->_client);
         $branchName = __CLASS__ . '\\' . $this->getName() . '\\' . $providedToken['id'];
-        $dummyBranchName = $branchName . '-dummy';
-        $this->deleteBranchesByPrefix($devBranch, $dummyBranchName);
         $this->deleteBranchesByPrefix($devBranch, $branchName);
-        // dummy branch to highlight potentially forgotten where on branch
-        $devBranch->createBranch($dummyBranchName);
         $branch = $devBranch->createBranch($branchName);
 
         $componentsApi = new \Keboola\StorageApi\Components($this->getBranchAwareDefaultClient($branch['id']));
@@ -1096,11 +1088,7 @@ class BranchComponentTest extends StorageApiTestCase
         $providedToken = $this->_client->verifyToken();
         $devBranch = new DevBranches($this->_client);
         $branchName = __CLASS__ . '\\' . $this->getName() . '\\' . $providedToken['id'];
-        $dummyBranchName = $branchName . '-dummy';
-        $this->deleteBranchesByPrefix($devBranch, $dummyBranchName);
         $this->deleteBranchesByPrefix($devBranch, $branchName);
-        // dummy branch to highlight potentially forgotten where on branch
-        $devBranch->createBranch($dummyBranchName);
         $branch = $devBranch->createBranch($branchName);
 
         $componentsApi = new \Keboola\StorageApi\Components($this->getBranchAwareDefaultClient($branch['id']));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,7 +16,6 @@ define('REDSHIFT_USER', getenv('REDSHIFT_USER'));
 define('REDSHIFT_PASSWORD', getenv('REDSHIFT_PASSWORD'));
 define('SUITE_NAME', getenv('SUITE_NAME'));
 define('TRAVIS_BUILD_ID', getenv('TRAVIS_BUILD_ID'));
-define('IS_VERSIONS_LIST_IMPLEMENTED_FOR_DEV_BRANCH', getenv('IS_VERSIONS_LIST_IMPLEMENTED_FOR_DEV_BRANCH'));
 
 $revisionFilePath = realpath(__DIR__ . '/../REVISION');
 


### PR DESCRIPTION
Before asking for review make sure that:

- [x] New client method(s) has tests (**no new client methods)**
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

**no BC break**

---

Kopirujem testy, ktore riesia `listConfigurationRowVersions`. Je to tam spravene tak, ze na zaciatku kazdeho testu mazem suvisiace branches.
