### PR TITLE
PS-815 Add queue variant of createTableAsync

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -943,6 +943,17 @@ class Client
     }
 
     /**
+     * @param string $bucketId
+     * @param array $options
+     * @return int
+     */
+    public function queueTableCreate($bucketId, $options = array())
+    {
+        $job = $this->apiPost("buckets/{$bucketId}/tables-async", $options, false);
+        return $job['id'];
+    }
+
+    /**
      * @param $tableId
      * @param array $options
      * @return int

--- a/tests/Common/QueueJobsTest.php
+++ b/tests/Common/QueueJobsTest.php
@@ -51,4 +51,33 @@ class QueueJobsTest extends StorageApiTestCase
         $this->assertEquals('in.c-API-tests.table1', $job['tableId']);
         $this->assertEquals('tableExport', $job['operationName']);
     }
+
+    public function testQueueCreateTableFromFile()
+    {
+        $fileId = $this->_client->uploadFile(__DIR__ . '/../_data/languages.csv', new FileUploadOptions());
+        $jobId = $this->_client->queueTableCreate('in.c-API-tests.table1', ['dataFileId' => $fileId]);
+        $job = $this->_client->getJob($jobId);
+        $this->assertNull($job['tableId']);
+        $this->assertEquals('tableCreate', $job['operationName']);
+        $this->assertEquals($fileId, $job['operationParams']['source']['fileId']);
+        $this->assertEquals('file', $job['operationParams']['source']['type']);
+    }
+
+    public function testQueueCreateTableFromWorkspace()
+    {
+        $jobId = $this->_client->queueTableCreate(
+            'in.c-API-tests.table1',
+            [
+                'dataWorkspaceId' => 'myWorkspace',
+                'dataTableName' => 'myTable',
+            ]
+        );
+        $job = $this->_client->getJob($jobId);
+        $this->assertNull($job['tableId']);
+        $this->assertEquals('tableCreate', $job['operationName']);
+        $this->assertEquals('myWorkspace', $job['operationParams']['source']['workspaceId']);
+        $this->assertEquals('myTable', $job['operationParams']['source']['tableName']);
+        $this->assertEquals('myTable', $job['operationParams']['source']['dataObject']);
+        $this->assertEquals('workspace', $job['operationParams']['source']['type']);
+    }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-815

We need to be able to call `createTableAsync` without waiting for the job finish, similarly it's done with `writeTableAsync` and `queueTableImport`.
