### PR TITLE
Reuse workspaces in tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -46,7 +46,6 @@
 
 	<testsuite name="backend-snowflake-abs-part-2">
 		<file>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</file>
-		<file>tests/Backend/Snowflake/TimestampTest.php</file>
 		<file>tests/Backend/Snowflake/DirectAccessTest.php</file>
 		<file>tests/Backend/Export/ExportParamsTest.php</file>
 	</testsuite>
@@ -55,7 +54,6 @@
 		<directory>tests/Backend/Snowflake</directory>
 		<directory>tests/Backend/CommonPart2</directory>
 		<exclude>tests/Backend/Snowflake/CloneIntoWorkspaceTest.php</exclude>
-		<exclude>tests/Backend/Snowflake/TimestampTest.php</exclude>
 		<exclude>tests/Backend/Snowflake/DirectAccessTest.php</exclude>
 		<file>tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php</file>
 		<file>tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php</file>

--- a/tests/Backend/Snowflake/TimestampTest.php
+++ b/tests/Backend/Snowflake/TimestampTest.php
@@ -141,11 +141,11 @@ class TimestampTest extends ParallelWorkspacesTestCase
         ));
 
         // create workspace and source table in workspace
-        $workspacesClient = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspacesClient->createWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
+        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"Id\" integer not null,
 			\"Name\" varchar not null,
@@ -193,7 +193,7 @@ class TimestampTest extends ParallelWorkspacesTestCase
     private function assertDataInTable($tableId, $workspaceTableName, $expectedRows)
     {
         $workspacesClient = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspacesClient->createWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         /** @var SnowflakeWorkspaceBackend $backend */
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);

--- a/tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+++ b/tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
@@ -183,4 +183,13 @@ class RedshiftWorkspaceBackend implements WorkspaceBackend
         }
         return $desc;
     }
+
+    public function dropTableIfExists($table)
+    {
+        $this->db->query(sprintf(
+            'DROP TABLE IF EXISTS %s.%s;',
+            $this->db->quoteIdentifier($this->schema),
+            $this->db->quoteIdentifier($table)
+        ));
+    }
 }

--- a/tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+++ b/tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
@@ -187,9 +187,9 @@ class RedshiftWorkspaceBackend implements WorkspaceBackend
     public function dropTableIfExists($table)
     {
         $this->db->query(sprintf(
-            'DROP TABLE IF EXISTS %s.%s;',
-            $this->db->quoteIdentifier($this->schema),
-            $this->db->quoteIdentifier($table)
+            'DROP TABLE IF EXISTS "%s"."%s";',
+            $this->schema,
+            $table
         ));
     }
 }

--- a/tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+++ b/tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
@@ -107,4 +107,13 @@ class SnowflakeWorkspaceBackend implements WorkspaceBackend
     {
         return $this->db->fetchAll(sprintf('DESC TABLE %s.%s', $this->db->quoteIdentifier($this->schema), $this->db->quoteIdentifier($tableName)));
     }
+
+    public function dropTableIfExists($table)
+    {
+        $this->db->query(sprintf(
+            'DROP TABLE IF EXISTS %s.%s;',
+            $this->db->quoteIdentifier($this->schema),
+            $this->db->quoteIdentifier($table)
+        ));
+    }
 }

--- a/tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+++ b/tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
@@ -141,4 +141,15 @@ class SynapseWorkspaceBackend implements WorkspaceBackend
     {
         $this->db->close();
     }
+
+    public function dropTableIfExists($table)
+    {
+        $this->db->exec(sprintf(
+            "IF OBJECT_ID (N'%s.%s', N'U') IS NOT NULL DROP TABLE %s.%s;",
+            $this->platform->quoteSingleIdentifier($this->schema),
+            $this->platform->quoteSingleIdentifier($table),
+            $this->platform->quoteSingleIdentifier($this->schema),
+            $this->platform->quoteSingleIdentifier($table)
+        ));
+    }
 }

--- a/tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+++ b/tests/Backend/Workspaces/Backend/WorkspaceBackend.php
@@ -18,6 +18,8 @@ interface WorkspaceBackend
     
     public function dropTable($table);
 
+    public function dropTableIfExists($table);
+
     public function dropTableColumn($table, $column);
 
     public function countRows($table);

