### PR TITLE
Remove common subfolder in temp folder

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1415,7 +1415,7 @@ class Client
         $currentUploadDir = null;
         if ($newOptions->getCompress() && !in_array(strtolower(pathinfo($filePath, PATHINFO_EXTENSION)), array("gzip", "gz", "zip"))) {
             $fs = new Filesystem();
-            $sapiClientTempDir = sys_get_temp_dir() . '/sapi-php-client';
+            $sapiClientTempDir = sys_get_temp_dir();
             if (!$fs->exists($sapiClientTempDir)) {
                 $fs->mkdir($sapiClientTempDir);
             }
@@ -1580,7 +1580,7 @@ class Client
         $fs = null;
         $currentUploadDir = null;
         $fs = new Filesystem();
-        $sapiClientTempDir = sys_get_temp_dir() . '/sapi-php-client';
+        $sapiClientTempDir = sys_get_temp_dir();
         if (!$fs->exists($sapiClientTempDir)) {
             $fs->mkdir($sapiClientTempDir);
         }

--- a/src/Keboola/StorageApi/TableExporter.php
+++ b/src/Keboola/StorageApi/TableExporter.php
@@ -45,7 +45,7 @@ class TableExporter
         );
 
         // Temporary folder to save downloaded files
-        $workingDir = sys_get_temp_dir() . '/sapi-php-client';
+        $workingDir = sys_get_temp_dir();
         $tmpFilePath = $workingDir . '/' . uniqid('sapi-export-', true);
 
         $fs = new Filesystem();

--- a/tests/Backend/FileWorkspace/Backend/Abs.php
+++ b/tests/Backend/FileWorkspace/Backend/Abs.php
@@ -129,7 +129,7 @@ class Abs
     private function exportFile($prefix, $isCompressed, $columns, $isSliced)
     {
         $client = $this->getClient();
-        $workingDir = sys_get_temp_dir() . '/sapi-php-client';
+        $workingDir = sys_get_temp_dir();
         $tmpFilePath = $workingDir . '/' . uniqid('sapi-abs-workspace-', true);
         $destination = $workingDir . '/' . uniqid('sapi-abs-workspace-dest-', true) . '.csv';
         $fs = new Filesystem();


### PR DESCRIPTION
The subfolder causes a problem when two non-root users run the SAPI client on the same machine. Temp folder is by default writeable by all users, but if userA creates the client, the subfolder sapi-php-client is created with userA being its owner. UserB can't then use the client, because the sapi-php-client subfolder is not writeable.

Related issues:
https://keboola.atlassian.net/browse/PS-2231
https://keboola.atlassian.net/browse/PS-2307

Imho not a BC break.