### PR TITLE
KBC-1464 Remove name parameter from creating requests

### DIFF
--- a/src/Keboola/StorageApi/Workspaces.php
+++ b/src/Keboola/StorageApi/Workspaces.php
@@ -24,7 +24,6 @@ class Workspaces
 
     /**
      * @param array $options
-     *  - name (optional)
      *  - backend (optional)
      */
     public function createWorkspace(array $options = [])

--- a/tests/Backend/Mixed/SharingTest.php
+++ b/tests/Backend/Mixed/SharingTest.php
@@ -1280,7 +1280,6 @@ class SharingTest extends StorageApiSharingTestCase
         // load data into workspace in destination project
         $workspacesClient = new Workspaces($this->_client2);
         $workspace = $workspacesClient->createWorkspace([
-            'name' => 'clone',
             'backend' => self::BACKEND_SNOWFLAKE,
         ]);
 

--- a/tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+++ b/tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
@@ -35,9 +35,7 @@ class CloneIntoWorkspaceTest extends WorkspacesTestCase
 
         $workspacesClient = new Workspaces($this->_client);
 
-        $workspace = $workspacesClient->createWorkspace([
-            'name' => 'clone',
-        ]);
+        $workspace = $workspacesClient->createWorkspace();
 
         $runId = $this->_client->generateRunId();
         $this->_client->setRunId($runId);
@@ -142,9 +140,7 @@ class CloneIntoWorkspaceTest extends WorkspacesTestCase
         );
 
         $workspacesClient = new Workspaces($this->_client);
-        $workspace = $workspacesClient->createWorkspace([
-            'name' => 'clone',
-        ]);
+        $workspace = $workspacesClient->createWorkspace();
 
         $workspacesClient->cloneIntoWorkspace($workspace['id'], [
            'input' => [
@@ -198,9 +194,7 @@ class CloneIntoWorkspaceTest extends WorkspacesTestCase
         );
 
         $workspacesClient = new Workspaces($this->_client);
-        $workspace = $workspacesClient->createWorkspace([
-            'name' => 'cloning',
-        ]);
+        $workspace = $workspacesClient->createWorkspace();
 
         $this->expectException(Exception::class);
         $workspacesClient->cloneIntoWorkspace($workspace['id'], [
@@ -223,9 +217,7 @@ class CloneIntoWorkspaceTest extends WorkspacesTestCase
         );
 
         $workspacesClient = new Workspaces($this->_client);
-        $workspace = $workspacesClient->createWorkspace([
-            'name' => 'cloning',
-        ]);
+        $workspace = $workspacesClient->createWorkspace();
 
         // first load
         $workspacesClient->cloneIntoWorkspace($workspace['id'], [
@@ -262,9 +254,7 @@ class CloneIntoWorkspaceTest extends WorkspacesTestCase
         );
 
         $workspacesClient = new Workspaces($this->_client);
-        $workspace = $workspacesClient->createWorkspace([
-            'name' => 'cloning',
-        ]);
+        $workspace = $workspacesClient->createWorkspace();
 
         // first load
         $workspacesClient->cloneIntoWorkspace($workspace['id'], [


### PR DESCRIPTION
Jira: KBC-1464
Connection: https://github.com/keboola/connection/pull/3165

removed `name` parameter from `POST workspaces` . Theoretical BC but parameter `name` wan't documented nor used. But instead of silent accepting this useless parameter it will throw an exception that it was not expected
