### PR TITLE
Keboola\StorageApi\Tokens for tokens manipulation

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1248,6 +1248,7 @@ class Client
      *
      * @param string $tokenId If not set, defaults to self
      * @return string new token
+     * @deprecated $tokenId parameter will be removed in next major release. Use Tokens::refreshToken()
      */
     public function refreshToken($tokenId = null)
     {

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1216,6 +1216,7 @@ class Client
      *
      * @param TokenUpdateOptions $options
      * @return int token id
+     * @deprecated Will be removed in next major release. Use Tokens::updateToken()
      */
     public function updateToken(TokenUpdateOptions $options)
     {

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -81,6 +81,9 @@ class Client
      */
     public $connectionTimeout = 7200;
 
+    /** @var Tokens */
+    private $tokens;
+
     /**
      * Clients accept an array of constructor parameters.
      *
@@ -143,6 +146,7 @@ class Client
         }
 
         $this->initClient();
+        $this->tokens = new Tokens($this);
     }
 
     private function initClient()
@@ -1151,7 +1155,7 @@ class Client
      */
     public function listTokens()
     {
-        return $this->apiGet("tokens");
+        return $this->tokens->listTokens();
     }
 
     /**
@@ -1164,7 +1168,7 @@ class Client
      */
     public function getToken($tokenId)
     {
-        return $this->apiGet("tokens/" . $tokenId);
+        return $this->tokens->getToken($tokenId);
     }
 
     /**
@@ -1203,7 +1207,7 @@ class Client
      */
     public function createToken(TokenCreateOptions $options)
     {
-        $result = $this->apiPost("tokens", $options->toParamsArray());
+        $result = $this->tokens->createToken($options);
 
         $this->log("Token {$result["id"]} created", ["options" => $options->toParamsArray(), "result" => $result]);
 
@@ -1220,7 +1224,7 @@ class Client
      */
     public function updateToken(TokenUpdateOptions $options)
     {
-        $result = $this->apiPut("tokens/" . $options->getTokenId(), $options->toParamsArray());
+        $result = $this->tokens->updateToken($options);
 
         $this->log("Token {$options->getTokenId()} updated", [
             "options" => $options->toParamsArray(),
@@ -1232,14 +1236,13 @@ class Client
 
     /**
      * @param string $tokenId
-     * @return mixed|string
      * @deprecated Will be removed in next major release. Use Tokens::dropToken()
      */
     public function dropToken($tokenId)
     {
-        $result = $this->apiDelete("tokens/" . $tokenId);
+        $this->tokens->dropToken($tokenId);
         $this->log("Token {$tokenId} deleted");
-        return $result;
+        return ''; // BC
     }
 
     /**
@@ -1257,7 +1260,7 @@ class Client
             $tokenId = $currentToken["id"];
         }
 
-        $result = $this->apiPost("tokens/" . $tokenId . "/refresh");
+        $result = $this->tokens->refreshToken($tokenId);
 
         if ($currentToken["id"] == $result["id"]) {
             $this->token = $result['token'];
@@ -1276,10 +1279,7 @@ class Client
      */
     public function shareToken($tokenId, $recipientEmail, $message)
     {
-        $this->apiPost("tokens/$tokenId/share", array(
-            'recipientEmail' => $recipientEmail,
-            'message' => $message,
-        ));
+        $this->tokens->shareToken($tokenId, $recipientEmail, $message);
     }
 
 

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1198,6 +1198,9 @@ class Client
         throw new ClientException('Api endpoint \'storage/tokens/keen\' was removed from KBC');
     }
 
+    /**
+     * @deprecated Will be removed in next major release. Use Tokens::createToken()
+     */
     public function createToken(TokenCreateOptions $options)
     {
         $result = $this->apiPost("tokens", $options->toParamsArray());

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1160,6 +1160,7 @@ class Client
      *
      * @param string $tokenId token id
      * @return array
+     * @deprecated Will be removed in next major release. Use Tokens::getToken()
      */
     public function getToken($tokenId)
     {

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1271,6 +1271,7 @@ class Client
      * @param $tokenId
      * @param $recipientEmail
      * @param $message
+     * @deprecated Will be removed in next major release. Use Tokens::shareToken()
      */
     public function shareToken($tokenId, $recipientEmail, $message)
     {

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1233,6 +1233,7 @@ class Client
     /**
      * @param string $tokenId
      * @return mixed|string
+     * @deprecated Will be removed in next major release. Use Tokens::dropToken()
      */
     public function dropToken($tokenId)
     {

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1147,6 +1147,7 @@ class Client
      * returns all tokens
      *
      * @return array
+     * @deprecated Will be removed in next major release. Use Tokens::listTokens()
      */
     public function listTokens()
     {

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -23,6 +23,7 @@ class Tokens
     }
 
     /**
+     * @param int $id
      * @return array
      */
     public function getToken($id)
@@ -43,27 +44,36 @@ class Tokens
      */
     public function updateToken(TokenUpdateOptions $options)
     {
-        return $this->client->apiPut("tokens/" . $options->getTokenId(), $options->toParamsArray());
+        return $this->client->apiPut("tokens/{$options->getTokenId()}", $options->toParamsArray());
     }
 
+    /**
+     * @param int $id
+     */
     public function dropToken($id)
     {
-        $this->client->apiDelete("tokens/" . $id);
+        $this->client->apiDelete("tokens/{$id}");
     }
 
+    /**
+     * @param int $id
+     * @param string $recipientEmail
+     * @param string $message
+     */
     public function shareToken($id, $recipientEmail, $message)
     {
-        $this->client->apiPost("tokens/$id/share", [
+        $this->client->apiPost("tokens/{$id}/share", [
             'recipientEmail' => $recipientEmail,
             'message' => $message,
         ]);
     }
 
     /**
+     * @param int $id
      * @return array
      */
     public function refreshToken($id)
     {
-        return $this->client->apiPost("tokens/$id/refresh");
+        return $this->client->apiPost("tokens/{$id}/refresh");
     }
 }

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -43,4 +43,8 @@ class Tokens
         return $this->client->apiPut("tokens/" . $options->getTokenId(), $options->toParamsArray());
     }
 
+    public function dropToken($id)
+    {
+        $this->client->apiDelete("tokens/" . $id);
+    }
 }

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -58,4 +58,12 @@ class Tokens
             'message' => $message,
         ]);
     }
+
+    /**
+     * @return array
+     */
+    public function refreshToken($id)
+    {
+        return $this->client->apiPost("tokens/$id/refresh");
+    }
 }

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -1,0 +1,18 @@
+<?php
+namespace Keboola\StorageApi;
+
+class Tokens
+{
+    /** @var Client */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function listTokens()
+    {
+        return $this->client->apiGet("tokens");
+    }
+}

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -1,6 +1,8 @@
 <?php
 namespace Keboola\StorageApi;
 
+use Keboola\StorageApi\Options\TokenCreateOptions;
+
 class Tokens
 {
     /** @var Client */
@@ -22,5 +24,13 @@ class Tokens
     public function getToken($id)
     {
         return $this->client->apiGet("tokens/{$id}");
+    }
+
+    /**
+     * @return array
+     */
+    public function createToken(TokenCreateOptions $options)
+    {
+        return $this->client->apiPost("tokens", $options->toParamsArray());
     }
 }

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -14,6 +14,9 @@ class Tokens
         $this->client = $client;
     }
 
+    /**
+     * @return array
+     */
     public function listTokens()
     {
         return $this->client->apiGet("tokens");

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -15,4 +15,12 @@ class Tokens
     {
         return $this->client->apiGet("tokens");
     }
+
+    /**
+     * @return array
+     */
+    public function getToken($id)
+    {
+        return $this->client->apiGet("tokens/{$id}");
+    }
 }

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -2,6 +2,7 @@
 namespace Keboola\StorageApi;
 
 use Keboola\StorageApi\Options\TokenCreateOptions;
+use Keboola\StorageApi\Options\TokenUpdateOptions;
 
 class Tokens
 {
@@ -33,4 +34,13 @@ class Tokens
     {
         return $this->client->apiPost("tokens", $options->toParamsArray());
     }
+
+    /**
+     * @return array
+     */
+    public function updateToken(TokenUpdateOptions $options)
+    {
+        return $this->client->apiPut("tokens/" . $options->getTokenId(), $options->toParamsArray());
+    }
+
 }

--- a/src/Keboola/StorageApi/Tokens.php
+++ b/src/Keboola/StorageApi/Tokens.php
@@ -50,4 +50,12 @@ class Tokens
     {
         $this->client->apiDelete("tokens/" . $id);
     }
+
+    public function shareToken($id, $recipientEmail, $message)
+    {
+        $this->client->apiPost("tokens/$id/share", [
+            'recipientEmail' => $recipientEmail,
+            'message' => $message,
+        ]);
+    }
 }

--- a/tests/Backend/CommonPart1/ExportParamsTest.php
+++ b/tests/Backend/CommonPart1/ExportParamsTest.php
@@ -211,7 +211,7 @@ class ExportParamsTest extends StorageApiTestCase
         ;
 
         $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->_client->getToken($newTokenId);
+        $newToken = $this->tokens->getToken($newTokenId);
         $client = $this->getClient([
             'token' => $newToken['token'],
             'url' => STORAGE_API_URL,

--- a/tests/Backend/CommonPart1/ExportParamsTest.php
+++ b/tests/Backend/CommonPart1/ExportParamsTest.php
@@ -210,8 +210,7 @@ class ExportParamsTest extends StorageApiTestCase
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->tokens->getToken($newTokenId);
+        $newToken = $this->tokens->createToken($tokenOptions);
         $client = $this->getClient([
             'token' => $newToken['token'],
             'url' => STORAGE_API_URL,

--- a/tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+++ b/tests/Backend/FileWorkspace/WorkspacesLoadTest.php
@@ -204,8 +204,7 @@ class WorkspacesLoadTest extends FileWorkspaceTestCase
             ->setCanReadAllFileUploads(true)
         ;
 
-        $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->tokens->getToken($newTokenId);
+        $newToken = $this->tokens->createToken($tokenOptions);
         $newTokenClient = $this->getClient([
             'token' => $newToken['token'],
             'url' => STORAGE_API_URL
@@ -1084,8 +1083,7 @@ class WorkspacesLoadTest extends FileWorkspaceTestCase
             ->setDescription('workspaceLoadTest: Out read token')
             ->addBucketPermission($this->getTestBucketId(self::STAGE_OUT), TokenAbstractOptions::BUCKET_PERMISSION_READ);
 
-        $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->tokens->getToken($tokenId);
+        $token = $this->tokens->createToken($tokenOptions);
 
         $testClient = $this->getClient([
             'token' => $token['token'],

--- a/tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+++ b/tests/Backend/FileWorkspace/WorkspacesLoadTest.php
@@ -229,8 +229,8 @@ class WorkspacesLoadTest extends FileWorkspaceTestCase
         );
 
         // non admin token without canReadAllFileUploads permission
-        $this->_client->updateToken(
-            (new TokenUpdateOptions($newTokenId))
+        $this->tokens->updateToken(
+            (new TokenUpdateOptions($newToken['id']))
                 ->setCanReadAllFileUploads(false)
         );
 

--- a/tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+++ b/tests/Backend/FileWorkspace/WorkspacesLoadTest.php
@@ -205,7 +205,7 @@ class WorkspacesLoadTest extends FileWorkspaceTestCase
         ;
 
         $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->_client->getToken($newTokenId);
+        $newToken = $this->tokens->getToken($newTokenId);
         $newTokenClient = $this->getClient([
             'token' => $newToken['token'],
             'url' => STORAGE_API_URL
@@ -1085,7 +1085,7 @@ class WorkspacesLoadTest extends FileWorkspaceTestCase
             ->addBucketPermission($this->getTestBucketId(self::STAGE_OUT), TokenAbstractOptions::BUCKET_PERMISSION_READ);
 
         $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $testClient = $this->getClient([
             'token' => $token['token'],

--- a/tests/Backend/Mixed/SharingTest.php
+++ b/tests/Backend/Mixed/SharingTest.php
@@ -287,12 +287,12 @@ class SharingTest extends StorageApiSharingTestCase
         // bucket unlink with token without canManage permission
         $token = $this->tokensInLinkingProject->createToken($this->createTestTokenOptions(false));
 
-        $this->_client2->updateToken(
+        $this->tokensInLinkingProject->updateToken(
             (new TokenUpdateOptions($token['id']))
                 ->addBucketPermission($linkedBucketId, TokenAbstractOptions::BUCKET_PERMISSION_READ)
         );
 
-        $cannotManageBucketsClient = $this->getClientForToken($this->tokensInLinkingProject->getToken($tokenId)['token']);
+        $cannotManageBucketsClient = $this->getClientForToken($token['token']);
 
         $this->assertTrue($cannotManageBucketsClient->bucketExists($linkedBucketId));
 

--- a/tests/Backend/Mixed/SharingTest.php
+++ b/tests/Backend/Mixed/SharingTest.php
@@ -55,8 +55,7 @@ class SharingTest extends StorageApiSharingTestCase
 
         $this->assertArrayHasKey('displayName', $response);
 
-        $tokenId = $this->_client2->createToken($this->createTestTokenOptions(true));
-        $token = $this->tokensInLinkingProject->getToken($tokenId);
+        $token = $this->tokensInLinkingProject->createToken($this->createTestTokenOptions(true));
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -286,10 +285,10 @@ class SharingTest extends StorageApiSharingTestCase
         );
 
         // bucket unlink with token without canManage permission
-        $tokenId = $this->_client2->createToken($this->createTestTokenOptions(false));
+        $token = $this->tokensInLinkingProject->createToken($this->createTestTokenOptions(false));
 
         $this->_client2->updateToken(
-            (new TokenUpdateOptions($tokenId))
+            (new TokenUpdateOptions($token['id']))
                 ->addBucketPermission($linkedBucketId, TokenAbstractOptions::BUCKET_PERMISSION_READ)
         );
 
@@ -334,8 +333,7 @@ class SharingTest extends StorageApiSharingTestCase
         );
 
         // new token creation
-        $tokenId = $this->_client->createToken($this->createTestTokenOptions(true));
-        $token = $this->tokens->getToken($tokenId);
+        $token = $this->tokens->createToken($this->createTestTokenOptions(true));
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -743,8 +741,7 @@ class SharingTest extends StorageApiSharingTestCase
 
         $linkedBucketId = $this->_client2->linkBucket("linked-" . time(), 'out', $sharedBucket['project']['id'], $sharedBucket['id']);
 
-        $tokenId = $this->_client2->createToken($this->createTestTokenOptions(true));
-        $token = $this->tokensInLinkingProject->getToken($tokenId);
+        $token = $this->tokensInLinkingProject->createToken($this->createTestTokenOptions(true));
 
         $client = $this->getClient([
             'token' => $token['token'],

--- a/tests/Backend/Mixed/SharingTest.php
+++ b/tests/Backend/Mixed/SharingTest.php
@@ -56,7 +56,7 @@ class SharingTest extends StorageApiSharingTestCase
         $this->assertArrayHasKey('displayName', $response);
 
         $tokenId = $this->_client2->createToken($this->createTestTokenOptions(true));
-        $token = $this->_client2->getToken($tokenId);
+        $token = $this->tokensInLinkingProject->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -293,7 +293,7 @@ class SharingTest extends StorageApiSharingTestCase
                 ->addBucketPermission($linkedBucketId, TokenAbstractOptions::BUCKET_PERMISSION_READ)
         );
 
-        $cannotManageBucketsClient = $this->getClientForToken($this->_client2->getToken($tokenId)['token']);
+        $cannotManageBucketsClient = $this->getClientForToken($this->tokensInLinkingProject->getToken($tokenId)['token']);
 
         $this->assertTrue($cannotManageBucketsClient->bucketExists($linkedBucketId));
 
@@ -335,7 +335,7 @@ class SharingTest extends StorageApiSharingTestCase
 
         // new token creation
         $tokenId = $this->_client->createToken($this->createTestTokenOptions(true));
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -744,7 +744,7 @@ class SharingTest extends StorageApiSharingTestCase
         $linkedBucketId = $this->_client2->linkBucket("linked-" . time(), 'out', $sharedBucket['project']['id'], $sharedBucket['id']);
 
         $tokenId = $this->_client2->createToken($this->createTestTokenOptions(true));
-        $token = $this->_client2->getToken($tokenId);
+        $token = $this->tokensInLinkingProject->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],

--- a/tests/Backend/Mixed/StorageApiSharingTestCase.php
+++ b/tests/Backend/Mixed/StorageApiSharingTestCase.php
@@ -4,6 +4,7 @@ namespace Keboola\Test\Backend\Mixed;
 
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\Tokens;
 use Keboola\StorageApi\Workspaces;
 use Keboola\Test\StorageApiTestCase;
 
@@ -13,6 +14,9 @@ abstract class StorageApiSharingTestCase extends StorageApiTestCase
 
     /** @var Client */
     protected $_client2;
+
+    /** @var Tokens */
+    protected $tokensInLinkingProject;
 
     /** @var Client */
     protected $clientAdmin2InSameOrg;
@@ -30,6 +34,8 @@ abstract class StorageApiSharingTestCase extends StorageApiTestCase
         $this->_client2 = $this->getClientForToken(
             STORAGE_API_LINKING_TOKEN
         );
+
+        $this->tokensInLinkingProject = new Tokens($this->_client2);
 
         $this->clientAdmin2InSameOrg = $this->getClientForToken(
             STORAGE_API_TOKEN_ADMIN_2_IN_SAME_ORGANIZATION

--- a/tests/Backend/Snowflake/DirectAccessTest.php
+++ b/tests/Backend/Snowflake/DirectAccessTest.php
@@ -110,8 +110,7 @@ class DirectAccessTest extends StorageApiTestCase
     public function testWithNonAdminToken()
     {
         $backend = self::BACKEND_SNOWFLAKE;
-        $newTokenId = $this->_client->createToken(new TokenCreateOptions());
-        $newToken = $this->tokens->getToken($newTokenId);
+        $newToken = $this->tokens->createToken(new TokenCreateOptions());
         $client = $this->getClient([
             'token' => $newToken['token'],
             'url' => STORAGE_API_URL,

--- a/tests/Backend/Snowflake/DirectAccessTest.php
+++ b/tests/Backend/Snowflake/DirectAccessTest.php
@@ -111,7 +111,7 @@ class DirectAccessTest extends StorageApiTestCase
     {
         $backend = self::BACKEND_SNOWFLAKE;
         $newTokenId = $this->_client->createToken(new TokenCreateOptions());
-        $newToken = $this->_client->getToken($newTokenId);
+        $newToken = $this->tokens->getToken($newTokenId);
         $client = $this->getClient([
             'token' => $newToken['token'],
             'url' => STORAGE_API_URL,

--- a/tests/Backend/Snowflake/TimeTravelTest.php
+++ b/tests/Backend/Snowflake/TimeTravelTest.php
@@ -203,8 +203,7 @@ class TimeTravelTest extends StorageApiTestCase
             ->addBucketPermission($this->getTestBucketId(self::STAGE_OUT), TokenAbstractOptions::BUCKET_PERMISSION_WRITE)
         ;
 
-        $outputBucketTokenId = $this->_client->createToken($outputBucketTokenOptions);
-        $outputBucketToken = $this->tokens->getToken($outputBucketTokenId);
+        $outputBucketToken = $this->tokens->createToken($outputBucketTokenOptions);
 
         $outputBucketClient = $this->getClient([
             'token' => $outputBucketToken['token'],
@@ -220,8 +219,7 @@ class TimeTravelTest extends StorageApiTestCase
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $inputBucketTokenId = $this->_client->createToken($inputBucketTokenOptions);
-        $inputBucketToken = $this->tokens->getToken($inputBucketTokenId);
+        $inputBucketToken = $this->tokens->createToken($inputBucketTokenOptions);
 
         $inputBucketClient = $this->getClient([
             'token' => $inputBucketToken['token'],
@@ -238,8 +236,7 @@ class TimeTravelTest extends StorageApiTestCase
             ->addBucketPermission($this->getTestBucketId(self::STAGE_OUT), TokenAbstractOptions::BUCKET_PERMISSION_WRITE)
         ;
 
-        $minimalTokenId = $this->_client->createToken($minimalTokenOptions);
-        $minimalToken = $this->tokens->getToken($minimalTokenId);
+        $minimalToken = $this->tokens->createToken($minimalTokenOptions);
 
         $minimalClient = $this->getClient([
             'token' => $minimalToken['token'],

--- a/tests/Backend/Snowflake/TimeTravelTest.php
+++ b/tests/Backend/Snowflake/TimeTravelTest.php
@@ -204,7 +204,7 @@ class TimeTravelTest extends StorageApiTestCase
         ;
 
         $outputBucketTokenId = $this->_client->createToken($outputBucketTokenOptions);
-        $outputBucketToken = $this->_client->getToken($outputBucketTokenId);
+        $outputBucketToken = $this->tokens->getToken($outputBucketTokenId);
 
         $outputBucketClient = $this->getClient([
             'token' => $outputBucketToken['token'],
@@ -221,7 +221,7 @@ class TimeTravelTest extends StorageApiTestCase
         ;
 
         $inputBucketTokenId = $this->_client->createToken($inputBucketTokenOptions);
-        $inputBucketToken = $this->_client->getToken($inputBucketTokenId);
+        $inputBucketToken = $this->tokens->getToken($inputBucketTokenId);
 
         $inputBucketClient = $this->getClient([
             'token' => $inputBucketToken['token'],
@@ -239,7 +239,7 @@ class TimeTravelTest extends StorageApiTestCase
         ;
 
         $minimalTokenId = $this->_client->createToken($minimalTokenOptions);
-        $minimalToken = $this->_client->getToken($minimalTokenId);
+        $minimalToken = $this->tokens->getToken($minimalTokenId);
 
         $minimalClient = $this->getClient([
             'token' => $minimalToken['token'],

--- a/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
@@ -1022,7 +1022,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
         ;
 
         $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $testClient = $this->getClient([
             'token' => $token['token'],

--- a/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
@@ -1021,8 +1021,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
             ->addBucketPermission($this->getTestBucketId(self::STAGE_OUT), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->tokens->getToken($tokenId);
+        $token = $this->tokens->createToken($tokenOptions);
 
         $testClient = $this->getClient([
             'token' => $token['token'],

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -66,7 +66,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
 
         foreach ($oldTestTokens as $oldTestToken) {
             if ($oldTestToken['canManageBuckets'] !== true) {
-                $this->_client->dropToken($oldTestToken['id']);
+                $this->tokens->dropToken($oldTestToken['id']);
             } else {
                 return $oldTestToken['token'];
             }

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -58,7 +58,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
     private function initTestToken($testName)
     {
         $oldTestTokens = array_filter(
-            $this->_client->listTokens(),
+            $this->tokens->listTokens(),
             function (array $token) use ($testName) {
                 return $token['description'] === $testName;
             }

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -78,7 +78,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($tokenOptions);
-        $tokenData = $this->_client->getToken($tokenId);
+        $tokenData = $this->tokens->getToken($tokenId);
         return $tokenData['token'];
     }
 

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -77,8 +77,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
             ->setDescription($testName)
         ;
 
-        $tokenId = $this->_client->createToken($tokenOptions);
-        $tokenData = $this->tokens->getToken($tokenId);
+        $tokenData = $this->tokens->createToken($tokenOptions);
         return $tokenData['token'];
     }
 

--- a/tests/Backend/Workspaces/WorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesLoadTest.php
@@ -1558,7 +1558,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
         ;
 
         $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $testClient = $this->getClient([
             'token' => $token['token'],

--- a/tests/Backend/Workspaces/WorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesLoadTest.php
@@ -1557,8 +1557,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
             ->addBucketPermission($this->getTestBucketId(self::STAGE_OUT), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->tokens->getToken($tokenId);
+        $token = $this->tokens->createToken($tokenOptions);
 
         $testClient = $this->getClient([
             'token' => $token['token'],

--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -1416,7 +1416,7 @@ class ComponentsTest extends StorageApiTestCase
             $this->assertEquals('accessDenied', $e->getStringCode());
         }
 
-        $this->_client->dropToken($tokenId);
+        $this->tokens->dropToken($token['id']);
     }
 
     public function testTokenWithManageAllBucketsShouldHaveAccessToComponents()
@@ -1446,7 +1446,7 @@ class ComponentsTest extends StorageApiTestCase
         $this->assertCount(1, $componentsList);
 
         $this->assertEquals($config['id'], $componentsList[0]['configurations'][0]['id']);
-        $this->_client->dropToken($token['id']);
+        $this->tokens->dropToken($token['id']);
     }
 
     public function testComponentConfigRowCreate()

--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -1361,8 +1361,7 @@ class ComponentsTest extends StorageApiTestCase
             ->setDescription('test')
         ;
 
-        $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->tokens->getToken($tokenId);
+        $token = $this->tokens->createToken($tokenOptions);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -1388,8 +1387,7 @@ class ComponentsTest extends StorageApiTestCase
             ->addComponentAccess('provisioning')
         ;
 
-        $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->tokens->getToken($tokenId);
+        $token = $this->tokens->createToken($tokenOptions);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -1428,9 +1426,8 @@ class ComponentsTest extends StorageApiTestCase
             ->setCanManageBuckets(true)
         ;
 
-        $tokenId = $this->_client->createToken($tokenOptions);
+        $token = $this->tokens->createToken($tokenOptions);
 
-        $token = $this->tokens->getToken($tokenId);
         $client = $this->getClient([
             'token' => $token['token'],
             'url' => STORAGE_API_URL,
@@ -1449,7 +1446,7 @@ class ComponentsTest extends StorageApiTestCase
         $this->assertCount(1, $componentsList);
 
         $this->assertEquals($config['id'], $componentsList[0]['configurations'][0]['id']);
-        $this->_client->dropToken($tokenId);
+        $this->_client->dropToken($token['id']);
     }
 
     public function testComponentConfigRowCreate()
@@ -1933,8 +1930,7 @@ class ComponentsTest extends StorageApiTestCase
             ->addComponentAccess('wr-db')
         ;
 
-        $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->tokens->getToken($newTokenId);
+        $newToken = $this->tokens->createToken($tokenOptions);
 
         $newClient = $this->getClient([
             'token' => $newToken['token'],

--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -1362,7 +1362,7 @@ class ComponentsTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -1389,7 +1389,7 @@ class ComponentsTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($tokenOptions);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -1430,7 +1430,7 @@ class ComponentsTest extends StorageApiTestCase
 
         $tokenId = $this->_client->createToken($tokenOptions);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
         $client = $this->getClient([
             'token' => $token['token'],
             'url' => STORAGE_API_URL,
@@ -1934,7 +1934,7 @@ class ComponentsTest extends StorageApiTestCase
         ;
 
         $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->_client->getToken($newTokenId);
+        $newToken = $this->tokens->getToken($newTokenId);
 
         $newClient = $this->getClient([
             'token' => $newToken['token'],

--- a/tests/Common/DevBranchesTest.php
+++ b/tests/Common/DevBranchesTest.php
@@ -222,7 +222,7 @@ class DevBranchesTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $branches = new DevBranches($this->getClientForToken($token['token']));
 

--- a/tests/Common/DevBranchesTest.php
+++ b/tests/Common/DevBranchesTest.php
@@ -221,8 +221,7 @@ class DevBranchesTest extends StorageApiTestCase
             ->setExpiresIn(3600)
         ;
 
-        $tokenId = $this->_client->createToken($options);
-        $token = $this->tokens->getToken($tokenId);
+        $token = $this->tokens->createToken($options);
 
         $branches = new DevBranches($this->getClientForToken($token['token']));
 

--- a/tests/Common/MetadataTest.php
+++ b/tests/Common/MetadataTest.php
@@ -817,7 +817,7 @@ class MetadataTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
         return $token['token'];
     }
 }

--- a/tests/Common/MetadataTest.php
+++ b/tests/Common/MetadataTest.php
@@ -816,8 +816,7 @@ class MetadataTest extends StorageApiTestCase
             ->addBucketPermission($bucketId, TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $tokenId = $this->_client->createToken($options);
-        $token = $this->tokens->getToken($tokenId);
+        $token = $this->tokens->createToken($options);
         return $token['token'];
     }
 }

--- a/tests/Common/TokensShareTest.php
+++ b/tests/Common/TokensShareTest.php
@@ -12,7 +12,7 @@ class TokensShareTest extends StorageApiTestCase
     {
         try {
             $token = $this->_client->verifyToken();
-            $this->_client->shareToken($token['id'], 'test@devel.keboola.com', 'Hi');
+            $this->tokens->shareToken($token['id'], 'test@devel.keboola.com', 'Hi');
             $this->fail('Master token should not be shareable');
         } catch (\Keboola\StorageApi\ClientException $e) {
             $this->assertEquals('storage.token.cannotShareMasterToken', $e->getStringCode());
@@ -22,6 +22,6 @@ class TokensShareTest extends StorageApiTestCase
     public function testTokenShare()
     {
         $newToken = $this->tokens->createToken(new TokenCreateOptions());
-        $this->_client->shareToken($newToken['id'], 'test@devel.keboola.com', 'Hi');
+        $this->tokens->shareToken($newToken['id'], 'test@devel.keboola.com', 'Hi');
     }
 }

--- a/tests/Common/TokensShareTest.php
+++ b/tests/Common/TokensShareTest.php
@@ -21,7 +21,7 @@ class TokensShareTest extends StorageApiTestCase
 
     public function testTokenShare()
     {
-        $newTokenId = $this->_client->createToken(new TokenCreateOptions());
-        $this->_client->shareToken($newTokenId, 'test@devel.keboola.com', 'Hi');
+        $newToken = $this->tokens->createToken(new TokenCreateOptions());
+        $this->_client->shareToken($newToken['id'], 'test@devel.keboola.com', 'Hi');
     }
 }

--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -285,7 +285,7 @@ class TokensTest extends StorageApiTestCase
     {
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('Argument "id" is expected to be type "int", value "foo" given.');
-        $this->_client->refreshToken('foo');
+        $this->tokens->refreshToken('foo');
     }
 
     public function testTokenGetWhenTokenIsString()
@@ -481,7 +481,7 @@ class TokensTest extends StorageApiTestCase
 
         sleep(1);
 
-        $this->_client->refreshToken($token['id']);
+        $this->tokens->refreshToken($token['id']);
         $token = $this->tokens->getToken($token['id']);
 
         $refreshed = new \DateTime($token['refreshed']);
@@ -507,7 +507,8 @@ class TokensTest extends StorageApiTestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionCode(403);
 
-        $limitAccessTokenClient->refreshToken($otherToken['id']);
+        $limitAccessTokens = new Tokens($limitAccessTokenClient);
+        $limitAccessTokens->refreshToken($otherToken['id']);
         $this->assertEquals($limitedAccessToken, $this->tokens->getToken($limitedAccessToken['id']));
     }
 

--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -313,8 +313,7 @@ class TokensTest extends StorageApiTestCase
             ->addBucketPermission($this->outBucketId, $permission)
         ;
 
-        $this->_client->updateToken($options);
-        $token = $this->tokens->getToken($token['id']);
+        $token = $this->tokens->updateToken($options);
 
         $bucketPermissions = $token['bucketPermissions'];
         $this->assertCount(1, $bucketPermissions);
@@ -328,8 +327,7 @@ class TokensTest extends StorageApiTestCase
             ->addBucketPermission($this->outBucketId, $permission)
         ;
 
-        $this->_client->updateToken($options);
-        $token = $this->tokens->getToken($token['id']);
+        $token = $this->tokens->updateToken($options);
 
         $bucketPermissions = $token['bucketPermissions'];
         $this->assertCount(1, $bucketPermissions);
@@ -343,7 +341,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         try {
-            $this->_client->updateToken($options);
+            $this->tokens->updateToken($options);
             $this->fail('Manage permissions should not be allowed to set');
         } catch (ClientException $e) {
             $this->assertEquals('storage.tokens.invalidPermissions', $e->getStringCode());
@@ -630,7 +628,7 @@ class TokensTest extends StorageApiTestCase
             ->addComponentAccess('provisioning')
         ;
 
-        $this->_client->updateToken($options);
+        $this->tokens->updateToken($options);
 
         $componentList = $components->listComponents();
         $this->assertCount(1, $componentList);
@@ -930,9 +928,7 @@ class TokensTest extends StorageApiTestCase
             ->addBucketPermission($this->outBucketId, TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $this->_client->updateToken($options);
-
-        $token = $this->tokens->getToken($token['id']);
+        $token = $this->tokens->updateToken($options);
 
         $this->assertTrue($token['canManageBuckets']);
 
@@ -948,9 +944,7 @@ class TokensTest extends StorageApiTestCase
             ->setDescription('CanManageBuckets update 2')
         ;
 
-        $this->_client->updateToken($options);
-
-        $token = $this->tokens->getToken($token['id']);
+        $token = $this->tokens->updateToken($options);
 
         $this->assertTrue($token['canManageBuckets']);
 
@@ -1076,9 +1070,8 @@ class TokensTest extends StorageApiTestCase
             ->setCanPurgeTrash(true)
         ;
 
-        $this->_client->updateToken($options);
+        $token = $this->tokens->updateToken($options);
 
-        $token = $this->tokens->getToken($token['id']);
         $this->assertTrue($token['canPurgeTrash']);
 
         $components->deleteConfiguration('provisioning', 'for-delete');

--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -51,7 +51,7 @@ class TokensTest extends StorageApiTestCase
                 continue;
             }
 
-            $this->_client->dropToken($token['id']);
+            $this->tokens->dropToken($token['id']);
         }
     }
 
@@ -271,14 +271,14 @@ class TokensTest extends StorageApiTestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('Request parameter "id" is missing.');
         // false is not event sent, because "string" . false = "string"
-        $this->_client->dropToken(false);
+        $this->tokens->dropToken(false);
     }
 
     public function testInvalidTokenWhenTokenIsString()
     {
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('Argument "id" is expected to be type "int", value "foo" given.');
-        $this->_client->dropToken('foo');
+        $this->tokens->dropToken('foo');
     }
 
     public function testTokenRefreshWhenTokenIsString()
@@ -380,7 +380,7 @@ class TokensTest extends StorageApiTestCase
         $tokens = $this->tokens->listTokens();
         $this->assertCount(count($initialTokens) + 1, $tokens);
 
-        $this->_client->dropToken($token['id']);
+        $this->tokens->dropToken($token['id']);
 
         $tokens = $this->tokens->listTokens();
         $this->assertCount(count($initialTokens), $tokens);

--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -12,6 +12,7 @@ use Keboola\StorageApi\Options\Components\ListComponentsOptions;
 use Keboola\StorageApi\Options\TokenAbstractOptions;
 use Keboola\StorageApi\Options\TokenCreateOptions;
 use Keboola\StorageApi\Options\TokenUpdateOptions;
+use Keboola\StorageApi\Tokens;
 use Keboola\Test\StorageApiTestCase;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Client;
@@ -45,7 +46,7 @@ class TokensTest extends StorageApiTestCase
 
     private function initTokens()
     {
-        foreach ($this->_client->listTokens() as $token) {
+        foreach ($this->tokens->listTokens() as $token) {
             if ($token['isMasterToken']) {
                 continue;
             }
@@ -140,7 +141,7 @@ class TokensTest extends StorageApiTestCase
         $this->assertEquals($firstLimit['name'], $limitKeys[0]);
 
         $tokenFound = false;
-        foreach ($this->_client->listTokens() as $token) {
+        foreach ($this->tokens->listTokens() as $token) {
             if ($token['id'] !== $currentToken['id']) {
                 continue;
             }
@@ -206,7 +207,7 @@ class TokensTest extends StorageApiTestCase
         $this->assertEquals($firstLimit['name'], $limitKeys[0]);
 
         $tokenFound = false;
-        foreach ($this->_client->listTokens() as $token) {
+        foreach ($this->tokens->listTokens() as $token) {
             if ($token['id'] !== $currentToken['id']) {
                 continue;
             }
@@ -375,16 +376,16 @@ class TokensTest extends StorageApiTestCase
 
     public function testTokenDrop()
     {
-        $initialTokens = $this->_client->listTokens();
+        $initialTokens = $this->tokens->listTokens();
 
         $tokenId = $this->_client->createToken(new TokenCreateOptions());
 
-        $tokens = $this->_client->listTokens();
+        $tokens = $this->tokens->listTokens();
         $this->assertCount(count($initialTokens) + 1, $tokens);
 
         $this->_client->dropToken($tokenId);
 
-        $tokens = $this->_client->listTokens();
+        $tokens = $this->tokens->listTokens();
         $this->assertCount(count($initialTokens), $tokens);
     }
 
@@ -978,7 +979,7 @@ class TokensTest extends StorageApiTestCase
 
     public function testTokenWithoutTokensManagePermissionCanListAndViewOnlySelf()
     {
-        $initialTokens = $this->_client->listTokens();
+        $initialTokens = $this->tokens->listTokens();
 
         $options = (new TokenCreateOptions())
             ->setDescription('Token without canManageTokens permission')
@@ -986,7 +987,7 @@ class TokensTest extends StorageApiTestCase
 
         $tokenId = $this->_client->createToken($options);
 
-        $tokens = $this->_client->listTokens();
+        $tokens = $this->tokens->listTokens();
         $this->assertCount(count($initialTokens) + 1, $tokens);
 
         $token = $this->_client->getToken($tokenId);
@@ -999,7 +1000,8 @@ class TokensTest extends StorageApiTestCase
 
         $verifiedToken = $client->verifyToken();
 
-        $tokens = $client->listTokens();
+        $tokens = new Tokens($client);
+        $tokens = $tokens->listTokens();
         $this->assertCount(1, $tokens);
 
         $token = reset($tokens);

--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -965,12 +965,12 @@ class TokensTest extends StorageApiTestCase
             ->setDescription('Token without canManageTokens permission')
         ;
 
-        $token = $this->_client->createToken($options);
+        $token = $this->tokens->createToken($options);
 
         $this->assertFalse($token['canManageTokens']);
 
-        $tokens = $this->tokens->listTokens();
-        $this->assertCount(count($initialTokens) + 1, $tokens);
+        $tokensList = $this->tokens->listTokens();
+        $this->assertCount(count($initialTokens) + 1, $tokensList);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -980,10 +980,10 @@ class TokensTest extends StorageApiTestCase
         $verifiedToken = $client->verifyToken();
 
         $tokens = new Tokens($client);
-        $tokens = $tokens->listTokens();
-        $this->assertCount(1, $tokens);
+        $tokensList = $tokens->listTokens();
+        $this->assertCount(1, $tokensList);
 
-        $token = reset($tokens);
+        $token = reset($tokensList);
         $this->assertSame($verifiedToken['id'], $token['id']);
 
         $token = $tokens->getToken($token['id']);
@@ -993,10 +993,10 @@ class TokensTest extends StorageApiTestCase
             ->setDescription('Token without canManageTokens permission')
         ;
 
-        $tokenId = $this->_client->createToken($options);
+        $token = $this->tokens->createToken($options);
 
         try {
-            $tokens->getToken($tokenId);
+            $tokens->getToken($token['id']);
             $this->fail('Other token detail with no permissions');
         } catch (ClientException $e) {
             $this->assertEquals(403, $e->getCode());

--- a/tests/Common/TokensTest.php
+++ b/tests/Common/TokensTest.php
@@ -170,7 +170,7 @@ class TokensTest extends StorageApiTestCase
     public function testGetToken()
     {
         $verifiedToken = $this->_client->verifyToken();
-        $currentToken = $this->_client->getToken($verifiedToken['id']);
+        $currentToken = $this->tokens->getToken($verifiedToken['id']);
 
         $this->assertArrayHasKey('created', $currentToken);
         $this->assertArrayHasKey('refreshed', $currentToken);
@@ -292,7 +292,7 @@ class TokensTest extends StorageApiTestCase
     {
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('Argument "id" is expected to be type "int", value "foo" given.');
-        $this->_client->getToken('foo');
+        $this->tokens->getToken('foo');
     }
 
 
@@ -303,7 +303,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $bucketPermissions = $token['bucketPermissions'];
         $this->assertCount(0, $bucketPermissions);
@@ -315,7 +315,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $this->_client->updateToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $bucketPermissions = $token['bucketPermissions'];
         $this->assertCount(1, $bucketPermissions);
@@ -330,7 +330,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $this->_client->updateToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $bucketPermissions = $token['bucketPermissions'];
         $this->assertCount(1, $bucketPermissions);
@@ -350,7 +350,7 @@ class TokensTest extends StorageApiTestCase
             $this->assertEquals('storage.tokens.invalidPermissions', $e->getStringCode());
         }
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $bucketPermissions = $token['bucketPermissions'];
         $this->assertCount(1, $bucketPermissions);
@@ -394,7 +394,7 @@ class TokensTest extends StorageApiTestCase
         $currentToken = $this->_client->verifyToken();
 
         $tokenId = $this->_client->createToken(new TokenCreateOptions());
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $this->assertNull($token['expires']);
 
@@ -436,7 +436,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $this->assertNotNull($token['expires']);
 
@@ -480,7 +480,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $tokenString = $token['token'];
         $created = new \DateTime($token['created']);
@@ -488,7 +488,7 @@ class TokensTest extends StorageApiTestCase
         sleep(1);
 
         $this->_client->refreshToken($tokenId);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $refreshed = new \DateTime($token['refreshed']);
 
@@ -503,7 +503,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $limitedAccessTokenId = $this->_client->createToken($options);
-        $limitedAccessToken = $this->_client->getToken($limitedAccessTokenId);
+        $limitedAccessToken = $this->tokens->getToken($limitedAccessTokenId);
         $limitAccessTokenClient = $this->getClient([
             'token' => $limitedAccessToken['token'],
             'url' => STORAGE_API_URL
@@ -515,7 +515,7 @@ class TokensTest extends StorageApiTestCase
         $this->expectExceptionCode(403);
 
         $limitAccessTokenClient->refreshToken($otherTokenId);
-        $this->assertEquals($limitedAccessToken, $this->_client->getToken($limitedAccessTokenId));
+        $this->assertEquals($limitedAccessToken, $this->tokens->getToken($limitedAccessTokenId));
     }
 
     public function testTokenComponentAccess()
@@ -529,7 +529,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -588,7 +588,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -661,7 +661,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient(array(
             'token' => $token['token'],
@@ -717,7 +717,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient(array(
             'token' => $token['token'],
@@ -762,7 +762,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient(array(
             'token' => $token['token'],
@@ -827,7 +827,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient(array(
             'token' => $token['token'],
@@ -855,7 +855,7 @@ class TokensTest extends StorageApiTestCase
         $buckets = $client->listBuckets();
         $this->assertCount($bucketsInitialCount + 1, $buckets);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
         $this->assertCount($bucketsInitialCount + 1, $token['bucketPermissions']);
         foreach ($token['bucketPermissions'] as $bucketId => $permission) {
             $this->assertEquals(self::BUCKET_PERMISSION_MANAGE, $permission);
@@ -873,7 +873,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient(array(
             'token' => $token['token'],
@@ -894,7 +894,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
         $tries = 0;
 
         $this->expectException(ClientException::class);
@@ -928,7 +928,7 @@ class TokensTest extends StorageApiTestCase
 
         $tokenId = $this->_client->createToken($options);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $this->assertTrue($token['canManageBuckets']);
 
@@ -947,7 +947,7 @@ class TokensTest extends StorageApiTestCase
 
         $this->_client->updateToken($options);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $this->assertTrue($token['canManageBuckets']);
 
@@ -965,7 +965,7 @@ class TokensTest extends StorageApiTestCase
 
         $this->_client->updateToken($options);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $this->assertTrue($token['canManageBuckets']);
 
@@ -990,7 +990,7 @@ class TokensTest extends StorageApiTestCase
         $tokens = $this->tokens->listTokens();
         $this->assertCount(count($initialTokens) + 1, $tokens);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
         $this->assertFalse($token['canManageTokens']);
 
         $client = $this->getClient([
@@ -1007,7 +1007,7 @@ class TokensTest extends StorageApiTestCase
         $token = reset($tokens);
         $this->assertSame($verifiedToken['id'], $token['id']);
 
-        $token = $client->getToken($tokenId);
+        $token = $tokens->getToken($tokenId);
         $this->assertSame($verifiedToken['id'], $token['id']);
 
         $options = (new TokenCreateOptions())
@@ -1017,7 +1017,7 @@ class TokensTest extends StorageApiTestCase
         $tokenId = $this->_client->createToken($options);
 
         try {
-            $client->getToken($tokenId);
+            $tokens->getToken($tokenId);
             $this->fail('Other token detail with no permissions');
         } catch (ClientException $e) {
             $this->assertEquals(403, $e->getCode());
@@ -1036,7 +1036,7 @@ class TokensTest extends StorageApiTestCase
 
         $tokenId = $this->_client->createToken($options);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
         $this->assertFalse($token['canPurgeTrash']);
 
         $client = $this->getClient([
@@ -1095,7 +1095,7 @@ class TokensTest extends StorageApiTestCase
 
         $this->_client->updateToken($options);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
         $this->assertTrue($token['canPurgeTrash']);
 
         $components->deleteConfiguration('provisioning', 'for-delete');
@@ -1113,7 +1113,7 @@ class TokensTest extends StorageApiTestCase
 
         $tokenId = $this->_client->createToken($options);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -1143,7 +1143,7 @@ class TokensTest extends StorageApiTestCase
         ;
 
         $tokenId = $this->_client->createToken($options);
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         $client = $this->getClient([
             'token' => $token['token'],
@@ -1311,7 +1311,7 @@ class TokensTest extends StorageApiTestCase
 
         $tokenId = $client->createToken($options);
 
-        $token = $this->_client->getToken($tokenId);
+        $token = $this->tokens->getToken($tokenId);
 
         if ($options->getDescription()) {
             $this->assertSame($options->getDescription(), $token['description']);

--- a/tests/Common/TriggersTest.php
+++ b/tests/Common/TriggersTest.php
@@ -29,12 +29,12 @@ class TriggersTest extends StorageApiTestCase
         $options = (new TokenCreateOptions())
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
-        $newTokenId = $this->_client->createToken($options);
+        $newToken = $this->tokens->createToken($options);
         $trigger = $this->_client->createTrigger([
             'component' => 'orchestrator',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table1,
             ],
@@ -43,7 +43,7 @@ class TriggersTest extends StorageApiTestCase
         $this->assertEquals('orchestrator', $trigger['component']);
         $this->assertEquals(123, $trigger['configurationId']);
         $this->assertEquals(10, $trigger['coolDownPeriodMinutes']);
-        $this->assertEquals($newTokenId, $trigger['runWithTokenId']);
+        $this->assertEquals($newToken['id'], $trigger['runWithTokenId']);
         $this->assertNotNull($trigger['lastRun']);
         $this->assertLessThan((new \DateTime()), (new \DateTime($trigger['lastRun'])));
         $this->assertEquals(
@@ -52,7 +52,7 @@ class TriggersTest extends StorageApiTestCase
             ],
             $trigger['tables']
         );
-        $token = $this->_client->verifyToken($newTokenId);
+        $token = $this->_client->verifyToken();
         $this->assertEquals(
             [
                 'id' => $token['id'],
@@ -71,13 +71,13 @@ class TriggersTest extends StorageApiTestCase
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $newTokenId = $this->_client->createToken($options);
+        $newToken = $this->tokens->createToken($options);
 
         $trigger = $this->_client->createTrigger([
             'component' => 'orchestrator',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table1,
                 $table2,
@@ -88,13 +88,13 @@ class TriggersTest extends StorageApiTestCase
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $brandNewTokenId = $this->_client->createToken($options);
+        $brandNewToken = $this->tokens->createToken($options);
 
         $updateData = [
             'component' => 'keboola.ex-1',
             'configurationId' => 111,
             'coolDownPeriodMinutes' => 20,
-            'runWithTokenId' => $brandNewTokenId,
+            'runWithTokenId' => $brandNewToken['id'],
             'tableIds' => [$table1],
         ];
 
@@ -103,7 +103,7 @@ class TriggersTest extends StorageApiTestCase
         $this->assertEquals('keboola.ex-1', $updateTrigger['component']);
         $this->assertEquals(111, $updateTrigger['configurationId']);
         $this->assertEquals(20, $updateTrigger['coolDownPeriodMinutes']);
-        $this->assertEquals($brandNewTokenId, $updateTrigger['runWithTokenId']);
+        $this->assertEquals($brandNewToken['id'], $updateTrigger['runWithTokenId']);
         $this->assertEquals([['tableId' => 'in.c-API-tests.watched-1']], $updateTrigger['tables']);
     }
 
@@ -144,13 +144,13 @@ class TriggersTest extends StorageApiTestCase
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $newTokenId = $this->_client->createToken($options);
+        $newToken = $this->tokens->createToken($options);
 
         $trigger = $this->_client->createTrigger([
             'component' => 'orchestrator',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table,
             ],
@@ -174,7 +174,7 @@ class TriggersTest extends StorageApiTestCase
         $options = (new TokenCreateOptions())
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
-        $newTokenId = $this->_client->createToken($options);
+        $newToken = $this->tokens->createToken($options);
 
         $trigger1ConfigurationId = time();
         $componentName = uniqid('test');
@@ -182,7 +182,7 @@ class TriggersTest extends StorageApiTestCase
             'component' => $componentName,
             'configurationId' => $trigger1ConfigurationId,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table1,
             ],
@@ -192,7 +192,7 @@ class TriggersTest extends StorageApiTestCase
             'component' => 'keboola.ex-manzelka',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table2,
             ],
@@ -227,7 +227,7 @@ class TriggersTest extends StorageApiTestCase
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
 
-        $newTokenId = $this->_client->createToken($options);
+        $newToken = $this->tokens->createToken($options);
 
         $trigger1ConfigurationId = time();
         $componentName = uniqid('test');
@@ -235,7 +235,7 @@ class TriggersTest extends StorageApiTestCase
             'component' => $componentName,
             'configurationId' => $trigger1ConfigurationId,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table,
             ],
@@ -244,7 +244,7 @@ class TriggersTest extends StorageApiTestCase
             'component' => 'keboola.ex-manzelka',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table,
             ],
@@ -277,16 +277,16 @@ class TriggersTest extends StorageApiTestCase
 
     public function testInvalidToken()
     {
-        $tokenId = $this->_client->createToken(new TokenCreateOptions());
-        $this->_client->dropToken($tokenId);
+        $token = $this->tokens->createToken(new TokenCreateOptions());
+        $this->_client->dropToken($token['id']);
 
         $this->expectException(ClientException::class);
-        $this->expectExceptionMessage("Token with id \"$tokenId\" was not found.");
+        $this->expectExceptionMessage("Token with id \"{$token['id']}\" was not found.");
         $this->_client->createTrigger([
             'component' => 'keboola.ex-manzelka',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $tokenId,
+            'runWithTokenId' => $token['id'],
             'tableIds' => [''],
         ]);
     }
@@ -297,18 +297,18 @@ class TriggersTest extends StorageApiTestCase
         $options = (new TokenCreateOptions())
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         ;
-        $newTokenId = $this->_client->createToken($options);
+        $newToken = $this->tokens->createToken($options);
         $trigger = $this->_client->createTrigger([
             'component' => 'orchestrator',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table1,
             ],
         ]);
         try {
-            $this->_client->dropToken($newTokenId);
+            $this->_client->dropToken($newToken['id']);
             $this->fail("Token should not be deleted");
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
@@ -319,12 +319,12 @@ class TriggersTest extends StorageApiTestCase
             );
         }
         $this->_client->deleteTrigger($trigger['id']);
-        $this->_client->dropToken($newTokenId);
+        $this->_client->dropToken($newToken['id']);
     }
 
     public function testTokenWithExpiration()
     {
-        $tokenId = $this->_client->createToken(
+        $token = $this->tokens->createToken(
             (new TokenCreateOptions())->setExpiresIn(5)
         );
 
@@ -335,7 +335,7 @@ class TriggersTest extends StorageApiTestCase
             'component' => 'keboola.ex-manzelka',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $tokenId,
+            'runWithTokenId' => $token['id'],
             'tableIds' => [''],
         ]);
     }
@@ -346,7 +346,7 @@ class TriggersTest extends StorageApiTestCase
         $readOnlyClient = $this->getClientForToken(STORAGE_API_READ_ONLY_TOKEN);
 
         $table1 = $this->createTableWithRandomData("watched-1");
-        $newTokenId = $this->_client->createToken(
+        $newToken = $this->tokens->createToken(
             (new TokenCreateOptions())
             ->addBucketPermission($this->getTestBucketId(), TokenAbstractOptions::BUCKET_PERMISSION_READ)
         );
@@ -355,7 +355,7 @@ class TriggersTest extends StorageApiTestCase
             'component' => 'orchestrator',
             'configurationId' => 123,
             'coolDownPeriodMinutes' => 10,
-            'runWithTokenId' => $newTokenId,
+            'runWithTokenId' => $newToken['id'],
             'tableIds' => [
                 $table1,
             ],

--- a/tests/Common/TriggersTest.php
+++ b/tests/Common/TriggersTest.php
@@ -278,7 +278,7 @@ class TriggersTest extends StorageApiTestCase
     public function testInvalidToken()
     {
         $token = $this->tokens->createToken(new TokenCreateOptions());
-        $this->_client->dropToken($token['id']);
+        $this->tokens->dropToken($token['id']);
 
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage("Token with id \"{$token['id']}\" was not found.");
@@ -308,7 +308,7 @@ class TriggersTest extends StorageApiTestCase
             ],
         ]);
         try {
-            $this->_client->dropToken($newToken['id']);
+            $this->tokens->dropToken($newToken['id']);
             $this->fail("Token should not be deleted");
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
@@ -319,7 +319,7 @@ class TriggersTest extends StorageApiTestCase
             );
         }
         $this->_client->deleteTrigger($trigger['id']);
-        $this->_client->dropToken($newToken['id']);
+        $this->tokens->dropToken($newToken['id']);
     }
 
     public function testTokenWithExpiration()

--- a/tests/File/CommonFileTest.php
+++ b/tests/File/CommonFileTest.php
@@ -256,8 +256,7 @@ class CommonFileTest extends StorageApiTestCase
             ->setDescription('Files test')
         ;
 
-        $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->tokens->getToken($newTokenId);
+        $newToken = $this->tokens->createToken($tokenOptions);
 
         $this->createAndWaitForFile($filePath, $uploadOptions);
 
@@ -281,7 +280,7 @@ class CommonFileTest extends StorageApiTestCase
         $files = $this->_client->listFiles();
         $this->assertEquals($newFileId, reset($files)['id']);
 
-        $this->_client->dropToken($newTokenId);
+        $this->_client->dropToken($newToken['id']);
     }
 
     public function testFilesPermissionsCanReadAllFiles()
@@ -296,8 +295,7 @@ class CommonFileTest extends StorageApiTestCase
             ->setCanReadAllFileUploads(true)
         ;
 
-        $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->tokens->getToken($newTokenId);
+        $newToken = $this->tokens->createToken($tokenOptions);
 
         // new token should not have access to any files
         $newTokenClient = $this->getClient([
@@ -309,11 +307,11 @@ class CommonFileTest extends StorageApiTestCase
         $this->assertNotEmpty($file);
 
         $this->_client->updateToken(
-            (new TokenUpdateOptions($newTokenId))
+            (new TokenUpdateOptions($newToken['id']))
                 ->setCanReadAllFileUploads(false)
         );
 
-        $token = $this->tokens->getToken($newTokenId);
+        $token = $this->tokens->getToken($newToken['id']);
         $this->assertFalse($token['canReadAllFileUploads']);
 
         try {

--- a/tests/File/CommonFileTest.php
+++ b/tests/File/CommonFileTest.php
@@ -306,12 +306,11 @@ class CommonFileTest extends StorageApiTestCase
         $file = $newTokenClient->getFile($file['id']);
         $this->assertNotEmpty($file);
 
-        $this->_client->updateToken(
+        $token = $this->tokens->updateToken(
             (new TokenUpdateOptions($newToken['id']))
                 ->setCanReadAllFileUploads(false)
         );
 
-        $token = $this->tokens->getToken($newToken['id']);
         $this->assertFalse($token['canReadAllFileUploads']);
 
         try {

--- a/tests/File/CommonFileTest.php
+++ b/tests/File/CommonFileTest.php
@@ -280,7 +280,7 @@ class CommonFileTest extends StorageApiTestCase
         $files = $this->_client->listFiles();
         $this->assertEquals($newFileId, reset($files)['id']);
 
-        $this->_client->dropToken($newToken['id']);
+        $this->tokens->dropToken($newToken['id']);
     }
 
     public function testFilesPermissionsCanReadAllFiles()

--- a/tests/File/CommonFileTest.php
+++ b/tests/File/CommonFileTest.php
@@ -257,7 +257,7 @@ class CommonFileTest extends StorageApiTestCase
         ;
 
         $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->_client->getToken($newTokenId);
+        $newToken = $this->tokens->getToken($newTokenId);
 
         $this->createAndWaitForFile($filePath, $uploadOptions);
 
@@ -297,7 +297,7 @@ class CommonFileTest extends StorageApiTestCase
         ;
 
         $newTokenId = $this->_client->createToken($tokenOptions);
-        $newToken = $this->_client->getToken($newTokenId);
+        $newToken = $this->tokens->getToken($newTokenId);
 
         // new token should not have access to any files
         $newTokenClient = $this->getClient([
@@ -313,7 +313,7 @@ class CommonFileTest extends StorageApiTestCase
                 ->setCanReadAllFileUploads(false)
         );
 
-        $token = $this->_client->getToken($newTokenId);
+        $token = $this->tokens->getToken($newTokenId);
         $this->assertFalse($token['canReadAllFileUploads']);
 
         try {

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -10,6 +10,7 @@
 namespace Keboola\Test;
 
 use Keboola\StorageApi\DevBranches;
+use Keboola\StorageApi\Tokens;
 use function array_key_exists;
 use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\Client;
@@ -35,10 +36,11 @@ abstract class StorageApiTestCase extends ClientTestCase
 
     protected $_bucketIds = array();
 
-    /**
-     * @var \Keboola\StorageApi\Client
-     */
+    /** @var Client */
     protected $_client;
+
+    /** @var Tokens */
+    protected $tokens;
 
     /**
      * Checks that two arrays are same except some keys, which MUST be different
@@ -80,6 +82,7 @@ abstract class StorageApiTestCase extends ClientTestCase
     public function setUp()
     {
         $this->_client = $this->getDefaultClient();
+        $this->tokens = new Tokens($this->_client);
     }
 
     protected function _initEmptyTestBuckets($stages = [self::STAGE_OUT, self::STAGE_IN])


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/KBC-1353

- [x] New client method(s) has tests~ _(Všechny testy používají `Keboola\StorageApi\Tokens`)_
- [x] ~Apiary file is updated~ _(Změna v apiary není)_
- [x] ~You declared if there is a BC break or not (will affect next release of a client)~ _(BC break v tomhle PR není)_

---

- Přesunul jsem token metody do `Keboola\StorageApi\Tokens`
- Deprekoval jsem metody v `Keboola\StorageApi\Client`
- Zrefactoroval jsem testy aby používaly metody z nové třídy
- Přidal jsem `testDeprecatedMethods` abych otetoval metody z `Keboola\StorageApi\Client`
- Upravil jsem deprecated metody aby volaly `Keboola\StorageApi\Tokens`