### PR TITLE
Configuration rows for deleted configuration should not be listed test

### DIFF
--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -1209,6 +1209,17 @@ class BranchComponentTest extends StorageApiTestCase
         $configurations = $branchComponents->listComponentConfigurations($listConfigurationOptions);
         $this->assertCount(1, $configurations);
 
+        try {
+            $rows = $branchComponents->listConfigurationRows((new ListConfigurationRowsOptions())
+                ->setComponentId($componentId)
+                ->setConfigurationId('main-1'));
+            $this->fail('Configuration rows for deleted configuration should not be listed');
+        } catch (ClientException $e) {
+            $this->assertSame(404, $e->getCode());
+            $this->assertSame('notFound', $e->getStringCode());
+            $this->assertContains('Configuration main-1 not found', $e->getMessage());
+        }
+
         // restore dev branch configuration with create same configuration id
         $configurationOptions = (new Configuration())
             ->setComponentId($componentId)


### PR DESCRIPTION
Jira: KBC-1724

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
Main PR: https://github.com/keboola/connection/pull/3337