--- a/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
@@ -16,7 +16,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         //setup test tables
         $tableId = $this->_client->createTable(
@@ -55,7 +55,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         //setup test tables
         $table1_id = $this->_client->createTable(
@@ -247,7 +247,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testWorkspaceLoadColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -308,7 +308,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -358,7 +358,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalAdditionalColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -408,7 +408,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalMissingColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -460,7 +460,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalDataTypesDiff($table, $firstLoadDataTypes, $secondLoadDataTypes)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.more-columns.csv";
      //   $importFile = __DIR__ . "/../../_data/$table.csv";
@@ -515,7 +515,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testSecondsFilter()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -554,7 +554,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testRowsParameter()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -620,7 +620,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testDataTypes($dataTypesDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.camel-case-columns.csv';
@@ -667,7 +667,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testDataTypeConversionUserError($dataTypesDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
         $tableId = $this->_client->createTable(
@@ -733,7 +733,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testDataTypeForNotExistingColumnUserError($dataTypesDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . '/../../_data/languages.camel-case-columns.csv';
         $tableId = $this->_client->createTable(
@@ -790,7 +790,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testInvalidDataTypeUserError()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
         $tableId = $this->_client->createTable(
@@ -824,7 +824,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testInvalidExtendedDataTypeUserError()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
         $tableId = $this->_client->createTable(
@@ -864,7 +864,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testDuplicateDestination()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         //setup test tables
         $table1_id = $this->_client->createTable(
@@ -894,7 +894,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testTableAlreadyExistsShouldThrowUserError()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $tableId = $this->_client->createTable(
             $this->getTestBucketId(self::STAGE_IN),

--- a/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
@@ -16,7 +16,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         //setup test tables
         $tableId = $this->_client->createTable(
@@ -55,7 +55,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         //setup test tables
         $table1_id = $this->_client->createTable(
@@ -247,7 +247,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testWorkspaceLoadColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -308,7 +308,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -358,7 +358,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalAdditionalColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -408,7 +408,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalMissingColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -460,7 +460,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalDataTypesDiff($table, $firstLoadDataTypes, $secondLoadDataTypes)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.more-columns.csv";
      //   $importFile = __DIR__ . "/../../_data/$table.csv";
@@ -515,7 +515,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testSecondsFilter()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -554,7 +554,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testRowsParameter()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -620,7 +620,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testDataTypes($dataTypesDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.camel-case-columns.csv';
@@ -667,7 +667,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testDataTypeConversionUserError($dataTypesDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
         $tableId = $this->_client->createTable(
@@ -733,7 +733,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testDataTypeForNotExistingColumnUserError($dataTypesDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . '/../../_data/languages.camel-case-columns.csv';
         $tableId = $this->_client->createTable(
@@ -790,7 +790,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testInvalidDataTypeUserError()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
         $tableId = $this->_client->createTable(
@@ -824,7 +824,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testInvalidExtendedDataTypeUserError()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
         $tableId = $this->_client->createTable(
@@ -864,7 +864,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testDuplicateDestination()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         //setup test tables
         $table1_id = $this->_client->createTable(
@@ -894,7 +894,7 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testTableAlreadyExistsShouldThrowUserError()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $tableId = $this->_client->createTable(
             $this->getTestBucketId(self::STAGE_IN),

--- a/tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
@@ -17,7 +17,7 @@ class LegacyWorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testColumnCompression($dataTypesDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -94,7 +94,7 @@ class LegacyWorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ["input" => [$mapping]]);
@@ -135,7 +135,7 @@ class LegacyWorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -226,7 +226,7 @@ class LegacyWorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 

--- a/tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
@@ -17,7 +17,7 @@ class LegacyWorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testColumnCompression($dataTypesDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -94,7 +94,7 @@ class LegacyWorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ["input" => [$mapping]]);
@@ -135,7 +135,7 @@ class LegacyWorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -226,7 +226,7 @@ class LegacyWorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 

--- a/tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
@@ -28,7 +28,7 @@ class LegacyWorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ["input" => [$mapping]]);
@@ -69,7 +69,7 @@ class LegacyWorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -160,7 +160,7 @@ class LegacyWorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -258,7 +258,7 @@ class LegacyWorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testsIncrementalDataTypesDiff($table, $firstLoadDataTypes, $secondLoadDataTypes, $shouldFail)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 

--- a/tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
@@ -28,7 +28,7 @@ class LegacyWorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ["input" => [$mapping]]);
@@ -69,7 +69,7 @@ class LegacyWorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -160,7 +160,7 @@ class LegacyWorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -258,7 +258,7 @@ class LegacyWorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testsIncrementalDataTypesDiff($table, $firstLoadDataTypes, $secondLoadDataTypes, $shouldFail)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 

--- a/tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
@@ -29,7 +29,7 @@ class LegacyWorkspacesSynapseTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ['input' => [$mapping]]);
@@ -74,7 +74,7 @@ class LegacyWorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -165,7 +165,7 @@ class LegacyWorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -263,7 +263,7 @@ class LegacyWorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testsIncrementalDataTypesDiff($table, $firstLoadDataTypes, $secondLoadDataTypes, $shouldFail)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 

--- a/tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
@@ -29,7 +29,7 @@ class LegacyWorkspacesSynapseTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ['input' => [$mapping]]);
@@ -74,7 +74,7 @@ class LegacyWorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -165,7 +165,7 @@ class LegacyWorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -263,7 +263,7 @@ class LegacyWorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testsIncrementalDataTypesDiff($table, $firstLoadDataTypes, $secondLoadDataTypes, $shouldFail)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 

--- a/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
@@ -5,7 +5,6 @@ namespace Keboola\Test\Backend\Workspaces;
 
 use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\ClientException;
-use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
 
 class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
@@ -26,8 +25,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "redshift"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.metadata_columns\" (
@@ -159,8 +157,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "redshift"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.Languages3\" (
@@ -225,8 +222,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "redshift"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
@@ -257,8 +253,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithUnsupportedDataType()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "redshift"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 

--- a/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
@@ -28,6 +28,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
+        $db->query("drop table if exists \"test.metadata_columns\";");
         $db->query("create table \"test.metadata_columns\" (
                     \"string\" varchar(16) not null default 'string',
                     \"char\" char null,
@@ -160,6 +161,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
+        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
                 \"id\" integer not null,
                 \"name\" varchar not null default 'honza'
@@ -226,6 +228,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
+         $db->query("drop table if exists \"test.metadata_columns\";");
          $db->query("create table \"test.metadata_columns\" (
                 \"id\" integer not null,
                 \"name\" geometry
@@ -257,6 +260,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
+        $db->query("drop table if exists \"test.metadata_columns\";");
         $db->query("create table \"test.metadata_columns\" (
                 \"id\" integer not null,
                 \"name\" geometry

--- a/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
@@ -28,7 +28,6 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("drop table if exists \"test.metadata_columns\";");
         $db->query("create table \"test.metadata_columns\" (
                     \"string\" varchar(16) not null default 'string',
                     \"char\" char null,
@@ -161,7 +160,6 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
                 \"id\" integer not null,
                 \"name\" varchar not null default 'honza'
@@ -228,7 +226,6 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
-         $db->query("drop table if exists \"test.metadata_columns\";");
          $db->query("create table \"test.metadata_columns\" (
                 \"id\" integer not null,
                 \"name\" geometry
@@ -260,7 +257,6 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
-        $db->query("drop table if exists \"test.metadata_columns\";");
         $db->query("create table \"test.metadata_columns\" (
                 \"id\" integer not null,
                 \"name\" geometry

--- a/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
@@ -25,7 +25,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.metadata_columns\" (
@@ -157,7 +157,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.Languages3\" (
@@ -222,7 +222,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
@@ -253,7 +253,7 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithUnsupportedDataType()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "redshift"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 

--- a/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
@@ -6,6 +6,7 @@ namespace Keboola\Test\Backend\Workspaces;
 use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\ClientException;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
+use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 
 class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
 {
@@ -25,9 +26,12 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
+        $workspace = $this->initTestWorkspace(self::BACKEND_REDSHIFT);
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.metadata_columns');
+
+        $db = $this->getDbConnection($workspace['connection']);
         $db->query("create table \"test.metadata_columns\" (
                     \"string\" varchar(16) not null default 'string',
                     \"char\" char null,
@@ -157,9 +161,12 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
+        $workspace = $this->initTestWorkspace(self::BACKEND_REDSHIFT);
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.Languages3');
+
+        $db = $this->getDbConnection($workspace['connection']);
         $db->query("create table \"test.Languages3\" (
                 \"id\" integer not null,
                 \"name\" varchar not null default 'honza'
@@ -222,9 +229,12 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
+        $workspace = $this->initTestWorkspace(self::BACKEND_REDSHIFT);
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.metadata_columns');
+
+        $db = $this->getDbConnection($workspace['connection']);
 
          $db->query("create table \"test.metadata_columns\" (
                 \"id\" integer not null,
@@ -253,9 +263,12 @@ class MetadataFromRedshiftWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithUnsupportedDataType()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
+        $workspace = $this->initTestWorkspace(self::BACKEND_REDSHIFT);
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.metadata_columns');
+
+        $db = $this->getDbConnection($workspace['connection']);
 
         $db->query("create table \"test.metadata_columns\" (
                 \"id\" integer not null,

--- a/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
@@ -27,6 +27,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
+        $db->query("drop table if exists \"test.metadata_columns\";");
         $db->query("create table \"test.metadata_columns\" (
                     \"id\" varchar(16),
                     \"name\" varchar
@@ -63,7 +64,8 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $this->assertArrayHasKey('name', $table['columnMetadata']);
         $this->assertMetadata($expectedNameMetadata, $table['columnMetadata']['name']);
 
-        $db->query("create or replace table \"test.metadata_columns\" (
+        $db->query("drop table if exists \"test.metadata_columns\";");
+        $db->query("create table \"test.metadata_columns\" (
                     \"id\" integer,
                     \"name\" char not null
                 );");
@@ -180,7 +182,8 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $this->assertArrayHasKey('name', $table['columnMetadata']);
         $this->assertMetadata($expectedNameMetadata, $table['columnMetadata']['name']);
 
-        $db->query("create or replace table \"test.metadata_columns\" (
+        $db->query("drop table if exists \"test.metadata_columns\";");
+        $db->query("create table \"test.metadata_columns\" (
                     \"id\" integer,
                     \"name\" varchar(32)
                 );");
@@ -224,6 +227,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
+        $db->query("drop table if exists \"test.metadata_columns\";");
         $db->query("create table \"test.metadata_columns\" (
                     \"string\" varchar(16) not null default 'string',
                     \"char\" char null,
@@ -363,6 +367,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
+        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
                 \"id\" integer not null,
                 \"name\" varchar not null default 'honza'
@@ -457,7 +462,8 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("CREATE OR REPLACE TABLE \"test.metadata_columns\" AS SELECT
+        $db->query("DROP TABLE IF EXISTS \"test.metadata_columns\";");
+        $db->query("CREATE TABLE \"test.metadata_columns\" AS SELECT
                         '1'::integer AS \"id\",
                         'roman'::string AS \"name\",
                         'test'::variant AS \"variant\",
@@ -482,7 +488,8 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("CREATE OR REPLACE TABLE \"test.metadata_columns\" AS SELECT
+        $db->query("DROP TABLE IF EXISTS \"test.metadata_columns\";");
+        $db->query("CREATE TABLE \"test.metadata_columns\" AS SELECT
                         '1'::integer AS \"id\",
                         'roman'::string AS \"name\",
                         'test'::variant AS \"variant\",

--- a/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
@@ -24,7 +24,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
     public function testIncrementalLoadUpdateDataType()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.metadata_columns\" (
@@ -221,7 +221,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
     {
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.metadata_columns\" (
@@ -360,7 +360,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.Languages3\" (
@@ -454,7 +454,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("CREATE TABLE \"test.metadata_columns\" AS SELECT
@@ -479,7 +479,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithSnowflakeBug()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("CREATE TABLE \"test.metadata_columns\" AS SELECT

--- a/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
@@ -4,7 +4,6 @@
 namespace Keboola\Test\Backend\Workspaces;
 
 use Keboola\Csv\CsvFile;
-use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
 
 class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
@@ -25,8 +24,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
     public function testIncrementalLoadUpdateDataType()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.metadata_columns\" (
@@ -223,8 +221,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
     {
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.metadata_columns\" (
@@ -363,8 +360,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("create table \"test.Languages3\" (
@@ -458,8 +454,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("CREATE OR REPLACE TABLE \"test.metadata_columns\" AS SELECT
@@ -484,8 +479,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithSnowflakeBug()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(["backend" => "snowflake"]);
+        $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
         $db->query("CREATE OR REPLACE TABLE \"test.metadata_columns\" AS SELECT

--- a/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
@@ -27,7 +27,6 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("drop table if exists \"test.metadata_columns\";");
         $db->query("create table \"test.metadata_columns\" (
                     \"id\" varchar(16),
                     \"name\" varchar
@@ -64,8 +63,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $this->assertArrayHasKey('name', $table['columnMetadata']);
         $this->assertMetadata($expectedNameMetadata, $table['columnMetadata']['name']);
 
-        $db->query("drop table if exists \"test.metadata_columns\";");
-        $db->query("create table \"test.metadata_columns\" (
+        $db->query("create or replace table \"test.metadata_columns\" (
                     \"id\" integer,
                     \"name\" char not null
                 );");
@@ -182,8 +180,7 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $this->assertArrayHasKey('name', $table['columnMetadata']);
         $this->assertMetadata($expectedNameMetadata, $table['columnMetadata']['name']);
 
-        $db->query("drop table if exists \"test.metadata_columns\";");
-        $db->query("create table \"test.metadata_columns\" (
+        $db->query("create or replace table \"test.metadata_columns\" (
                     \"id\" integer,
                     \"name\" varchar(32)
                 );");
@@ -227,7 +224,6 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("drop table if exists \"test.metadata_columns\";");
         $db->query("create table \"test.metadata_columns\" (
                     \"string\" varchar(16) not null default 'string',
                     \"char\" char null,
@@ -367,7 +363,6 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
                 \"id\" integer not null,
                 \"name\" varchar not null default 'honza'
@@ -462,7 +457,6 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("DROP TABLE IF EXISTS \"test.metadata_columns\";");
         $db->query("CREATE TABLE \"test.metadata_columns\" AS SELECT
                         '1'::integer AS \"id\",
                         'roman'::string AS \"name\",
@@ -488,7 +482,6 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         $workspace = $this->recreateTestWorkspace(["backend" => "snowflake"]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
-        $db->query("DROP TABLE IF EXISTS \"test.metadata_columns\";");
         $db->query("CREATE TABLE \"test.metadata_columns\" AS SELECT
                         '1'::integer AS \"id\",
                         'roman'::string AS \"name\",

--- a/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
@@ -5,6 +5,7 @@ namespace Keboola\Test\Backend\Workspaces;
 
 use Keboola\Csv\CsvFile;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
+use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 
 class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
 {
@@ -24,10 +25,10 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
     public function testIncrementalLoadUpdateDataType()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
-        $db->query("create table \"test.metadata_columns\" (
+        $workspace = $this->initTestWorkspace(self::BACKEND_SNOWFLAKE);
+
+        $db = $this->getDbConnection($workspace['connection']);
+        $db->query("create or replace table \"test.metadata_columns\" (
                     \"id\" varchar(16),
                     \"name\" varchar
                 );");
@@ -219,12 +220,11 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
 
     public function testCreateTableFromWorkspace()
     {
-
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
-        $db->query("create table \"test.metadata_columns\" (
+        $workspace = $this->initTestWorkspace(self::BACKEND_SNOWFLAKE);
+
+        $db = $this->getDbConnection($workspace['connection']);
+        $db->query("create or replace table \"test.metadata_columns\" (
                     \"string\" varchar(16) not null default 'string',
                     \"char\" char null,
                     \"integer\" integer not null default 4,
@@ -360,10 +360,10 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
-        $db->query("create table \"test.Languages3\" (
+        $workspace = $this->initTestWorkspace(self::BACKEND_SNOWFLAKE);
+
+        $db = $this->getDbConnection($workspace['connection']);
+        $db->query("create or replace table \"test.Languages3\" (
                 \"id\" integer not null,
                 \"name\" varchar not null default 'honza'
             );");
@@ -454,10 +454,10 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
-        $db->query("CREATE TABLE \"test.metadata_columns\" AS SELECT
+        $workspace = $this->initTestWorkspace(self::BACKEND_SNOWFLAKE);
+
+        $db = $this->getDbConnection($workspace['connection']);
+        $db->query("CREATE OR REPLACE TABLE \"test.metadata_columns\" AS SELECT
                         '1'::integer AS \"id\",
                         'roman'::string AS \"name\",
                         'test'::variant AS \"variant\",
@@ -479,10 +479,10 @@ class MetadataFromSnowflakeWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithSnowflakeBug()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
-        $connection = $workspace['connection'];
-        $db = $this->getDbConnection($connection);
-        $db->query("CREATE TABLE \"test.metadata_columns\" AS SELECT
+        $workspace = $this->initTestWorkspace(self::BACKEND_SNOWFLAKE);
+
+        $db = $this->getDbConnection($workspace['connection']);
+        $db->query("CREATE OR REPLACE TABLE \"test.metadata_columns\" AS SELECT
                         '1'::integer AS \"id\",
                         'roman'::string AS \"name\",
                         'test'::variant AS \"variant\",

--- a/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
@@ -23,7 +23,7 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(['backend' => 'synapse']);
+        $workspace = $this->recreateTestWorkspace(['backend' => self::BACKEND_SYNAPSE]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
@@ -141,7 +141,7 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(['backend' => 'synapse']);
+        $workspace = $this->recreateTestWorkspace(['backend' => self::BACKEND_SYNAPSE]);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 

--- a/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
@@ -3,7 +3,6 @@
 namespace Keboola\Test\Backend\Workspaces;
 
 use Keboola\Csv\CsvFile;
-use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
 
 class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
@@ -24,8 +23,7 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(['backend' => 'synapse']);
+        $workspace = $this->recreateTestWorkspace(['backend' => 'synapse']);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
@@ -143,8 +141,7 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace(['backend' => 'synapse']);
+        $workspace = $this->recreateTestWorkspace(['backend' => 'synapse']);
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 

--- a/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
@@ -4,6 +4,7 @@ namespace Keboola\Test\Backend\Workspaces;
 
 use Keboola\Csv\CsvFile;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
+use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 
 class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
 {
@@ -23,11 +24,16 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(['backend' => self::BACKEND_SYNAPSE]);
+        $workspace = $this->initTestWorkspace(self::BACKEND_SYNAPSE);
+
+        $tableId = 'metadata_columns';
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists($tableId);
+
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
-        $tableId = 'metadata_columns';
         $quotedTableId = $db->getDatabasePlatform()->quoteIdentifier(sprintf(
             '%s.%s',
             $connection['schema'],
@@ -141,11 +147,16 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
         );
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace(['backend' => self::BACKEND_SYNAPSE]);
+        $workspace = $this->initTestWorkspace(self::BACKEND_SYNAPSE);
+
+        $tableId = 'Languages3';
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists($tableId);
+
         $connection = $workspace['connection'];
         $db = $this->getDbConnection($connection);
 
-        $tableId = 'Languages3';
         $quotedTableId = $db->getDatabasePlatform()->quoteIdentifier(sprintf(
             '%s.%s',
             $connection['schema'],

--- a/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
@@ -34,7 +34,6 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
             $tableId
         ));
 
-        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
                     \"string\" varchar(16) not null default 'string',
                     \"char\" char null,
@@ -153,7 +152,6 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
             $tableId
         ));
 
-        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
                 \"id\" integer not null,
                 \"name\" varchar(50) not null default 'honza'

--- a/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+++ b/tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
@@ -34,6 +34,7 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
             $tableId
         ));
 
+        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
                     \"string\" varchar(16) not null default 'string',
                     \"char\" char null,
@@ -152,6 +153,7 @@ class MetadataFromSynapseWorkspaceTest extends ParallelWorkspacesTestCase
             $tableId
         ));
 
+        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
                 \"id\" integer not null,
                 \"name\" varchar(50) not null default 'honza'

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -19,7 +19,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         parent::setUp();
         $this->initEmptyTestBucketsForParallelTests();
 
-        $description = get_class($this) . '\\' . $this->getName();
+        $description = $this->generateDescriptionForTestObject();
 
         $this->deleteOldTestWorkspaces($description);
 

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -19,12 +19,10 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         parent::setUp();
         $this->initEmptyTestBucketsForParallelTests();
 
-        $description = $this->generateDescriptionForTestObject();
-
-        $this->deleteOldTestWorkspaces($description);
+        $this->deleteOldTestWorkspaces();
 
         $this->workspaceSapiClient = $this->getClient([
-            'token' => $this->initTestToken($description),
+            'token' => $this->initTestToken(),
             'url' => STORAGE_API_URL,
             'backoffMaxTries' => 1,
             'jobPollRetryDelay' => function () {
@@ -33,18 +31,11 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         ]);
     }
 
-    private function deleteOldTestWorkspaces($testName)
+    private function deleteOldTestWorkspaces()
     {
         $workspaces = new Workspaces($this->_client);
 
-        $oldTestWorkspaces = array_filter(
-            $workspaces->listWorkspaces(),
-            function (array $workspace) use ($testName) {
-                return $workspace['creatorToken']['description'] === $testName;
-            }
-        );
-
-        foreach ($oldTestWorkspaces as $workspace) {
+        foreach ($this->listTestWorkspaces() as $workspace) {
             $workspaces->deleteWorkspace($workspace['id'], [
                 'async' => true,
             ]);
@@ -52,15 +43,16 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
     }
 
     /**
-     * @param string $testName
      * @return string
      */
-    private function initTestToken($testName)
+    private function initTestToken()
     {
+        $description = $this->generateDescriptionForTestObject();
+
         $oldTestTokens = array_filter(
             $this->tokens->listTokens(),
-            function (array $token) use ($testName) {
-                return $token['description'] === $testName;
+            function (array $token) use ($description) {
+                return $token['description'] === $description;
             }
         );
 
@@ -74,7 +66,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
 
         $tokenOptions = (new TokenCreateOptions())
             ->setCanManageBuckets(true)
-            ->setDescription($testName)
+            ->setDescription($this->generateDescriptionForTestObject())
         ;
 
         $tokenData = $this->tokens->createToken($tokenOptions);
@@ -88,6 +80,19 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
             function ($job) use ($workspaceId) {
                 $workspaceIdParam = isset($job['operationParams']['workspaceId']) ? (int) $job['operationParams']['workspaceId'] : 0;
                 return (int) $workspaceIdParam === $workspaceId;
+            }
+        );
+    }
+
+    private function listTestWorkspaces()
+    {
+        $description = $this->generateDescriptionForTestObject();
+        $workspaces = new Workspaces($this->_client);
+
+        return array_filter(
+            $workspaces->listWorkspaces(),
+            function (array $workspace) use ($description) {
+                return $workspace['creatorToken']['description'] === $description;
             }
         );
     }

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -42,6 +42,27 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         return $workspaces->createWorkspace($options);
     }
 
+    /**
+     * Creates a new workspace for current test. If workspace already exist, resets its password
+     *
+     * @return array workspace detail
+     */
+    protected function initTestWorkspace()
+    {
+        $oldWorkspaces = $this->listTestWorkspaces();
+
+        $workspaces = new Workspaces($this->workspaceSapiClient);
+
+        if ($oldWorkspaces) {
+            $oldWorkspace = reset($oldWorkspaces);
+            $result = $workspaces->resetWorkspacePassword($oldWorkspace['id']);
+            $oldWorkspace['connection']['password'] = $result['password'];
+            return $oldWorkspace;
+        } else {
+            return $workspaces->createWorkspace();
+        }
+    }
+
     private function deleteOldTestWorkspaces()
     {
         $workspaces = new Workspaces($this->_client);

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -19,8 +19,6 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         parent::setUp();
         $this->initEmptyTestBucketsForParallelTests();
 
-        $this->deleteOldTestWorkspaces();
-
         $this->workspaceSapiClient = $this->getClient([
             'token' => $this->initTestToken(),
             'url' => STORAGE_API_URL,
@@ -29,6 +27,19 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
                 return 1;
             },
         ]);
+    }
+
+    /**
+     * Drops all workspaces created by current test and creates a new one
+     *
+     * @param array $options
+     * @return array workspace detail
+     */
+    protected function recreateTestWorkspace($options = [])
+    {
+        $this->deleteOldTestWorkspaces();
+        $workspaces = new Workspaces($this->workspaceSapiClient);
+        return $workspaces->createWorkspace($options);
     }
 
     private function deleteOldTestWorkspaces()

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -116,7 +116,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         );
     }
 
-    private function listTestWorkspaces()
+    protected function listTestWorkspaces()
     {
         $description = $this->generateDescriptionForTestObject();
         $workspaces = new Workspaces($this->_client);

--- a/tests/Backend/Workspaces/ReadOnlyUserTest.php
+++ b/tests/Backend/Workspaces/ReadOnlyUserTest.php
@@ -13,7 +13,7 @@ class ReadOnlyUserTest extends ParallelWorkspacesTestCase
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $workspace = $workspaces->getWorkspace($workspace['id']);
 
         $readOnlyWorkspaces = new Workspaces($readOnlyClient);

--- a/tests/Backend/Workspaces/ReadOnlyUserTest.php
+++ b/tests/Backend/Workspaces/ReadOnlyUserTest.php
@@ -13,7 +13,7 @@ class ReadOnlyUserTest extends ParallelWorkspacesTestCase
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $workspace = $workspaces->getWorkspace($workspace['id']);
 
         $readOnlyWorkspaces = new Workspaces($readOnlyClient);

--- a/tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
@@ -4,6 +4,7 @@ namespace Keboola\Test\Backend\Workspaces;
 
 use Keboola\StorageApi\ClientException;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
+use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 
 class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
 {
@@ -14,18 +15,21 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
+        $tableId = 'Languages3';
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists($tableId);
+
         $connection = $workspace['connection'];
 
         $db = $this->getDbConnection($connection);
 
-        $tableId = 'Languages3';
         $quotedTableId = $db->getDatabasePlatform()->quoteIdentifier(sprintf(
             '%s.%s',
             $connection['schema'],
             $tableId
         ));
 
-        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
 			[Id] integer not null,
 			[Name] varchar(50) not null
@@ -56,18 +60,21 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
+        $tableId = 'Languages3';
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists($tableId);
+
         $connection = $workspace['connection'];
 
         $db = $this->getDbConnection($connection);
 
-        $tableId = 'Languages3';
         $quotedTableId = $db->getDatabasePlatform()->quoteIdentifier(sprintf(
             '%s.%s',
             $connection['schema'],
             $tableId
         ));
 
-        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
 			[_Id] integer not null,
 			[Name] varchar(50) not null
@@ -93,18 +100,21 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
+        $tableId = 'Languages3';
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists($tableId);
+
         $connection = $workspace['connection'];
 
         $db = $this->getDbConnection($connection);
 
-        $tableId = 'Languages3';
         $quotedTableId = $db->getDatabasePlatform()->quoteIdentifier(sprintf(
             '%s.%s',
             $connection['schema'],
             $tableId
         ));
 
-        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
 			[Id] integer not null,
 			[Name] varchar(50) not null,
@@ -143,18 +153,21 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
+        $tableId = 'Languages3';
+
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists($tableId);
+
         $connection = $workspace['connection'];
 
         $db = $this->getDbConnection($connection);
 
-        $tableId = 'Languages3';
         $quotedTableId = $db->getDatabasePlatform()->quoteIdentifier(sprintf(
             '%s.%s',
             $connection['schema'],
             $tableId
         ));
 
-        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
 			[Id] integer not null,
 			[Name] varchar(50) not null,

--- a/tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
@@ -12,7 +12,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -53,7 +53,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithInvalidColumnNames()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -89,7 +89,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testImportFromWorkspaceWithInvalidColumnNames()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -138,7 +138,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
         ));
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 

--- a/tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
@@ -25,6 +25,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
             $tableId
         ));
 
+        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
 			[Id] integer not null,
 			[Name] varchar(50) not null
@@ -66,6 +67,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
             $tableId
         ));
 
+        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
 			[_Id] integer not null,
 			[Name] varchar(50) not null
@@ -102,6 +104,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
             $tableId
         ));
 
+        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
 			[Id] integer not null,
 			[Name] varchar(50) not null,
@@ -151,6 +154,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
             $tableId
         ));
 
+        $db->query("drop table if exists $quotedTableId;");
         $db->query("create table $quotedTableId (
 			[Id] integer not null,
 			[Name] varchar(50) not null,

--- a/tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
@@ -3,7 +3,6 @@
 namespace Keboola\Test\Backend\Workspaces;
 
 use Keboola\StorageApi\ClientException;
-use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
 
 class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
@@ -13,8 +12,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -55,8 +53,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithInvalidColumnNames()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -92,8 +89,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testImportFromWorkspaceWithInvalidColumnNames()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -142,8 +138,7 @@ class SynapseWorkspacesUnloadTest extends ParallelWorkspacesTestCase
         ));
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 

--- a/tests/Backend/Workspaces/WorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesLoadTest.php
@@ -17,7 +17,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         //setup test tables
         $tableId = $this->_client->createTable(
@@ -81,7 +81,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         //setup test tables
         $table1_id = $this->_client->createTable(
@@ -160,7 +160,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         //setup test tables
         $table1Id = $this->_client->createTable(
@@ -273,7 +273,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testWorkspaceLoadColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -387,7 +387,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -461,7 +461,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalAdditionalColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -540,7 +540,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalMissingColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';

--- a/tests/Backend/Workspaces/WorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesLoadTest.php
@@ -17,7 +17,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         //setup test tables
         $tableId = $this->_client->createTable(
@@ -81,7 +81,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         //setup test tables
         $table1_id = $this->_client->createTable(
@@ -160,7 +160,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         //setup test tables
         $table1Id = $this->_client->createTable(
@@ -273,7 +273,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testWorkspaceLoadColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -387,7 +387,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -461,7 +461,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalAdditionalColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -540,7 +540,7 @@ class WorkspacesLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalMissingColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';

--- a/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
@@ -29,7 +29,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testColumnCompression($columnsDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -64,7 +64,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testLoadedSortKey()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $db = $this->getDbConnection($workspace['connection']);
 
         // Create a table of sample data
@@ -122,7 +122,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testLoadedDist($dist)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $db = $this->getDbConnection($workspace['connection']);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -172,7 +172,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testLoadDataTypesDefaults()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -265,7 +265,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ["input" => [$mapping]]);
@@ -345,7 +345,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -422,7 +422,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -495,7 +495,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -593,7 +593,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -682,7 +682,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testOutBytesMetricsWithLoadWorkspaceWithRows()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $table1Id = $this->_client->createTable(
@@ -726,7 +726,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testOutBytesMetricsWithLoadWorkspaceWithSeconds()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $table1Id = $this->_client->createTable(

--- a/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
@@ -14,8 +14,9 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
 
     public function testCreateNotSupportedBackend()
     {
+        $workspaces = new Workspaces($this->workspaceSapiClient);
         try {
-            $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
+            $workspaces->createWorkspace(['backend' => self::BACKEND_SNOWFLAKE]);
             $this->fail("should not be able to create WS for unsupported backend");
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), "workspace.backendNotSupported");

--- a/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
@@ -15,7 +15,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testCreateNotSupportedBackend()
     {
         try {
-            $this->recreateTestWorkspace(["backend" => "snowflake"]);
+            $this->recreateTestWorkspace(["backend" => self::BACKEND_SNOWFLAKE]);
             $this->fail("should not be able to create WS for unsupported backend");
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), "workspace.backendNotSupported");

--- a/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRedshiftTest.php
@@ -14,9 +14,8 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
 
     public function testCreateNotSupportedBackend()
     {
-        $workspaces = new Workspaces($this->workspaceSapiClient);
         try {
-            $workspaces->createWorkspace(["backend" => "snowflake"]);
+            $this->recreateTestWorkspace(["backend" => "snowflake"]);
             $this->fail("should not be able to create WS for unsupported backend");
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), "workspace.backendNotSupported");
@@ -30,7 +29,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testColumnCompression($columnsDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -65,7 +64,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testLoadedSortKey()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $db = $this->getDbConnection($workspace['connection']);
 
         // Create a table of sample data
@@ -123,7 +122,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testLoadedDist($dist)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $db = $this->getDbConnection($workspace['connection']);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -173,7 +172,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testLoadDataTypesDefaults()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -266,7 +265,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ["input" => [$mapping]]);
@@ -346,7 +345,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -423,7 +422,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -496,7 +495,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -594,7 +593,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -683,7 +682,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testOutBytesMetricsWithLoadWorkspaceWithRows()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $table1Id = $this->_client->createTable(
@@ -727,7 +726,7 @@ class WorkspacesRedshiftTest extends ParallelWorkspacesTestCase
     public function testOutBytesMetricsWithLoadWorkspaceWithSeconds()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $table1Id = $this->_client->createTable(

--- a/tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
@@ -17,7 +17,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -136,7 +136,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testDottedDestination()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -191,7 +191,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalAdditionalColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -275,7 +275,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalMissingColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -352,7 +352,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalDataTypesDiff($table, $firstLoadDataColumns, $secondLoadDataColumns)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 
@@ -409,7 +409,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testDataTypes($columnsDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.camel-case-columns.csv';

--- a/tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
@@ -17,7 +17,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
@@ -136,7 +136,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testDottedDestination()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -191,7 +191,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalAdditionalColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -275,7 +275,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalMissingColumns()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -352,7 +352,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testIncrementalDataTypesDiff($table, $firstLoadDataColumns, $secondLoadDataColumns)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 
@@ -409,7 +409,7 @@ class WorkspacesRenameLoadTest extends ParallelWorkspacesTestCase
     public function testDataTypes($columnsDefinition)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $importFile = __DIR__ . '/../../_data/languages.camel-case-columns.csv';

--- a/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
@@ -14,8 +14,9 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
 
     public function testCreateNotSupportedBackend()
     {
+        $workspaces = new Workspaces($this->workspaceSapiClient);
         try {
-            $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
+            $workspaces->createWorkspace(['backend' => self::BACKEND_REDSHIFT]);
             $this->fail("should not be able to create WS for unsupported backend");
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), "workspace.backendNotSupported");

--- a/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
@@ -25,7 +25,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testLoadDataTypesDefaults()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -106,7 +106,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
 
     public function testStatementTimeout()
     {
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $this->assertGreaterThan(0, $workspace['statementTimeoutSeconds']);
 
@@ -118,7 +118,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
 
     public function testClientSessionKeepAlive()
     {
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $db = $this->getDbConnection($workspace['connection']);
 
@@ -132,7 +132,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testTransientTables()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -217,7 +217,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ["input" => [$mapping]]);
@@ -267,7 +267,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -349,7 +349,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -422,7 +422,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -519,7 +519,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -611,7 +611,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testsIncrementalDataTypesDiff($table, $firstLoadColumns, $secondLoadColumns, $shouldFail)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 

--- a/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
@@ -14,9 +14,8 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
 
     public function testCreateNotSupportedBackend()
     {
-        $workspaces = new Workspaces($this->workspaceSapiClient);
         try {
-            $workspaces->createWorkspace(["backend" => "redshift"]);
+            $this->recreateTestWorkspace(["backend" => "redshift"]);
             $this->fail("should not be able to create WS for unsupported backend");
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), "workspace.backendNotSupported");
@@ -26,7 +25,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testLoadDataTypesDefaults()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -107,8 +106,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
 
     public function testStatementTimeout()
     {
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $this->assertGreaterThan(0, $workspace['statementTimeoutSeconds']);
 
@@ -120,8 +118,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
 
     public function testClientSessionKeepAlive()
     {
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $db = $this->getDbConnection($workspace['connection']);
 
@@ -135,7 +132,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testTransientTables()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -220,7 +217,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ["input" => [$mapping]]);
@@ -270,7 +267,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -352,7 +349,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -425,7 +422,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -522,7 +519,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -614,7 +611,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testsIncrementalDataTypesDiff($table, $firstLoadColumns, $secondLoadColumns, $shouldFail)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 

--- a/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
@@ -15,7 +15,7 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
     public function testCreateNotSupportedBackend()
     {
         try {
-            $this->recreateTestWorkspace(["backend" => "redshift"]);
+            $this->recreateTestWorkspace(["backend" => self::BACKEND_REDSHIFT]);
             $this->fail("should not be able to create WS for unsupported backend");
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), "workspace.backendNotSupported");

--- a/tests/Backend/Workspaces/WorkspacesSynapseTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSynapseTest.php
@@ -14,7 +14,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testCreateNotSupportedBackend()
     {
         try {
-            $this->recreateTestWorkspace(['backend' => 'redshift']);
+            $this->recreateTestWorkspace(['backend' => self::BACKEND_REDSHIFT]);
             $this->fail('should not be able to create WS for unsupported backend');
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), 'workspace.backendNotSupported');

--- a/tests/Backend/Workspaces/WorkspacesSynapseTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSynapseTest.php
@@ -13,8 +13,9 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
 
     public function testCreateNotSupportedBackend()
     {
+        $workspaces = new Workspaces($this->workspaceSapiClient);
         try {
-            $this->recreateTestWorkspace(['backend' => self::BACKEND_REDSHIFT]);
+            $workspaces->createWorkspace(['backend' => self::BACKEND_REDSHIFT]);
             $this->fail('should not be able to create WS for unsupported backend');
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), 'workspace.backendNotSupported');

--- a/tests/Backend/Workspaces/WorkspacesSynapseTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSynapseTest.php
@@ -26,7 +26,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
         $importFile = __DIR__ . '/../../_data/languages.csv';
         $tableId = $this->_client->createTableAsync(
@@ -90,7 +90,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testLoadDataTypesDefaults()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -190,7 +190,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ['input' => [$mapping]]);
@@ -249,7 +249,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -326,7 +326,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -399,7 +399,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -496,7 +496,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -588,7 +588,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testsIncrementalDataTypesDiff($table, $firstLoadColumns, $secondLoadColumns, $shouldFail)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 
@@ -639,7 +639,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testOutBytesMetricsWithLoadWorkspaceWithRows()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $table1Id = $this->_client->createTable(
@@ -683,7 +683,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testOutBytesMetricsWithLoadWorkspaceWithSeconds()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         // Create a table of sample data
         $table1Id = $this->_client->createTable(

--- a/tests/Backend/Workspaces/WorkspacesSynapseTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSynapseTest.php
@@ -13,9 +13,8 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
 
     public function testCreateNotSupportedBackend()
     {
-        $workspaces = new Workspaces($this->workspaceSapiClient);
         try {
-            $workspaces->createWorkspace(['backend' => 'redshift']);
+            $this->recreateTestWorkspace(['backend' => 'redshift']);
             $this->fail('should not be able to create WS for unsupported backend');
         } catch (ClientException $e) {
             $this->assertEquals($e->getStringCode(), 'workspace.backendNotSupported');
@@ -27,7 +26,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
         $importFile = __DIR__ . '/../../_data/languages.csv';
         $tableId = $this->_client->createTableAsync(
@@ -91,7 +90,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testLoadDataTypesDefaults()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $importFile = __DIR__ . '/../../_data/languages.csv';
@@ -191,7 +190,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         ];
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
         $workspaces->loadWorkspaceData($workspace['id'], ['input' => [$mapping]]);
@@ -250,7 +249,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -327,7 +326,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -400,7 +399,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -497,7 +496,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
 
 
@@ -589,7 +588,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testsIncrementalDataTypesDiff($table, $firstLoadColumns, $secondLoadColumns, $shouldFail)
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $importFile = __DIR__ . "/../../_data/$table.csv";
 
@@ -640,7 +639,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testOutBytesMetricsWithLoadWorkspaceWithRows()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $table1Id = $this->_client->createTable(
@@ -684,7 +683,7 @@ class WorkspacesSynapseTest extends ParallelWorkspacesTestCase
     public function testOutBytesMetricsWithLoadWorkspaceWithSeconds()
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         // Create a table of sample data
         $table1Id = $this->_client->createTable(

--- a/tests/Backend/Workspaces/WorkspacesTest.php
+++ b/tests/Backend/Workspaces/WorkspacesTest.php
@@ -20,21 +20,23 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
 
     public function testWorkspaceCreate()
     {
-
         $workspaces = new Workspaces($this->workspaceSapiClient);
+
+        foreach ($this->listTestWorkspaces() as $workspace) {
+            $workspaces->deleteWorkspace($workspace['id']);
+        }
 
         $runId = $this->_client->generateRunId();
         $this->_client->setRunId($runId);
         $this->workspaceSapiClient->setRunId($runId);
 
-        $workspace = $this->initTestWorkspace();
+        $workspace = $workspaces->createWorkspace();
         $connection = $workspace['connection'];
 
         $tokenInfo = $this->_client->verifyToken();
         $this->assertEquals($tokenInfo['owner']['defaultBackend'], $connection['backend']);
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
-
         $backend->createTable("mytable", ["amount" => ($connection['backend'] === self::BACKEND_SNOWFLAKE) ? "NUMBER" : "VARCHAR"]);
 
         $tableNames = $backend->getTables();
@@ -86,7 +88,7 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
         $this->assertEquals($tokenInfo['owner']['defaultBackend'], $connection['backend']);
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
-
+        $backend->dropTableIfExists('mytable');
         $backend->createTable("mytable", ["amount" => ($connection['backend'] === self::BACKEND_SNOWFLAKE) ? "NUMBER" : "VARCHAR"]);
 
         $tableNames = $backend->getTables();
@@ -142,10 +144,14 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
+        foreach ($this->listTestWorkspaces() as $workspace) {
+            $workspaces->deleteWorkspace($workspace['id']);
+        }
+
         $runId = $this->_client->generateRunId();
         $this->workspaceSapiClient->setRunId($runId);
 
-        $workspace = $this->initTestWorkspace();
+        $workspace = $workspaces->createWorkspace();
         $connection = $workspace['connection'];
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);

--- a/tests/Backend/Workspaces/WorkspacesTest.php
+++ b/tests/Backend/Workspaces/WorkspacesTest.php
@@ -27,7 +27,7 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
         $this->_client->setRunId($runId);
         $this->workspaceSapiClient->setRunId($runId);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $connection = $workspace['connection'];
 
         $tokenInfo = $this->_client->verifyToken();
@@ -78,7 +78,7 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -145,7 +145,7 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
         $runId = $this->_client->generateRunId();
         $this->workspaceSapiClient->setRunId($runId);
 
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
         $connection = $workspace['connection'];
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);

--- a/tests/Backend/Workspaces/WorkspacesTest.php
+++ b/tests/Backend/Workspaces/WorkspacesTest.php
@@ -27,7 +27,7 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
         $this->_client->setRunId($runId);
         $this->workspaceSapiClient->setRunId($runId);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $connection = $workspace['connection'];
 
         $tokenInfo = $this->_client->verifyToken();
@@ -78,7 +78,7 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
     {
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -145,7 +145,7 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
         $runId = $this->_client->generateRunId();
         $this->workspaceSapiClient->setRunId($runId);
 
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
         $connection = $workspace['connection'];
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);

--- a/tests/Backend/Workspaces/WorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesUnloadTest.php
@@ -34,6 +34,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $db = $this->getDbConnection($connection);
 
+        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"id\" integer not null,
 			\"Name\" varchar not null
@@ -60,6 +61,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $db = $this->getDbConnection($connection);
 
+        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"Id\" integer not null,
 			\"Name\" varchar not null
@@ -93,6 +95,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $db = $this->getDbConnection($connection);
 
+        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"_Id\" integer not null,
 			\"Name\" varchar not null
@@ -121,6 +124,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $db = $this->getDbConnection($connection);
 
+        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"Id\" integer not null,
 			\"Name\" varchar not null,
@@ -162,6 +166,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $db = $this->getDbConnection($connection);
 
+        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"Id\" integer not null,
 			\"Name\" varchar not null,

--- a/tests/Backend/Workspaces/WorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesUnloadTest.php
@@ -33,6 +33,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
         $backend->dropTableIfExists('test.Languages3');
+        unset($backend);
 
         $db = $this->getDbConnection($workspace['connection']);
 
@@ -40,6 +41,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 			\"id\" integer not null,
 			\"Name\" varchar not null
 		);");
+
 
         $db->query("insert into \"test.Languages3\" (\"id\", \"Name\") values (1, 'cz'), (2, 'en');");
 
@@ -60,6 +62,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
         $backend->dropTableIfExists('test.Languages3');
+        unset($backend);
 
         $connection = $workspace['connection'];
 
@@ -96,6 +99,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
         $backend->dropTableIfExists('test.Languages3');
+        unset($backend);
 
         $db = $this->getDbConnection($workspace['connection']);
 
@@ -125,6 +129,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
         $backend->dropTableIfExists('test.Languages3');
+        unset($backend);
 
         $db = $this->getDbConnection($workspace['connection']);
 
@@ -167,6 +172,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 
         $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
         $backend->dropTableIfExists('test.Languages3');
+        unset($backend);
 
         $db = $this->getDbConnection($workspace['connection']);
 

--- a/tests/Backend/Workspaces/WorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesUnloadTest.php
@@ -11,9 +11,7 @@ namespace Keboola\Test\Backend\Workspaces;
 
 use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\ClientException;
-use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
-use Keboola\Test\StorageApiTestCase;
 
 class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 {
@@ -30,8 +28,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         $tableId = $this->_client->createTable($this->getTestBucketId(self::STAGE_IN), 'languages-case-sensitive', $importFile);
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -57,8 +54,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -91,8 +87,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithInvalidColumnNames()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -120,8 +115,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testImportFromWorkspaceWithInvalidColumnNames()
     {
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -162,8 +156,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         ));
 
         // create workspace and source table in workspace
-        $workspaces = new Workspaces($this->workspaceSapiClient);
-        $workspace = $workspaces->createWorkspace();
+        $workspace = $this->recreateTestWorkspace();
 
         $connection = $workspace['connection'];
 

--- a/tests/Backend/Workspaces/WorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesUnloadTest.php
@@ -28,7 +28,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         $tableId = $this->_client->createTable($this->getTestBucketId(self::STAGE_IN), 'languages-case-sensitive', $importFile);
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -54,7 +54,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspace()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -87,7 +87,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testCreateTableFromWorkspaceWithInvalidColumnNames()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -115,7 +115,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
     public function testImportFromWorkspaceWithInvalidColumnNames()
     {
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 
@@ -156,7 +156,7 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         ));
 
         // create workspace and source table in workspace
-        $workspace = $this->recreateTestWorkspace();
+        $workspace = $this->initTestWorkspace();
 
         $connection = $workspace['connection'];
 

--- a/tests/Backend/Workspaces/WorkspacesUnloadTest.php
+++ b/tests/Backend/Workspaces/WorkspacesUnloadTest.php
@@ -12,6 +12,7 @@ namespace Keboola\Test\Backend\Workspaces;
 use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\ClientException;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
+use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 
 class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
 {
@@ -30,11 +31,11 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
-        $connection = $workspace['connection'];
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.Languages3');
 
-        $db = $this->getDbConnection($connection);
+        $db = $this->getDbConnection($workspace['connection']);
 
-        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"id\" integer not null,
 			\"Name\" varchar not null
@@ -57,11 +58,13 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.Languages3');
+
         $connection = $workspace['connection'];
 
         $db = $this->getDbConnection($connection);
 
-        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"Id\" integer not null,
 			\"Name\" varchar not null
@@ -91,11 +94,11 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
-        $connection = $workspace['connection'];
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.Languages3');
 
-        $db = $this->getDbConnection($connection);
+        $db = $this->getDbConnection($workspace['connection']);
 
-        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"_Id\" integer not null,
 			\"Name\" varchar not null
@@ -120,11 +123,11 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
-        $connection = $workspace['connection'];
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.Languages3');
 
-        $db = $this->getDbConnection($connection);
+        $db = $this->getDbConnection($workspace['connection']);
 
-        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"Id\" integer not null,
 			\"Name\" varchar not null,
@@ -162,11 +165,11 @@ class WorkspacesUnloadTest extends ParallelWorkspacesTestCase
         // create workspace and source table in workspace
         $workspace = $this->initTestWorkspace();
 
-        $connection = $workspace['connection'];
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+        $backend->dropTableIfExists('test.Languages3');
 
-        $db = $this->getDbConnection($connection);
+        $db = $this->getDbConnection($workspace['connection']);
 
-        $db->query("drop table if exists \"test.Languages3\";");
         $db->query("create table \"test.Languages3\" (
 			\"Id\" integer not null,
 			\"Name\" varchar not null,

--- a/tests/Common/BranchBucketsTest.php
+++ b/tests/Common/BranchBucketsTest.php
@@ -24,7 +24,7 @@ class BranchBucketsTest extends StorageApiTestCase
         $devBranchClient = new DevBranches($this->_client);
         $metadata = new Metadata($this->_client);
 
-        $description = get_class($this) . '\\' . $this->getName();
+        $description = $this->generateDescriptionForTestObject();
 
         $branchName1 = $this->generateBranchNameForParallelTest();
         $devBucketName1 = sprintf('Dev-Branch-Bucket-' . sha1($description));

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -94,7 +94,7 @@ abstract class StorageApiTestCase extends ClientTestCase
 
     protected function initEmptyTestBucketsForParallelTests($stages = [self::STAGE_OUT, self::STAGE_IN])
     {
-        $description = get_class($this) . '\\' . $this->getName();
+        $description = $this->generateDescriptionForTestObject();
         $bucketName = sprintf('API-tests-' . sha1($description));
         foreach ($stages as $stage) {
             $this->_bucketIds[$stage] = $this->initEmptyBucket($bucketName, $stage, $description);
@@ -103,7 +103,7 @@ abstract class StorageApiTestCase extends ClientTestCase
 
     protected function listTestBucketsForParallelTests($stages = [self::STAGE_OUT, self::STAGE_IN])
     {
-        $description = get_class($this) . '\\' . $this->getName();
+        $description = $this->generateDescriptionForTestObject();
         $bucketName = sprintf('API-tests-' . sha1($description));
         $buckets = [];
         foreach ($stages as $stage) {
@@ -520,7 +520,7 @@ abstract class StorageApiTestCase extends ClientTestCase
 
     protected function getExportFilePathForTest($fileName)
     {
-        $testName = get_class($this) . '\\' . $this->getName();
+        $testName = $this->generateDescriptionForTestObject();
         return __DIR__ . '/_tmp/' . sha1($testName) . '.' . $fileName;
     }
 
@@ -552,5 +552,13 @@ abstract class StorageApiTestCase extends ClientTestCase
         }
 
         return $name;
+    }
+
+    /**
+     * @return string
+     */
+    protected function generateDescriptionForTestObject()
+    {
+        return get_class($this) . '\\' . $this->getName();
     }
 }


### PR DESCRIPTION
KBC: https://github.com/keboola/connection/pull/3138

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
V paralelních testech se nevytvářejí při každém testu nové workspacy, ale používají se již vytvořené _(případně se vytvoří nové pokud neexistujou a nebo nesedí požadovaný backend)_.
Zrychluje to build, zejména na RS _(viz PR v KBC)_

Review asi ideálně jako celek. Snažil jsem se to tlačit po commitech ale několikrát jsem to refactoroval. Výsledná úprava nakonec neni tak moc velká.