### PR TITLE
KBC-1295 Add configuration test for keeping version when no update

### DIFF
--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -1245,13 +1245,16 @@ class BranchComponentTest extends StorageApiTestCase
         ]);
         $componentsApi->addConfigurationRow($configurationRow);
 
+        $componentConfiguration = $componentsApi->getConfiguration('wr-db', 'main-1');
+
+        $this->assertEquals(3, $componentConfiguration['version']);
+
         $configuration = new \Keboola\StorageApi\Options\Components\Configuration();
         $configuration
             ->setComponentId('wr-db')
             ->setConfigurationId('main-1')
             ->setRowsSortOrder(['main-1-1', 'main-1-2']);
         $componentsApi->updateConfiguration($configuration);
-
 
         $componentConfiguration = $componentsApi->getConfiguration('wr-db', 'main-1');
 

--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -1213,6 +1213,63 @@ class BranchComponentTest extends StorageApiTestCase
         $this->assertCount(3, $versions);
     }
 
+
+    public function testVersionIncreaseWhenUpdate()
+    {
+        $providedToken = $this->_client->verifyToken();
+        $devBranch = new DevBranches($this->_client);
+        $branchName = __CLASS__ . '\\' . $this->getName() . '\\' . $providedToken['id'];
+        $this->deleteBranchesByPrefix($devBranch, $branchName);
+        $branch = $devBranch->createBranch($branchName);
+
+        $componentsApi = new \Keboola\StorageApi\Components($this->getBranchAwareDefaultClient($branch['id']));
+
+        $configuration = new \Keboola\StorageApi\Options\Components\Configuration();
+        $configuration
+            ->setComponentId('wr-db')
+            ->setConfigurationId('main-1')
+            ->setName('Main');
+        $componentsApi->addConfiguration($configuration);
+
+        $configurationRow = new \Keboola\StorageApi\Options\Components\ConfigurationRow($configuration);
+        $configurationRow->setRowId('main-1-1');
+        $configurationRow->setConfiguration([
+            'my-value' => 666,
+        ]);
+        $componentsApi->addConfigurationRow($configurationRow);
+
+        $configurationRow = new \Keboola\StorageApi\Options\Components\ConfigurationRow($configuration);
+        $configurationRow->setRowId('main-1-2');
+        $configurationRow->setConfiguration([
+            'my-value' => 666,
+        ]);
+        $componentsApi->addConfigurationRow($configurationRow);
+
+        $configuration = new \Keboola\StorageApi\Options\Components\Configuration();
+        $configuration
+            ->setComponentId('wr-db')
+            ->setConfigurationId('main-1')
+            ->setRowsSortOrder(['main-1-1', 'main-1-2']);
+        $componentsApi->updateConfiguration($configuration);
+
+
+        $componentConfiguration = $componentsApi->getConfiguration('wr-db', 'main-1');
+
+        $this->assertEquals(4, $componentConfiguration['version']);
+
+        // calling the update once again without any change, the version should remain
+        $configuration = new \Keboola\StorageApi\Options\Components\Configuration();
+        $configuration
+            ->setComponentId('wr-db')
+            ->setConfigurationId('main-1')
+            ->setRowsSortOrder(['main-1-1', 'main-1-2']);
+        $componentsApi->updateConfiguration($configuration);
+
+        $componentConfiguration = $componentsApi->getConfiguration('wr-db', 'main-1');
+
+        $this->assertEquals(4, $componentConfiguration['version']);
+    }
+
     /**
      * @param string $branchPrefix
      */

--- a/tests/Common/ConfigurationRowsSortOrderTest.php
+++ b/tests/Common/ConfigurationRowsSortOrderTest.php
@@ -244,7 +244,7 @@ class ConfigurationRowsSortOrderTest extends StorageApiTestCase
         }
     }
 
-    public function testReorderVersionIncrease()
+    public function testVersionChangeWhenRowsSortOrderIsManipulated()
     {
         $components = new \Keboola\StorageApi\Components($this->_client);
         $configuration = new \Keboola\StorageApi\Options\Components\Configuration();
@@ -276,6 +276,17 @@ class ConfigurationRowsSortOrderTest extends StorageApiTestCase
         $this->assertEquals(4, $configurationResponse['version']);
         $this->assertEquals(1, $configurationResponse['rows'][0]['version']);
         $this->assertEquals(1, $configurationResponse['rows'][1]['version']);
+
+        // running one more update without any change. The version should stay on 4
+        $updateConfig = new Configuration();
+        $updateConfig
+            ->setComponentId('wr-db')
+            ->setConfigurationId('main-1')
+            ->setRowsSortOrder(['main-1-2', 'main-1-1']);
+        $components->updateConfiguration($updateConfig);
+
+        $configurationResponseAfterChange = $components->getConfiguration('wr-db', 'main-1');
+        $this->assertEquals(4, $configurationResponseAfterChange['version']);
     }
 
     public function testVersionRollbackToUnsorted()


### PR DESCRIPTION
Jira: KBC-1295

New test for https://github.com/keboola/connection/pull/3076 . Checking that if you update a Configuration with the same data (no change) it wont increase version.
