### PR TITLE
Use xDebug 2 for PHP 7.1

### DIFF
--- a/docker/xdebug/Dockerfile
+++ b/docker/xdebug/Dockerfile
@@ -1,4 +1,4 @@
 FROM keboola/storage-api-tests
 
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.9.8 \
   && docker-php-ext-enable xdebug


### PR DESCRIPTION
Nejnovejsi verze xDebug je 3, ale ta podporuje jen PHP 7.2 a vyssi. Takze je potreba pouzit posledni verzi z 2.x.