### PR TITLE
KBC-1931 add phpstan to sapi client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ set-env.sharing.sh
 .env
 snowflake_linux_x8664_odbc.tgz
 REVISION
+/cache

--- a/composer.json
+++ b/composer.json
@@ -33,17 +33,17 @@
 		"keboola/php-csv-db-import": "^2.2",
 		"ext-pdo_pgsql": "*",
 		"phpcompatibility/php-compatibility": "*",
-		"phpstan/phpstan-shim": "^0.9.2",
 		"keboola/table-backend-utils": "^0.16",
 		"brianium/paratest": "2.*",
 		"ext-pdo": "*",
-		"keboola/retry": "^0.5.0"
+		"keboola/retry": "^0.5.0",
+		"phpstan/phpstan": "^1.0"
     },
 	"scripts": {
 		"phpcs": "phpcs -n .",
 		"phpcs-compatibility": "phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility && phpcs --ignore=*vendor/* -n . --standard=PHPCompatibility --runtime-set testVersion 5.6-7.4",
 		"phpcbf": "phpcbf -n .",
-		"phpstan": "phpstan analyse --no-progress --level=1 . -c phpstan.neon",
+		"phpstan": "phpstan analyse --no-progress --level=max . -c phpstan.neon",
 		"ci": [
 			"@phpcs",
 			"@phpcs-compatibility",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,13462 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Cannot call method resolve\\(\\) on GuzzleHttp\\\\Promise\\\\Promise\\|null\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ABSUploader\\:\\:uploadByBlocks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ABSUploader\\:\\:uploadByBlocks\\(\\) has parameter \\$blobName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ABSUploader\\:\\:uploadByBlocks\\(\\) has parameter \\$container with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ABSUploader\\:\\:uploadByBlocks\\(\\) has parameter \\$file with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ABSUploader\\:\\:uploadFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ABSUploader\\:\\:uploadSlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$s3Client$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Parameter \\#3 \\$content of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:createBlockBlob\\(\\) expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|resource\\|string, resource\\|false given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Parameter \\#4 \\$options of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:commitBlobBlocks\\(\\) expects MicrosoftAzure\\\\Storage\\\\Blob\\\\Models\\\\CommitBlobBlocksOptions\\|null, MicrosoftAzure\\\\Storage\\\\Blob\\\\Models\\\\CommitBlobBlocksOptions\\|MicrosoftAzure\\\\Storage\\\\Blob\\\\Models\\\\CreateBlockBlobOptions given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Parameter \\#4 \\$options of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:createBlockBlob\\(\\) expects MicrosoftAzure\\\\Storage\\\\Blob\\\\Models\\\\CreateBlockBlobOptions\\|null, MicrosoftAzure\\\\Storage\\\\Blob\\\\Models\\\\CommitBlobBlocksOptions\\|MicrosoftAzure\\\\Storage\\\\Blob\\\\Models\\\\CreateBlockBlobOptions\\|null given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ABSUploader\\\\PromiseHelper\\:\\:all\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader/PromiseHelper.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ABSUploader\\\\PromiseHelper\\:\\:throwException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader/PromiseHelper.php
+
+		-
+			message: "#^Parameter \\#2 \\$code of class Keboola\\\\StorageApi\\\\ClientException constructor expects int\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ABSUploader/PromiseHelper.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\BranchAwareClient\\:\\:__construct\\(\\) has parameter \\$branchId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareClient.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\BranchAwareClient\\:\\:request\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareClient.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\BranchAwareClient\\:\\:request\\(\\) has parameter \\$handleAsyncTask with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareClient.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\BranchAwareClient\\:\\:request\\(\\) has parameter \\$method with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareClient.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\BranchAwareClient\\:\\:request\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareClient.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\BranchAwareClient\\:\\:request\\(\\) has parameter \\$responseFileName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareClient.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\BranchAwareClient\\:\\:request\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareClient.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\BranchAwareClient\\:\\:\\$branchId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareClient.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\BranchAwareGuzzleClient\\:\\:__construct\\(\\) has parameter \\$branchId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareGuzzleClient.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\BranchAwareGuzzleClient\\:\\:\\$branchId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/BranchAwareGuzzleClient.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Cannot access offset 'code' on mixed\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Cannot access offset 'entries' on mixed\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Cannot access offset 'error' on mixed\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 18
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Cannot access offset 'reason' on mixed\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Cannot access offset 'sharing' on mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Cannot access offset 'url' on mixed\\.$#"
+			count: 4
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:addFileTag\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:addFileTag\\(\\) has parameter \\$fileId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:addFileTag\\(\\) has parameter \\$tagName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:addTableColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:addTableColumn\\(\\) has parameter \\$definition with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiDeleteParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiDeleteParams\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiDeleteParams\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiGet\\(\\) has parameter \\$fileName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiPost\\(\\) has parameter \\$handleAsyncTask with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiPostJson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiPostJson\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiPostJson\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiPostMultipart\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiPostMultipart\\(\\) has parameter \\$handleAsyncTask with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiPostMultipart\\(\\) has parameter \\$postData with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:apiPostMultipart\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:changeBucketSharing\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:changeBucketSharing\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:changeBucketSharing\\(\\) has parameter \\$sharing with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) has parameter \\$sourceTableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createBucket\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createBucket\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createBucket\\(\\) should return string but returns string\\|true\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createEvent\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTable\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTable\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTable\\(\\) should return string but returns string\\|true\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableAsync\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableAsync\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableAsyncDirect\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableAsyncDirect\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableDefinition\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSnapshot\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSnapshot\\(\\) has parameter \\$snapshotId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSourceTableAtTimestamp\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSourceTableAtTimestamp\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSourceTableAtTimestamp\\(\\) has parameter \\$sourceTableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSourceTableAtTimestamp\\(\\) has parameter \\$timestamp with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTablePrimaryKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableSnapshot\\(\\) has parameter \\$snapshotDescription with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableSnapshot\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTableSnapshot\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTrigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:createTrigger\\(\\) has parameter \\$option with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteFile\\(\\) has parameter \\$fileId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteFileTag\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteFileTag\\(\\) has parameter \\$fileId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteFileTag\\(\\) has parameter \\$tagName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteSnapshot\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteSnapshot\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteTableRows\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteTrigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:deleteTrigger\\(\\) has parameter \\$triggerId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:disableAliasTableColumnsAutoSync\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:disableAliasTableColumnsAutoSync\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadAbsFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadAbsFile\\(\\) has parameter \\$destination with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadAbsSlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadAbsSlicedFile\\(\\) has parameter \\$destinationFolder with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadFile\\(\\) has parameter \\$destination with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadFile\\(\\) has parameter \\$fileId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadS3File\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadS3File\\(\\) has parameter \\$destination with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadS3SlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadS3SlicedFile\\(\\) has parameter \\$destinationFolder with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadSlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadSlicedFile\\(\\) has parameter \\$destinationFolder with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:downloadSlicedFile\\(\\) has parameter \\$fileId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:dropToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:enableAliasTableColumnsAutoSync\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:enableAliasTableColumnsAutoSync\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:exportTableAsync\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:exportTableAsync\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:fixRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:forceUnlinkBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:forceUnlinkBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:forceUnlinkBucket\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:forceUnlinkBucket\\(\\) has parameter \\$projectId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:generateId\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:generateRunId\\(\\) should return string but returns int\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getBucket\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getEvent\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getEvent\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getFile\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getJob\\(\\) has parameter \\$jobId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getJob\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getKeenReadCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getRunId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getSnapshot\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getSnapshot\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getTable\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getTableDataPreview\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getTrigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getTrigger\\(\\) has parameter \\$triggerId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:handleJobError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:indexAction\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:initClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:isSharedBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:isSharedBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listBucketEvents\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listBuckets\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listBuckets\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listEvents\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listFiles\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listJobs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listJobs\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listSharedBuckets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listSharedBuckets\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listTableEvents\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listTableEvents\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listTableSnapshots\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listTableSnapshots\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listTables\\(\\) should return array but returns mixed\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listTokenEvents\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listTriggers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:listTriggers\\(\\) has parameter \\$filter with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:log\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:prepareExportOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:prepareFileUpload\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:prepareMultipartData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:prepareMultipartData\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:queueTableCreate\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:queueTableExport\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:queueTableExport\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:queueTableExport\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:queueTableImport\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:queueTableImport\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:removeAliasTableFilter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:removeAliasTableFilter\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:removeTablePrimaryKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:removeTablePrimaryKey\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:replaceBucketAttributes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:replaceBucketAttributes\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:replaceTableAttributes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:replaceTableAttributes\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:request\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:request\\(\\) has parameter \\$handleAsyncTask with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:request\\(\\) has parameter \\$method with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:request\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:request\\(\\) has parameter \\$responseFileName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:request\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:searchComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:searchTables\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setAliasTableFilter\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setBucketAttribute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setBucketAttribute\\(\\) has parameter \\$protected with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setJobPollRetryDelay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setLogger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setRunId\\(\\) has parameter \\$runId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setTableAttribute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setTableAttribute\\(\\) has parameter \\$protected with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:setTimeout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucket\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucketToProjects\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucketToProjects\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucketToProjects\\(\\) has parameter \\$targetProjectIds with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucketToUsers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucketToUsers\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareBucketToUsers\\(\\) has parameter \\$targetUsers with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareOrganizationBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareOrganizationBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareOrganizationProjectBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareOrganizationProjectBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareToken\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareToken\\(\\) has parameter \\$recipientEmail with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:shareToken\\(\\) has parameter \\$tokenId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:unshareBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:unshareBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:updateBucket\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:updateTable\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:updateTrigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:updateTrigger\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:updateTrigger\\(\\) has parameter \\$triggerId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:uploadFile\\(\\) has parameter \\$filePath with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:uploadFileToAbs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:uploadFileToS3\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:uploadSlicedFileToAbs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:uploadSlicedFileToS3\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:waitForJob\\(\\) has parameter \\$jobId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:webalizeDisplayName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:webalizeDisplayName\\(\\) has parameter \\$displayName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:writeTable\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:writeTableAsync\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:writeTableAsyncDirect\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:writeTableAsyncDirect\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:writeTableOptionsPrepare\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:writeTableOptionsPrepare\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Offset 'results' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketId destination bucket\\)\\: Unexpected token \"\\$bucketId\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketId string destination bucket\\)\\: Unexpected token \"\\$bucketId\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketId\\)\\: Unexpected token \"\\$bucketId\", expected type at offset 18$#"
+			count: 3
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketId\\)\\: Unexpected token \"\\$bucketId\", expected type at offset 37$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketId\\)\\: Unexpected token \"\\$bucketId\", expected type at offset 437$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketId\\)\\: Unexpected token \"\\$bucketId\", expected type at offset 80$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketId\\)\\: Unexpected token \"\\$bucketId\", expected type at offset 88$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$fileId\\)\\: Unexpected token \"\\$fileId\", expected type at offset 41$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$fileId\\)\\: Unexpected token \"\\$fileId\", expected type at offset 46$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$filePath\\)\\: Unexpected token \"\\$filePath\", expected type at offset 62$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$id\\)\\: Unexpected token \"\\$id\", expected type at offset 18$#"
+			count: 3
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$jobId\\)\\: Unexpected token \"\\$jobId\", expected type at offset 18$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$message\\)\\: Unexpected token \"\\$message\", expected type at offset 71$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$name string table name\\)\\: Unexpected token \"\\$name\", expected type at offset 191$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$name\\)\\: Unexpected token \"\\$name\", expected type at offset 42$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$name\\)\\: Unexpected token \"\\$name\", expected type at offset 461$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$options\\)\\: Unexpected token \"\\$options\", expected type at offset 41$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$recipientEmail\\)\\: Unexpected token \"\\$recipientEmail\", expected type at offset 41$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$runId\\)\\: Unexpected token \"\\$runId\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$snapshotId source snapshot\\)\\: Unexpected token \"\\$snapshotId\", expected type at offset 61$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$sourceTableId string source snapshot\\)\\: Unexpected token \"\\$sourceTableId\", expected type at offset 68$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$sourceTableId\\)\\: Unexpected token \"\\$sourceTableId\", expected type at offset 42$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tableId\\)\\: Unexpected token \"\\$tableId\", expected type at offset 18$#"
+			count: 10
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tableId\\)\\: Unexpected token \"\\$tableId\", expected type at offset 185$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tableId\\)\\: Unexpected token \"\\$tableId\", expected type at offset 273$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tableId\\)\\: Unexpected token \"\\$tableId\", expected type at offset 37$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tableId\\)\\: Unexpected token \"\\$tableId\", expected type at offset 57$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tableId\\)\\: Unexpected token \"\\$tableId\", expected type at offset 89$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tagName\\)\\: Unexpected token \"\\$tagName\", expected type at offset 63$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$timestamp string timestamp to use for table replication\\)\\: Unexpected token \"\\$timestamp\", expected type at offset 120$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tokenId\\)\\: Unexpected token \"\\$tokenId\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(bool null \\$protected\\)\\: Unexpected token \"null\", expected variable at offset 169$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(bool null \\$protected\\)\\: Unexpected token \"null\", expected variable at offset 171$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(string null \\$fileName\\)\\: Unexpected token \"null\", expected variable at offset 107$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function fopen expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fgetcsv expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function rewind expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$function of function call_user_func expects callable\\(\\)\\: mixed, \\(callable\\(\\)\\: mixed\\)\\|null given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:dropToken\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:getToken\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:refreshToken\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$job of method Keboola\\\\StorageApi\\\\Client\\:\\:handleJobError\\(\\) expects array, array\\|null given\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$jobCreatedResponse of method Keboola\\\\StorageApi\\\\Client\\:\\:handleAsyncTask\\(\\) expects GuzzleHttp\\\\Psr7\\\\Response, Psr\\\\Http\\\\Message\\\\ResponseInterface given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function GuzzleHttp\\\\json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function GuzzleHttp\\\\json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$message of class Keboola\\\\StorageApi\\\\ClientException constructor expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, mixed given\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$seconds of function sleep expects int, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function strtr expects string, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#2 \\$code of class Keboola\\\\StorageApi\\\\ClientException constructor expects int\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#2 \\$length of function fgetcsv expects int\\<0, max\\>, null given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#3 \\$content of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:createBlockBlob\\(\\) expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|resource\\|string, string\\|false given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Parameter \\#4 \\$stringCode of class Keboola\\\\StorageApi\\\\ClientException constructor expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Part \\$result\\[\"id\"\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 3
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Part \\$result\\['id'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Part \\$tokenId \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Client\\:\\:\\$apiUrl has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Client\\:\\:\\$awsDebug has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Client\\:\\:\\$awsRetries has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Client\\:\\:\\$backoffMaxTries has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Client\\:\\:\\$runId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Client\\:\\:\\$token has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Client\\:\\:\\$userAgent has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Client.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:addConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:addConfigurationMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:addConfigurationRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationFromVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationFromVersion\\(\\) has parameter \\$changeDescription with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationFromVersion\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationFromVersion\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationFromVersion\\(\\) has parameter \\$description with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationFromVersion\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationFromVersion\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationRowFromVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationRowFromVersion\\(\\) has parameter \\$changeDescription with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationRowFromVersion\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationRowFromVersion\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationRowFromVersion\\(\\) has parameter \\$rowId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationRowFromVersion\\(\\) has parameter \\$targetConfigurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationRowFromVersion\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationWorkspace\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:createConfigurationWorkspace\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfiguration\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfiguration\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationMetadata\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationMetadata\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationMetadata\\(\\) has parameter \\$metadataId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationRow\\(\\) has parameter \\$changeDescription with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationRow\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationRow\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:deleteConfigurationRow\\(\\) has parameter \\$rowId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getComponent\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfiguration\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfiguration\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRow\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRow\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRow\\(\\) has parameter \\$rowId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRowVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRowVersion\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRowVersion\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRowVersion\\(\\) has parameter \\$rowId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationRowVersion\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationVersion\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationVersion\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:getConfigurationVersion\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:listComponentConfigurations\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:listComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:listConfigurationMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:listConfigurationRowVersions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:listConfigurationRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:listConfigurationVersions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:listConfigurationWorkspaces\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:resetToDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:resetToDefault\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:resetToDefault\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:restoreComponentConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:restoreComponentConfiguration\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:restoreComponentConfiguration\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfiguration\\(\\) has parameter \\$changeDescription with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfiguration\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfiguration\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfiguration\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfigurationRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfigurationRow\\(\\) has parameter \\$changeDescription with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfigurationRow\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfigurationRow\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfigurationRow\\(\\) has parameter \\$rowId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:rollbackConfigurationRow\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:updateConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:updateConfigurationRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:updateConfigurationRowState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Components\\:\\:updateConfigurationState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 6
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 6
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Parameter \\#4 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 3
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Part \\$options\\-\\>getComponentId\\(\\) \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 7
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Part \\$options\\-\\>getConfigurationId\\(\\) \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 5
+			path: src/Keboola/StorageApi/Components.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DevBranches\\:\\:createBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DevBranches.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DevBranches\\:\\:deleteBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DevBranches.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DevBranches\\:\\:getBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DevBranches.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DevBranches\\:\\:listBranches\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DevBranches.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DevBranches\\:\\:updateBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DevBranches.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DevBranches\\:\\:updateBranch\\(\\) has parameter \\$branchId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DevBranches.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:createCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:createCredentials\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:deleteCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:deleteCredentials\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:disableForBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:disableForBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:enableForBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:enableForBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:getCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:getCredentials\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:resetPassword\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\DirectAccess\\:\\:resetPassword\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/DirectAccess.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:getComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:getDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:getDuration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:getMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:getParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:getResults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:getRunId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:getType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setComponent\\(\\) has parameter \\$component with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setComponentName\\(\\) has parameter \\$componentName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setComponentType\\(\\) has parameter \\$componentType with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setConfigurationId\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setDescription\\(\\) has parameter \\$description with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setDuration\\(\\) has parameter \\$duration with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setMessage\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setRunId\\(\\) has parameter \\$runId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Event\\:\\:setType\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$component\\)\\: Unexpected token \"\\$component\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$componentName\\)\\: Unexpected token \"\\$componentName\", expected type at offset 37$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$componentType\\)\\: Unexpected token \"\\$componentType\", expected type at offset 37$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$configurationId\\)\\: Unexpected token \"\\$configurationId\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$description\\)\\: Unexpected token \"\\$description\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$duration\\)\\: Unexpected token \"\\$duration\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$message\\)\\: Unexpected token \"\\$message\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$results\\)\\: Unexpected token \"\\$results\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$runId\\)\\: Unexpected token \"\\$runId\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$type\\)\\: Unexpected token \"\\$type\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 18$#"
+			count: 2
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 15$#"
+			count: 3
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 48$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Event\\:\\:\\$component has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Event\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Event\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Event\\:\\:\\$runId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Event.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Exception\\:\\:getContextParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Exception\\:\\:getStringCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Exception\\:\\:setStringCode\\(\\) has parameter \\$stringCode with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$stringCode\\)\\: Unexpected token \"\\$stringCode\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^Parameter \\#1 \\$contextParams of method Keboola\\\\StorageApi\\\\Exception\\:\\:setContextParams\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^Parameter \\#1 \\$message of method Exception\\:\\:__construct\\(\\) expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Exception\\:\\:\\$contextParams has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Exception\\:\\:\\$previous is never read, only written\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Exception\\:\\:\\$stringCode has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Exception.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/HandlerStack.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:create\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/HandlerStack.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:createDefaultDecider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/HandlerStack.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:createDefaultDecider\\(\\) has parameter \\$maxRetries with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/HandlerStack.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:createExponentialDelay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/HandlerStack.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\MaintenanceException\\:\\:__construct\\(\\) has parameter \\$reason with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/MaintenanceException.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\MaintenanceException\\:\\:__construct\\(\\) has parameter \\$retryAfter with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/MaintenanceException.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:deleteBucketMetadata\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:deleteBucketMetadata\\(\\) has parameter \\$metadataId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:deleteColumnMetadata\\(\\) has parameter \\$columnId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:deleteColumnMetadata\\(\\) has parameter \\$metadataId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:deleteTableMetadata\\(\\) has parameter \\$metadataId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:deleteTableMetadata\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:listBucketMetadata\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:listColumnMetadata\\(\\) has parameter \\$columnId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:listTableMetadata\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:postBucketMetadata\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:postBucketMetadata\\(\\) has parameter \\$provider with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:postColumnMetadata\\(\\) has parameter \\$columnId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:postColumnMetadata\\(\\) has parameter \\$provider with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:postTableMetadata\\(\\) has parameter \\$provider with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Metadata\\:\\:postTableMetadata\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketId\\)\\: Unexpected token \"\\$bucketId\", expected type at offset 18$#"
+			count: 3
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$columnId  \\-\\- ex\\: \"in\\.c\\-bucket\\.table\\.column\"\\)\\: Unexpected token \"\\$columnId\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$columnId\\)\\: Unexpected token \"\\$columnId\", expected type at offset 18$#"
+			count: 2
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$metadataId\\)\\: Unexpected token \"\\$metadataId\", expected type at offset 41$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$metadataId\\)\\: Unexpected token \"\\$metadataId\", expected type at offset 42$#"
+			count: 2
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$provider\\)\\: Unexpected token \"\\$provider\", expected type at offset 41$#"
+			count: 1
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$provider\\)\\: Unexpected token \"\\$provider\", expected type at offset 42$#"
+			count: 2
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tableId\\)\\: Unexpected token \"\\$tableId\", expected type at offset 18$#"
+			count: 3
+			path: src/Keboola/StorageApi/Metadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\BucketUpdateOptions\\:\\:__construct\\(\\) has parameter \\$async with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/BucketUpdateOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\BucketUpdateOptions\\:\\:__construct\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/BucketUpdateOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\BucketUpdateOptions\\:\\:__construct\\(\\) has parameter \\$displayName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/BucketUpdateOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:setChangeDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:setComponentId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:setConfiguration\\(\\) has parameter \\$configuration with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:setConfigurationId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:setDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:setName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:setState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$configuration\\)\\: Unexpected token \"\\$configuration\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:\\$changeDescription has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:\\$configuration has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:\\$name has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:\\$rowsSortOrder has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\Configuration\\:\\:\\$state has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/Configuration.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationMetadata\\:\\:setMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationMetadata.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:setChangeDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:setConfiguration\\(\\) has parameter \\$configuration with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$configuration\\)\\: Unexpected token \"\\$configuration\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:\\$changeDescription has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:\\$configuration has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:\\$isDisabled has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:\\$name has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:\\$rowId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRow\\:\\:\\$state has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRow.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRowState\\:\\:\\$rowId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRowState.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationRowState\\:\\:\\$state has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationRowState.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationState\\:\\:setComponentId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationState.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationState\\:\\:setConfigurationId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationState.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationState\\:\\:setState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationState.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationState\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationState.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationState\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationState.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ConfigurationState\\:\\:\\$state has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ConfigurationState.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentConfigurationsOptions\\:\\:toParamsArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentConfigurationsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentConfigurationsOptions\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentConfigurationsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentConfigurationsOptions\\:\\:\\$isDeleted has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentConfigurationsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentsOptions\\:\\:getInclude\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentsOptions\\:\\:setComponentType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentsOptions\\:\\:toParamsArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentsOptions\\:\\:\\$componentType has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentsOptions\\:\\:\\$include has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListComponentsOptions\\:\\:\\$isDeleted has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListComponentsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationMetadataOptions\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationMetadataOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationMetadataOptions\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationMetadataOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowVersionsOptions\\:\\:getInclude\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowVersionsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowVersionsOptions\\:\\:toParamsArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowVersionsOptions\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowVersionsOptions\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowVersionsOptions\\:\\:\\$include has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowVersionsOptions\\:\\:\\$limit has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowVersionsOptions\\:\\:\\$offset has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowVersionsOptions\\:\\:\\$rowId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowsOptions\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationRowsOptions\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationRowsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationVersionsOptions\\:\\:getInclude\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationVersionsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationVersionsOptions\\:\\:toParamsArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationVersionsOptions\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationVersionsOptions\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationVersionsOptions\\:\\:\\$include has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationVersionsOptions\\:\\:\\$limit has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationVersionsOptions\\:\\:\\$offset has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationVersionsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationWorkspacesOptions\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationWorkspacesOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\ListConfigurationWorkspacesOptions\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/ListConfigurationWorkspacesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\SearchComponentConfigurationsOptions\\:\\:setInclude\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/SearchComponentConfigurationsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\SearchComponentConfigurationsOptions\\:\\:setMetadataKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/SearchComponentConfigurationsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\Components\\\\SearchComponentConfigurationsOptions\\:\\:toParamsArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/SearchComponentConfigurationsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\SearchComponentConfigurationsOptions\\:\\:\\$componentId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/SearchComponentConfigurationsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\SearchComponentConfigurationsOptions\\:\\:\\$configurationId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/SearchComponentConfigurationsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\SearchComponentConfigurationsOptions\\:\\:\\$include has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/SearchComponentConfigurationsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\Components\\\\SearchComponentConfigurationsOptions\\:\\:\\$metadataKeys has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/Components/SearchComponentConfigurationsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setCompress\\(\\) has parameter \\$compress with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setFederationToken\\(\\) has parameter \\$federationToken with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setFileName\\(\\) has parameter \\$fileName with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setIsEncrypted\\(\\) has parameter \\$encrypted with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setIsPermanent\\(\\) has parameter \\$permanent with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setIsPublic\\(\\) has parameter \\$isPublic with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setIsSliced\\(\\) has parameter \\$isSliced with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setNotify\\(\\) has parameter \\$notify with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:setSizeBytes\\(\\) has parameter \\$sizeBytes with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$compress\\)\\: Unexpected token \"\\$compress\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$encrypted\\)\\: Unexpected token \"\\$encrypted\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$federationToken\\)\\: Unexpected token \"\\$federationToken\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$fileName\\)\\: Unexpected token \"\\$fileName\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$isPublic\\)\\: Unexpected token \"\\$isPublic\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$isSliced\\)\\: Unexpected token \"\\$isSliced\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$notify\\)\\: Unexpected token \"\\$notify\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$permanent\\)\\: Unexpected token \"\\$permanent\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$sizeBytes\\)\\: Unexpected token \"\\$sizeBytes\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$compress has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$federationToken has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$fileName has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$isEncrypted has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$isPermanent has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$isPublic has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$isSliced has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$notify has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$sizeBytes has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\FileUploadOptions\\:\\:\\$tags has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadTransferOptions\\:\\:setChunkSize\\(\\) has parameter \\$chunkSize with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadTransferOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\FileUploadTransferOptions\\:\\:setMaxRetriesPerChunk\\(\\) has parameter \\$maxRetriesPerChunk with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadTransferOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$chunkSize\\)\\: Unexpected token \"\\$chunkSize\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadTransferOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$maxRetriesPerChunk\\)\\: Unexpected token \"\\$maxRetriesPerChunk\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/FileUploadTransferOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\GetFileOptions\\:\\:setFederationToken\\(\\) has parameter \\$federationToken with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/GetFileOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$federationToken\\)\\: Unexpected token \"\\$federationToken\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/GetFileOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\IndexOptions\\:\\:setExclude\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/IndexOptions.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:setLimit\\(\\) has parameter \\$limit with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:setMaxId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:setOffset\\(\\) has parameter \\$offset with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:setQuery\\(\\) has parameter \\$query with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:setRunId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:setSinceId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:toArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$limit\\)\\: Unexpected token \"\\$limit\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$offset\\)\\: Unexpected token \"\\$offset\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$query\\)\\: Unexpected token \"\\$query\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:\\$limit has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:\\$maxId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:\\$offset has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:\\$query has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:\\$runId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:\\$sinceId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\ListFilesOptions\\:\\:\\$tags has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/ListFilesOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\StatsOptions\\:\\:setRunId\\(\\) has parameter \\$runId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/StatsOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\StatsOptions\\:\\:toArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/StatsOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$runId\\)\\: Unexpected token \"\\$runId\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/StatsOptions.php
+
+		-
+			message: "#^Property Keboola\\\\StorageApi\\\\Options\\\\StatsOptions\\:\\:\\$runId has no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/StatsOptions.php
+
+		-
+			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/TokenAbstractOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\TokenCreateOptions\\:\\:setExpiresIn\\(\\) has parameter \\$seconds with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/TokenCreateOptions.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$seconds\\)\\: Unexpected token \"\\$seconds\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/TokenCreateOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Options\\\\TokenUpdateOptions\\:\\:__construct\\(\\) has parameter \\$tokenId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Options/TokenUpdateOptions.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\ProcessPolyfill\\:\\:createProcess\\(\\) should return Symfony\\\\Component\\\\Process\\\\Process but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/ProcessPolyfill.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:putFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:putFile\\(\\) has parameter \\$acl with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:putFile\\(\\) has parameter \\$bucket with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:putFile\\(\\) has parameter \\$filePath with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:putFile\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:upload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:upload\\(\\) has parameter \\$acl with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:upload\\(\\) has parameter \\$bucket with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadFile\\(\\) has parameter \\$acl with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadFile\\(\\) has parameter \\$bucket with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadFile\\(\\) has parameter \\$file with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadFile\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadFile\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadSlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadSlicedFile\\(\\) has parameter \\$acl with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadSlicedFile\\(\\) has parameter \\$bucket with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadSlicedFile\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:uploadSlicedFile\\(\\) has parameter \\$slices with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$acl\\)\\: Unexpected token \"\\$acl\", expected type at offset 40$#"
+			count: 2
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$acl\\)\\: Unexpected token \"\\$acl\", expected type at offset 59$#"
+			count: 2
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucket\\)\\: Unexpected token \"\\$bucket\", expected type at offset 18$#"
+			count: 4
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$file\\)\\: Unexpected token \"\\$file\", expected type at offset 78$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$filePath\\)\\: Unexpected token \"\\$filePath\", expected type at offset 78$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$key\\)\\: Unexpected token \"\\$key\", expected type at offset 40$#"
+			count: 2
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$key\\)\\: Unexpected token \"\\$key\", expected type at offset 59$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$name\\)\\: Unexpected token \"\\$name\", expected type at offset 98$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$slices\\)\\: Unexpected token \"\\$slices\", expected type at offset 78$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Parameter \\#3 \\$key of method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:multipartUploaderFactory\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Parameter \\#7 \\$name of method Keboola\\\\StorageApi\\\\S3Uploader\\:\\:multipartUploaderFactory\\(\\) expects null, string given\\.$#"
+			count: 2
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Ternary operator condition is always false\\.$#"
+			count: 5
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Variable \\$encryption in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Variable \\$name in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\S3Uploader\\\\PromiseResultHandler\\:\\:getRejected\\(\\) has parameter \\$results with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader/PromiseResultHandler.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$results\\)\\: Unexpected token \"\\$results\", expected type at offset 18$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader/PromiseResultHandler.php
+
+		-
+			message: "#^Variable \\$reason in PHPDoc tag @var does not exist\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/S3Uploader/PromiseResultHandler.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Cannot access offset 'entries' on mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:exportTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:exportTable\\(\\) has parameter \\$destination with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:exportTable\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:exportTable\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:handleExportedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:handleExportedFile\\(\\) has parameter \\$destination with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:handleExportedFile\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:handleExportedFile\\(\\) has parameter \\$fileId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:handleExportedFile\\(\\) has parameter \\$gzipOutput with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\TableExporter\\:\\:handleExportedFile\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$destination\\)\\: Unexpected token \"\\$destination\", expected type at offset 112$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$exportOptions\\)\\: Unexpected token \"\\$exportOptions\", expected type at offset 139$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$tableId\\)\\: Unexpected token \"\\$tableId\", expected type at offset 89$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Parameter \\#2 \\$entry of method Keboola\\\\StorageApi\\\\Downloader\\\\DownloaderInterface\\:\\:downloadManifestEntry\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/TableExporter.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Tokens\\:\\:createToken\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Tokens.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Tokens\\:\\:dropToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Tokens.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Tokens\\:\\:getToken\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Tokens.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Tokens\\:\\:listTokens\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Tokens.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Tokens\\:\\:refreshToken\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Tokens.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Tokens\\:\\:shareToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Tokens.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Tokens\\:\\:updateToken\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Tokens.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:cloneIntoWorkspace\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:createWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:deleteWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:deleteWorkspace\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:getWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:getWorkspace\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:listWorkspaces\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:loadWorkspaceData\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:resetWorkspacePassword\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Workspaces\\:\\:resetWorkspacePassword\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$id\\)\\: Unexpected token \"\\$id\", expected type at offset 18$#"
+			count: 2
+			path: src/Keboola/StorageApi/Workspaces.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:invalidColumnNameProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testAddColumnWithInvalidNameShouldThrowError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testAddInvalidPrimaryKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testEmptyPrimaryKeyDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testPrimaryKeyAddRequiredParam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testPrimaryKeyAddWithDuplicty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testPrimaryKeyAddWithSameColumnsInDifferentBuckets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testPrimaryKeyDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testTableColumnAdd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testTableColumnDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testTableColumnNameShouldBeWebalized\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testTableColumnNameShouldBeWebalized\\(\\) has parameter \\$expectedColumnName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testTableColumnNameShouldBeWebalized\\(\\) has parameter \\$requestedColumnName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testTableExistingColumnAdd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testTablePkColumnDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testTooManyColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:testsTableExistingColumnAddWithDifferentCaseShouldThrowError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\AlterTableTest\\:\\:webalizeColumnNameProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedColumnName\\)\\: Unexpected token \"\\$expectedColumnName\", expected type at offset 101$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$requestedColumnName\\)\\: Unexpected token \"\\$requestedColumnName\", expected type at offset 66$#"
+			count: 1
+			path: tests/Backend/CommonPart1/AlterTableTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:clearBucketAttributes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:clearBucketAttributes\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:invalidAttributes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketAttributes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketAttributesClear\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketAttributesReplace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketAttributesReplaceValidation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketAttributesReplaceValidation\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketCreateWithInvalidBackend\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketCreateWithoutDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketDetail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketEvents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketManipulation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketsList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketsListWithIncludeMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\BucketsTest\\:\\:testBucketsListWithIncludeParameter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$attributes\\)\\: Unexpected token \"\\$attributes\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/CommonPart1/BucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:removeTablePrimaryKey\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:createTableFromSlicedFileData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:invalidPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:syncAsyncData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:tableCreateData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testCreateTableFromSlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testCreateTableFromSlicedFile\\(\\) has parameter \\$fileName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testCreateTableWithInvalidTableName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testRowNumberAmbiguity\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testSyntheticPrimaryKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableColumnNamesSanitize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableColumnNamesSanitize\\(\\) has parameter \\$async with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreate\\(\\) has parameter \\$async with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreate\\(\\) has parameter \\$createFile with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreate\\(\\) has parameter \\$expectationFile with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreate\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreate\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreateFromNotUploadedFileShouldThrowError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreateInvalidPkType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreateWithInvalidPK\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreateWithInvalidPK\\(\\) has parameter \\$primaryKey with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableCreateWithPK\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableFromEmptyFileShouldNotBeCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableWithEmptyColumnNamesShouldNotBeCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableWithLongColumnNamesShouldNotBeCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableWithLongColumnNamesShouldNotBeCreated\\(\\) has parameter \\$async with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\CreateTableTest\\:\\:testTableWithUnsupportedCharactersInNameShouldNotBeCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$async\\)\\: Unexpected token \"\\$async\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$async\\)\\: Unexpected token \"\\$async\", expected type at offset 41$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$backend\\)\\: Unexpected token \"\\$backend\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$backend\\)\\: Unexpected token \"\\$backend\", expected type at offset 58$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$createFile\\)\\: Unexpected token \"\\$createFile\", expected type at offset 55$#"
+			count: 1
+			path: tests/Backend/CommonPart1/CreateTableTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:generateCsv\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:generateCsv\\(\\) has parameter \\$collsCount with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:generateCsv\\(\\) has parameter \\$rowsCount with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:getTruncatedRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:testDataPreviewDefaultLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:testDataPreviewMaximumLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:testDataPreviewParametrizedLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:testJsonTruncationLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:testSimplePreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Offset 'columns' does not exist on array\\{string\\}\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Offset 'columns' does not exist on string\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Offset 'rows' does not exist on array\\{string\\}\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Offset 'rows' does not exist on string\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$jsonPreview of method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DataPreviewLimitsTest\\:\\:getTruncatedRow\\(\\) expects array, string given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DataPreviewLimitsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DeleteRowsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteRowsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DeleteRowsTest\\:\\:tableDeleteRowsByFiltersData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteRowsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DeleteRowsTest\\:\\:testDeleteRowsMissingValuesShouldReturnUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteRowsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DeleteRowsTest\\:\\:testTableDeleteRowsByFilter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteRowsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DeleteRowsTest\\:\\:testTableDeleteRowsByFilter\\(\\) has parameter \\$expectedTableContent with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteRowsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DeleteRowsTest\\:\\:testTableDeleteRowsByFilter\\(\\) has parameter \\$filterParams with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteRowsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedTableContent\\)\\: Unexpected token \"\\$expectedTableContent\", expected type at offset 46$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteRowsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$filterParams\\)\\: Unexpected token \"\\$filterParams\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteRowsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DeleteTableTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\DeleteTableTest\\:\\:testTableDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/DeleteTableTest.php
+
+		-
+			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testInvalidExportFormat\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportAsyncCache\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportAsyncPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportColumnsParam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportFilterShouldFailOnNonIndexedColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportFilters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportFilters\\(\\) has parameter \\$expectedResult with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportFilters\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ExportParamsTest\\:\\:testTableExportShouldFailOnNonExistingColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedResult\\)\\: Unexpected token \"\\$expectedResult\", expected type at offset 47$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$exportOptions\\)\\: Unexpected token \"\\$exportOptions\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ExportParamsTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Cannot access offset 'importedColumns' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 5
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Cannot access offset 'region' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Cannot access offset 'totalDataSizeBytes' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Cannot access offset 'transaction' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Cannot access offset 'warnings' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:incrementalImportPkDedupeData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:tableImportData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:tableImportInvalidData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testImportWithColumnsList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testImportWithoutHeaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testIncrementalImportPkDedupe\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testIncrementalImportPkDedupe\\(\\) has parameter \\$createFile with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testIncrementalImportPkDedupe\\(\\) has parameter \\$expectationFileAfterCreate with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testIncrementalImportPkDedupe\\(\\) has parameter \\$expectationFinal with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testIncrementalImportPkDedupe\\(\\) has parameter \\$incrementFile with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testIncrementalImportPkDedupe\\(\\) has parameter \\$primaryKey with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testRowsCountAndSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableAsyncExportRepeatedly\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableAsyncImportExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableAsyncImportExport\\(\\) has parameter \\$colNames with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableAsyncImportExport\\(\\) has parameter \\$createTableOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableAsyncImportExport\\(\\) has parameter \\$expectationsFileName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableAsyncImportExport\\(\\) has parameter \\$format with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableAsyncImportMissingFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportCaseSensitiveThrowsUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportColumnsCaseInsensitive\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportCreateMissingColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportExport\\(\\) has parameter \\$colNames with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportExport\\(\\) has parameter \\$createTableOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportExport\\(\\) has parameter \\$expectationsFileName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportExport\\(\\) has parameter \\$format with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportFromEmptyFileShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportFromString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportInvalidCsvParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableImportNotExistingFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableInvalidAsyncImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableInvalidImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableInvalidImport\\(\\) has parameter \\$languagesFile with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\ImportExportCommonTest\\:\\:testTableNotExistsImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$createFile\\)\\: Unexpected token \"\\$createFile\", expected type at offset 69$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectationFileAfterCreate\\)\\: Unexpected token \"\\$expectationFileAfterCreate\", expected type at offset 121$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectationFinal\\)\\: Unexpected token \"\\$expectationFinal\", expected type at offset 192$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$importFileName\\)\\: Unexpected token \"\\$importFileName\", expected type at offset 55$#"
+			count: 2
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$incrementFile\\)\\: Unexpected token \"\\$incrementFile\", expected type at offset 163$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$primaryKey\\)\\: Unexpected token \"\\$primaryKey\", expected type at offset 95$#"
+			count: 1
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_values expects array, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart1/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\LegacyIndexedColumnsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/LegacyIndexedColumnsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\LegacyIndexedColumnsTest\\:\\:testIndexApiCallsDoesNotThrowError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/LegacyIndexedColumnsTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:tableExportData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testExportTablesEmptyColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testExportTablesEmptyDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testExportTablesEmptyTableId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testExportTablesInvalidTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testExportTablesMissingDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testExportTablesMissingTableId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testExportTablesWithColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testLimitParameter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testTableAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testTableAsyncExport\\(\\) has parameter \\$expectationsFileName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:testTableAsyncExport\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$importFileName\\)\\: Unexpected token \"\\$importFileName\", expected type at offset 55$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:\\$downloadPath has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\CommonPart1\\\\TableExporterTest\\:\\:\\$downloadPathGZip has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart1/TableExporterTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 4
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\MetricsTest\\:\\:importMetricsData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\MetricsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\MetricsTest\\:\\:testAsyncImportMetrics\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\MetricsTest\\:\\:testAsyncImportMetrics\\(\\) has parameter \\$expectedMetrics with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\MetricsTest\\:\\:testTableCreateMetrics\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\MetricsTest\\:\\:testTableCreateMetrics\\(\\) has parameter \\$expectedMetrics with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\MetricsTest\\:\\:testTableExportMetrics\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Offset 'metrics' does not exist on array\\|null\\.$#"
+			count: 4
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedMetrics\\)\\: Unexpected token \"\\$expectedMetrics\", expected type at offset 88$#"
+			count: 1
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, array\\|null given\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart2/MetricsTest.php
+
+		-
+			message: "#^Cannot access offset 'aliasFilter' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Cannot access offset 'column' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Cannot access offset 'operator' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Cannot access offset 'values' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:assertAliasMetadataAndExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:assertAliasMetadataAndExport\\(\\) has parameter \\$aliasTable with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:assertAliasMetadataAndExport\\(\\) has parameter \\$expectedData with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:assertAliasMetadataAndExport\\(\\) has parameter \\$sourceTable with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasAutoSyncCannotBeChangedIfDependentAliases\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasColumnWithoutAutoSyncCanBeAdded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasColumnWithoutAutoSyncShouldBeDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasColumnsAutoSync\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasFilterCannotBeChangedIfDependentAliases\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasWithAliasesShouldBeForceDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasingAliasWithFilterShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasingAliasWithoutAutoSyncShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testAliasingBetweenInAndOutShouldBeAllowed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testColumnAssignedToAliasWithAutoSyncShouldNotBeDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testColumnAssignedToAliasWithoutAutoSyncShouldNotBeDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testColumnAssignedToAliasWithoutAutoSyncShouldNotBeForceDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testColumnNotUsedInAnyAliasShouldBeDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testColumnUsedInFilteredAliasShouldNotBeDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testColumnUsedInFilteredAliasShouldNotBeForceDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testFilterOnFilteredAlias\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testFilteredAliasWithColumnsListed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testFilteredAliases\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testFilteredAliases\\(\\) has parameter \\$expectedResult with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testFilteredAliases\\(\\) has parameter \\$filterOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testSourceTableColumnAddWithAutoSyncAliases\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testSourceTableColumnDeleteWithAutoSyncAliases\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testTableAlias\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testTableAliasFilterModifications\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testTableAliasFromDevBranchBucketCannotBeCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testTableAliasInDevBranchBucketCannotBeCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testTableAliasWithDot\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testTableWithAliasShouldBeForceDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testTableWithAliasShouldNotBeDeletableWithoutForce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SimpleAliasTest\\:\\:testTableWithAliasWithoutAutoSyncShouldBeForceDeletable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedResult\\)\\: Unexpected token \"\\$expectedResult\", expected type at offset 47$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$filterOptions\\)\\: Unexpected token \"\\$filterOptions\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 6
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 46
+			path: tests/Backend/CommonPart2/SimpleAliasTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsTest\\:\\:testInvalidFilesInManifest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsTest\\:\\:testSlicedImportGzipped\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsTest\\:\\:testSlicedImportMissingManifest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsTest\\:\\:testSlicedImportSingleFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsTest\\:\\:testUnauthorizedAccessInManifestFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$content of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:createBlockBlob\\(\\) expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|resource\\|string, resource\\|false given\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$content of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:createBlockBlob\\(\\) expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|resource\\|string, string\\|false given\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart2/SlicedImportsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsWithSlicedUploadsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsWithSlicedUploadsTest\\:\\:testSlicedFileImportWithoutColumnsShouldBeUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsWithSlicedUploadsTest\\:\\:testSlicedFileImportWithoutHeadersOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsWithSlicedUploadsTest\\:\\:testSlicedImportCompress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsWithSlicedUploadsTest\\:\\:testSlicedImportGzipped\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SlicedImportsWithSlicedUploadsTest\\:\\:testSlicedImportSingleFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SlicedImportsWithSlicedUploadsTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SnapshottingTest\\:\\:filterIdAndTimestampFromMetadataArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SnapshottingTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SnapshottingTest\\:\\:testCreateTableFromSnapshotWithDifferentName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SnapshottingTest\\:\\:testGetTableSnapshot\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SnapshottingTest\\:\\:testSnapshotPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SnapshottingTest\\:\\:testTableSnapshotCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SnapshottingTest\\:\\:testTableSnapshotDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function reset expects array\\|object, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSnapshot\\(\\) expects null, string given\\.$#"
+			count: 2
+			path: tests/Backend/CommonPart2/SnapshottingTest.php
+
+		-
+			message: "#^Cannot access offset 'importedColumns' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SystemColumnsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SystemColumnsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SystemColumnsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SystemColumnsTest\\:\\:testImportWithNewSystemColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SystemColumnsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SystemColumnsTest\\:\\:testSystemColumnAdd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SystemColumnsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SystemColumnsTest\\:\\:testSystemColumnImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SystemColumnsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\SystemColumnsTest\\:\\:testSystemColumnsConversionOnTableCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/SystemColumnsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\UploadSlicedFileTest\\:\\:testCompress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/UploadSlicedFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\CommonPart2\\\\UploadSlicedFileTest\\:\\:testNoCompress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/CommonPart2/UploadSlicedFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\ExasolImportExportCommonTest\\:\\:incrementalImportPkDedupeData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/ExasolImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\ExasolImportExportCommonTest\\:\\:testTableImportNullValuesOnPrimaryKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/ExasolImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:getExportedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:getExportedTable\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:getExportedTable\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:invalidDataProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:prepareTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testComplexSort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has parameter \\$order with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has parameter \\$order with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testInvalidStructuredQueryInADataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testInvalidStructuredQueryInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testNonArrayParamsShouldReturnErrorInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testNonArrayParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testSimpleSort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\OrderByTest\\:\\:testSortWithDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/OrderByTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 2 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 3 on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:createTableDefinition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:testAddColumnOnTypedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:testAddTypedColumnToNonTypedTableShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:testCreateSnapshotOnTypedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:testDataPreviewForTableDefinitionWithDecimalType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:testDropColumnOnTypedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:testPrimaryKeyOperationsOnTypedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:testTableWithDot\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Offset 'rows' does not exist on string\\.$#"
+			count: 4
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$actual of method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsExceptKeys\\(\\) expects array, mixed given\\.$#"
+			count: 7
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 5
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSnapshot\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Exasol\\\\TableDefinitionOperationsTest\\:\\:\\$tableId has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:prepareTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testCastToDouble\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testDataPreviewInvalidComparingOperator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testDataPreviewWithNonExistingDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testExportTableInvalidComparingOperator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testFilterWithCast\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testInvalidStructuredQueryInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testInvalidStructuredQueryInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testMultipleConditions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testNonArrayParamsShouldReturnErrorInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testNonArrayParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testSimpleWhereConditions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\WhereFilterTest\\:\\:testTableExportWithNonExistingDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\Workspace\\\\LegacyWorkspaceLoadTest\\:\\:testDottedDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/Workspace/LegacyWorkspaceLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\Workspace\\\\WorkspaceLoadTest\\:\\:testDottedDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/Workspace/WorkspaceLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Exasol\\\\Workspace\\\\WorkspacesRenameLoadTest\\:\\:testDottedDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Exasol/Workspace/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^Cannot access offset 'Key' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Export\\\\ExportParamsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Export\\\\ExportParamsTest\\:\\:testTableExportAsyncSliced\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Export\\\\ExportParamsTest\\:\\:testTableExportAsyncSliced\\(\\) has parameter \\$expectedResult with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Export\\\\ExportParamsTest\\:\\:testTableExportAsyncSliced\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedResult\\)\\: Unexpected token \"\\$expectedResult\", expected type at offset 47$#"
+			count: 1
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$exportOptions\\)\\: Unexpected token \"\\$exportOptions\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringStartsWith\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Export/ExportParamsTest.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Cannot access offset 'entries' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Cannot access offset 'url' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\Backend\\\\Abs\\:\\:uploadFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#1 \\$container of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:createBlockBlob\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#1 \\$container of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:getBlob\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#1 \\$container of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:listBlobs\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of function file_put_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#1 \\$filePath of method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\Backend\\\\Abs\\:\\:uploadFile\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, string\\|false given\\.$#"
+			count: 2
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of static method Keboola\\\\StorageApi\\\\Downloader\\\\AbsUrlParser\\:\\:parseAbsUrl\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Parameter \\#3 \\$content of method MicrosoftAzure\\\\Storage\\\\Blob\\\\BlobRestProxy\\:\\:createBlockBlob\\(\\) expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|resource\\|string, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/Backend/Abs.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\ComponentsWorkspacesTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/ComponentsWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\ComponentsWorkspacesTest\\:\\:testWorkspaceCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/ComponentsWorkspacesTest.php
+
+		-
+			message: "#^Cannot access offset 'fileStorageProvider' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/FileWorkspaceTestCase.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/FileWorkspaceTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\FileWorkspaceTestCase\\:\\:resolveFileWorkspaceBackend\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/FileWorkspaceTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:assertManifest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testDataFileIdNotFound\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testDottedDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testDuplicateDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testInvalidBucketPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testInvalidInputs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testLoadWorkspaceWithOverwrite\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testRowsParameter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testSourceTableNotFound\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has parameter \\$expectedResult with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testWorkspaceLoadAliasTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testWorkspaceLoadColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testWorkspaceLoadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:testWorkspaceLoadFilePermissionsCanReadAllFiles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesLoadTest\\:\\:workspaceExportFiltersData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedResult\\)\\: Unexpected token \"\\$expectedResult\", expected type at offset 47$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$exportOptions\\)\\: Unexpected token \"\\$exportOptions\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 4
+			path: tests/Backend/FileWorkspace/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesTest\\:\\:dropOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesTest\\:\\:testDropWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesTest\\:\\:testDropWorkspace\\(\\) has parameter \\$dropOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesTest\\:\\:testWorkspaceCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesTest\\:\\:testWorkspacePasswordReset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dropOptions\\)\\: Unexpected token \"\\$dropOptions\", expected type at offset 52$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesUnloadTest\\:\\:loadTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\FileWorkspace\\\\WorkspacesUnloadTest\\:\\:testCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/FileWorkspace/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:loadToRedshiftDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testDataTypesLoadToRedshift\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testDataTypesLoadToRedshift\\(\\) has parameter \\$dataTypesDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadIncrementalNotNullable\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadIncrementalNotNullable\\(\\) has parameter \\$bucketBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadIncrementalNullable\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadIncrementalNullable\\(\\) has parameter \\$bucketBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadUserError\\(\\) has parameter \\$dataTypesDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadUserError\\(\\) has parameter \\$sourceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadUserError\\(\\) has parameter \\$workspaceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadWorkspaceExtendedDataTypesNullify\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadWorkspaceExtendedDataTypesNullify\\(\\) has parameter \\$sourceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:testLoadWorkspaceExtendedDataTypesNullify\\(\\) has parameter \\$workspaceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:workspaceMixedAndSameBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:workspaceMixedAndSameBackendDataWithDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\LegacyWorkspacesTest\\:\\:workspaceMixedBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 3
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$backend\\)\\: Unexpected token \"\\$backend\", expected type at offset 65$#"
+			count: 2
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dataTypesDefinition\\)\\: Unexpected token \"\\$dataTypesDefinition\", expected type at offset 146$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dataTypesDefinition\\)\\: Unexpected token \"\\$dataTypesDefinition\", expected type at offset 63$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$sourceBackend\\)\\: Unexpected token \"\\$sourceBackend\", expected type at offset 104$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$sourceBackend\\)\\: Unexpected token \"\\$sourceBackend\", expected type at offset 117$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$workspaceBackend\\)\\: Unexpected token \"\\$workspaceBackend\", expected type at offset 72$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$workspaceBackend\\)\\: Unexpected token \"\\$workspaceBackend\", expected type at offset 85$#"
+			count: 1
+			path: tests/Backend/Mixed/LegacyWorkspacesTest.php
+
+		-
+			message: "#^Cannot access offset 'admin' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 9
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'isOrganizationMember' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 13
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'role' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\StorageApi\\\\Client\\:\\:getTable\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:createTestTokenOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:createTestTokenOptions\\(\\) has parameter \\$canManageBuckets with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:invalidSharingTypeData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testAdminWithShareRoleSharesBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testBucketCannotBeLinkedMoreTimes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testCloneLinkedBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testDevBranchBucketCannotBeShared\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testForcedDrop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testForcedDrop\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testInvalidSharingType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testInvalidSharingType\\(\\) has parameter \\$sharingType with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testLinkBucketDry\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testLinkBucketDry\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testLinkBucketToOrganizationDeletePermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testLinkBucketToOrganizationDeletePermissions\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testLinkedBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testLinkedBucket\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testNonOrganizationAdminInToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testOrganizationAdminInTokenVerify\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testOrganizationPublicSharing\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testRestrictedDrop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testRestrictedDrop\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testShareBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testShareBucket\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testShareBucketChangeType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testShareBucketChangeType\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testShareBucketChangeTypeOnUnsharedBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testShareBucketChangeTypeOnUnsharedBucket\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testSharedBuckets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testSharedBuckets\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testSharedBucketsWithInclude\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testSharedBucketsWithInclude\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testWorkspaceLoadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testWorkspaceLoadData\\(\\) has parameter \\$sharingBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:testWorkspaceLoadData\\(\\) has parameter \\$workspaceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:validateTablesMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:validateTablesMetadata\\(\\) has parameter \\$linkedBucketId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingTest\\:\\:validateTablesMetadata\\(\\) has parameter \\$sharedBucketId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:bucketExists\\(\\) expects string, mixed given\\.$#"
+			count: 5
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:dropBucket\\(\\) expects string, mixed given\\.$#"
+			count: 6
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:getBucket\\(\\) expects string, mixed given\\.$#"
+			count: 4
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:listTables\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Options\\\\TokenAbstractOptions\\:\\:addBucketPermission\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
+			count: 9
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, mixed given\\.$#"
+			count: 7
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 4
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$sourceProjectId of method Keboola\\\\StorageApi\\\\Client\\:\\:linkBucket\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 12
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 10
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testLinkBucketToSpecificProject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testLinkBucketToSpecificProject\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testNotAbleToLinkBucketToSpecificProject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testNotAbleToLinkBucketToSpecificProject\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testShareBucketToAnotherOrganizationProject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testShareBucketToAnotherOrganizationProject\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testShareBucketToProject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testShareBucketToProject\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testShareOrganizationBucketChangeType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testShareOrganizationBucketChangeType\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testUpdateShareBucketToProject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificProjectsTest\\:\\:testUpdateShareBucketToProject\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:getBucket\\(\\) expects string, mixed given\\.$#"
+			count: 4
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$sourceProjectId of method Keboola\\\\StorageApi\\\\Client\\:\\:linkBucket\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificProjectsTest.php
+
+		-
+			message: "#^Cannot access offset 'admin' on mixed\\.$#"
+			count: 16
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 5
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 15
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 4
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testLinkBucketToSpecificUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testLinkBucketToSpecificUser\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testNotAbleToLinkBucketToSpecificUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testNotAbleToLinkBucketToSpecificUser\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testShareBucketToAnotherOrganizationUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testShareBucketToAnotherOrganizationUser\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testShareBucketToUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testShareBucketToUser\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testShareBucketToUserByEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testShareBucketToUserByEmail\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testShareOrganizationBucketChangeType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testShareOrganizationBucketChangeType\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testUpdateShareBucketToUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\SharingToSpecificUsersTest\\:\\:testUpdateShareBucketToUser\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:getBucket\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$sourceProjectId of method Keboola\\\\StorageApi\\\\Client\\:\\:linkBucket\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/SharingToSpecificUsersTest.php
+
+		-
+			message: "#^Cannot access offset 'admin' on mixed\\.$#"
+			count: 4
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 10
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Cannot access offset 'organization' on mixed\\.$#"
+			count: 6
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\StorageApiSharingTestCase\\:\\:deleteAllWorkspaces\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\StorageApiSharingTestCase\\:\\:initEmptyBucketForSharingTest\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\StorageApiSharingTestCase\\:\\:initEmptyBucketForSharingTest\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\StorageApiSharingTestCase\\:\\:initEmptyBucketForSharingTest\\(\\) has parameter \\$stage with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\StorageApiSharingTestCase\\:\\:initTestBuckets\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\StorageApiSharingTestCase\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\StorageApiSharingTestCase\\:\\:sharingBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\StorageApiSharingTestCase\\:\\:workspaceMixedBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$backend\\)\\: Unexpected token \"\\$backend\", expected type at offset 135$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$name\\)\\: Unexpected token \"\\$name\", expected type at offset 62$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$stage\\)\\: Unexpected token \"\\$stage\", expected type at offset 82$#"
+			count: 1
+			path: tests/Backend/Mixed/StorageApiSharingTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\AbsWorkspacesTest\\:\\:workspaceBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/AbsWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\AbsWorkspacesTest\\:\\:workspaceMixedAndSameBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/AbsWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\AbsWorkspacesTest\\:\\:workspaceMixedAndSameBackendDataWithDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/AbsWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testCreateWorkspaceParam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testCreateWorkspaceParam\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testCreateWorkspaceParam\\(\\) has parameter \\$dataTypesDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testLoadUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testLoadUserError\\(\\) has parameter \\$columnsDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testLoadUserError\\(\\) has parameter \\$sourceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testLoadUserError\\(\\) has parameter \\$workspaceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testLoadWorkspaceExtendedDataTypesNullify\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testLoadWorkspaceExtendedDataTypesNullify\\(\\) has parameter \\$sourceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:testLoadWorkspaceExtendedDataTypesNullify\\(\\) has parameter \\$workspaceBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:workspaceBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:workspaceMixedAndSameBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\BaseWorkSpacesTestCase\\:\\:workspaceMixedAndSameBackendDataWithDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$backend\\)\\: Unexpected token \"\\$backend\", expected type at offset 61$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$columnsDefinition\\)\\: Unexpected token \"\\$columnsDefinition\", expected type at offset 146$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dataTypesDefinition\\)\\: Unexpected token \"\\$dataTypesDefinition\", expected type at offset 84$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$sourceBackend\\)\\: Unexpected token \"\\$sourceBackend\", expected type at offset 104$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$sourceBackend\\)\\: Unexpected token \"\\$sourceBackend\", expected type at offset 117$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$workspaceBackend\\)\\: Unexpected token \"\\$workspaceBackend\", expected type at offset 72$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$workspaceBackend\\)\\: Unexpected token \"\\$workspaceBackend\", expected type at offset 85$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/BaseWorkSpacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testDataTypesLoadToRedshift\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncremental\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncremental\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncremental\\(\\) has parameter \\$bucketBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncrementalNotNullable\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncrementalNotNullable\\(\\) has parameter \\$bucketBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncrementalNullable\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testLoadIncrementalNullable\\(\\) has parameter \\$bucketBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testMixedBackendWorkspaceLoad\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testMixedBackendWorkspaceLoad\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:testMixedBackendWorkspaceLoad\\(\\) has parameter \\$bucketBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:workspaceBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:workspaceMixedAndSameBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:workspaceMixedAndSameBackendDataWithDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\Workspaces\\\\S3WorkspacesTest\\:\\:workspaceMixedBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 7
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$backend\\)\\: Unexpected token \"\\$backend\", expected type at offset 65$#"
+			count: 4
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 3
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 3
+			path: tests/Backend/Mixed/Workspaces/S3WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\WorkspacesRenameTest\\:\\:testLoadIncremental\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\WorkspacesRenameTest\\:\\:testLoadIncremental\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\WorkspacesRenameTest\\:\\:testLoadIncremental\\(\\) has parameter \\$bucketBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\WorkspacesRenameTest\\:\\:testLoadIncrementalWithColumnsReorder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\WorkspacesRenameTest\\:\\:testLoadIncrementalWithColumnsReorder\\(\\) has parameter \\$backend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\WorkspacesRenameTest\\:\\:testLoadIncrementalWithColumnsReorder\\(\\) has parameter \\$bucketBackend with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Mixed\\\\WorkspacesRenameTest\\:\\:workspaceMixedBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 3 parameters, 1 required\\.$#"
+			count: 4
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$backend\\)\\: Unexpected token \"\\$backend\", expected type at offset 65$#"
+			count: 2
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$bucketBackend\\)\\: Unexpected token \"\\$bucketBackend\", expected type at offset 88$#"
+			count: 2
+			path: tests/Backend/Mixed/WorkspacesRenameTest.php
+
+		-
+			message: "#^Cannot access offset 'admin' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'isOrganizationMember' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\MixedSnowflakeSynapse\\\\SharingTest\\:\\:assertExpectedDistributionKeyColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\MixedSnowflakeSynapse\\\\SharingTest\\:\\:sharingBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\MixedSnowflakeSynapse\\\\SharingTest\\:\\:testOrganizationAdminInTokenVerify\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\MixedSnowflakeSynapse\\\\SharingTest\\:\\:testWorkspaceLoadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\MixedSnowflakeSynapse\\\\SharingTest\\:\\:workspaceMixedBackendData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:dropBucket\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:listTables\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, mixed given\\.$#"
+			count: 7
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: tests/Backend/MixedSnowflakeSynapse/SharingTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CommonTest.php
+
+		-
+			message: "#^Cannot access offset 'hasRedshift' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CommonTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CommonTest.php
+
+		-
+			message: "#^Cannot access offset 'redshift' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\CommonTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\CommonTest\\:\\:testBucketUpdateOnTableTruncate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\CommonTest\\:\\:testTokenProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CommonTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
+			count: 4
+			path: tests/Backend/Redshift/CommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\CreateTableTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\CreateTableTest\\:\\:syncAsyncData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\CreateTableTest\\:\\:testTableWithLongPkShouldNotBeCreatedInRedshift\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\CreateTableTest\\:\\:testTableWithLongPkShouldNotBeCreatedInRedshift\\(\\) has parameter \\$async with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\CreateTableTest\\:\\:testTimeTravelNotSupported\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/CreateTableTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$async\\)\\: Unexpected token \"\\$async\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/Redshift/CreateTableTest.php
+
+		-
+			message: "#^Cannot access offset 'maxDuplicity' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/DedupeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\DedupeTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/DedupeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\DedupeTest\\:\\:testDedupe\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/DedupeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\DirectAccessTest\\:\\:testGetDirectAccessCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/DirectAccessTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\FulltextSearchTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\FulltextSearchTest\\:\\:testForbiddenWhereOperators\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\ImportExportCommonTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\ImportExportCommonTest\\:\\:testRedshiftErrorInCsv\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\ImportExportCommonTest\\:\\:testRedshiftUnsupportedCsvParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/ImportExportCommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\OptimizeTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/OptimizeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\OptimizeTest\\:\\:testOptimize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/OptimizeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\OrderByTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\OrderByTest\\:\\:testForbiddenWhereOperators\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\WhereFilterTest\\:\\:conditionProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\WhereFilterTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Redshift\\\\WhereFilterTest\\:\\:testForbiddenWhereOperators\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Redshift/WhereFilterTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:aliasSettingsProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:cloneProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:createTableAliasChain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:createTableAliasChain\\(\\) has parameter \\$aliasNamePrefix with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:createTableAliasChain\\(\\) has parameter \\$nestingLevel with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:createTableAliasChain\\(\\) has parameter \\$sourceTableId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:testClone\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:testCloneMultipleTables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:testCloneOtherAliasesNotAllowed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:testClonePreserve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:testClonePreserveOffByDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:testCloneWithWrongInput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CloneIntoWorkspaceTest\\:\\:testTableAlreadyExistsAndOverwrite\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 2
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$sourceProjectId of method Keboola\\\\StorageApi\\\\Client\\:\\:linkBucket\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$sourceBucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:linkBucket\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CopyIntoWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CopyIntoWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\CopyIntoWorkspaceTest\\:\\:testOverwrite\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CopyIntoWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$sourceProjectId of method Keboola\\\\StorageApi\\\\Client\\:\\:linkBucket\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CopyIntoWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$sourceBucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:linkBucket\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/CopyIntoWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Snowflake/DirectAccessTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Snowflake/DirectAccessTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\DirectAccessTest\\:\\:prepareDirectAccess\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/DirectAccessTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\DirectAccessTest\\:\\:testDirectAccessAndRestrictions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/DirectAccessTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\DirectAccessTest\\:\\:testGetDirectAccessCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/DirectAccessTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\DirectAccessTest\\:\\:testWithNonAdminToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/DirectAccessTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/DirectAccessTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 3
+			path: tests/Backend/Snowflake/DirectAccessTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\FulltextSearchTest\\:\\:prepareTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\FulltextSearchTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\FulltextSearchTest\\:\\:testFindDataByFulltext\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\FulltextSearchTest\\:\\:testFindNonExistingDataByFulltext\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\FulltextSearchTest\\:\\:testFulltextAndWhereFiltersAtTheSameTimeShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:getExportedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:getExportedTable\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:getExportedTable\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:invalidDataProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:prepareTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testComplexSort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has parameter \\$order with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has parameter \\$order with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testInvalidStructuredQueryInADataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testInvalidStructuredQueryInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testNonArrayParamsShouldReturnErrorInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testNonArrayParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testSimpleSort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\OrderByTest\\:\\:testSortWithDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/OrderByTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Snowflake/TableExportTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TableExportTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TableExportTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TableExportTest\\:\\:testSyncExportMax30cols\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TableExportTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TableExportTest\\:\\:testSyncExportShouldReturnErrorForLargeNumberOfCols\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TableExportTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tableId of method Keboola\\\\StorageApi\\\\Client\\:\\:getTableDataPreview\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Snowflake/TableExportTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimeTravelTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimeTravelTest\\:\\:testCreateTableFromTimestamp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimeTravelTest\\:\\:testCreateTableFromTimestampOfAlteredTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimeTravelTest\\:\\:testInvalidCreateTableFromTimestampRequests\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimeTravelTest\\:\\:testTableCreationInLinkedBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimeTravelTest\\:\\:testTimeTravelBucketPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:listTables\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int, int\\|false given\\.$#"
+			count: 2
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$sourceProjectId of method Keboola\\\\StorageApi\\\\Client\\:\\:linkBucket\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimeTravelTest\\:\\:\\$downloadPath has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimeTravelTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 5
+			path: tests/Backend/Snowflake/TimestampTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimestampTest\\:\\:assertDataInTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimestampTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimestampTest\\:\\:testTimestampCSVImportAsync\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimestampTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimestampTest\\:\\:testTimestampCSVImportSync\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimestampTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimestampTest\\:\\:testTimestampCopyImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimestampTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimestampTest\\:\\:testTimestampSlicedImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/TimestampTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tableId of method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\TimestampTest\\:\\:assertDataInTable\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Snowflake/TimestampTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:prepareTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testCastToDouble\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testDataPreviewInvalidComparingOperator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testDataPreviewWithNonExistingDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testExportTableInvalidComparingOperator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testFilterWithCast\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testInvalidStructuredQueryInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testInvalidStructuredQueryInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testMultipleConditions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testNonArrayParamsShouldReturnErrorInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testNonArrayParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testSimpleWhereConditions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Snowflake\\\\WhereFilterTest\\:\\:testTableExportWithNonExistingDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Snowflake/WhereFilterTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Cannot access offset 2 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Cannot access offset 3 on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\CreateTableTest\\:\\:invalidDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\CreateTableTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\CreateTableTest\\:\\:testColumnTypesInTableDefinition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\CreateTableTest\\:\\:testCreateTableDefinition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\CreateTableTest\\:\\:testCreateTableDefinitionNoPrimaryKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\CreateTableTest\\:\\:testCreateTableDefinitionWithWrongInput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\CreateTableTest\\:\\:testCreateTableWithCrlfLineEndings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\CreateTableTest\\:\\:testCreateTableWithDistributionKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$actual of method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsExceptKeys\\(\\) expects array, mixed given\\.$#"
+			count: 7
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/CreateTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\FulltextSearchTest\\:\\:prepareTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\FulltextSearchTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\FulltextSearchTest\\:\\:testFindDataByFulltext\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\FulltextSearchTest\\:\\:testFindNonExistingDataByFulltext\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/FulltextSearchTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\FulltextSearchTest\\:\\:testFulltextAndWhereFiltersAtTheSameTimeShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/FulltextSearchTest.php
+
+		-
+			message: "#^Call to an undefined method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:getTableReflection\\(\\)\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\ImportTypedTableTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\ImportTypedTableTest\\:\\:testCreateTableDefinition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\ImportTypedTableTest\\:\\:testLoadTypedTables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\ImportTypedTableTest\\:\\:testLoadTypedTablesConversionError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/ImportTypedTableTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:getExportedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:getExportedTable\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:getExportedTable\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:invalidDataProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:prepareTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testComplexSort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInDataPreview\\(\\) has parameter \\$order with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testInvalidOrderByParamsShouldReturnErrorInExport\\(\\) has parameter \\$order with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testInvalidStructuredQueryInADataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testInvalidStructuredQueryInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testNonArrayParamsShouldReturnErrorInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testNonArrayParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testSimpleSort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\OrderByTest\\:\\:testSortWithDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/OrderByTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\SnapshottingTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/SnapshottingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\SnapshottingTest\\:\\:testCreateTableFromSnapshotWithDistributionKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/SnapshottingTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSnapshot\\(\\) expects null, string given\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/SnapshottingTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 2 on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Cannot access offset 3 on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:createTableDefinition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:testAddColumnOnTypedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:testAddTypedColumnToNonTypedTableShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:testCreateSnapshotOnTypedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:testDataPreviewForTableDefinitionWithDecimalType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:testDropColumnOnTypedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:testPrimaryKeyOperationsOnTypedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Offset 'rows' does not exist on string\\.$#"
+			count: 4
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$actual of method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsExceptKeys\\(\\) expects array, mixed given\\.$#"
+			count: 7
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 5
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createTableFromSnapshot\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Synapse\\\\TableDefinitionOperationsTest\\:\\:\\$tableId has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/TableDefinitionOperationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:getExportedTable\\(\\) has parameter \\$tableId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:prepareTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testCastToDouble\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testDataPreviewInvalidComparingOperator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testDataPreviewWithNonExistingDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testExportTableInvalidComparingOperator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testFilterWithCast\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testInvalidStructuredQueryInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testInvalidStructuredQueryInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testMultipleConditions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testNonArrayParamsShouldReturnErrorInAsyncExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testNonArrayParamsShouldReturnErrorInDataPreview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testSimpleWhereConditions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Synapse\\\\WhereFilterTest\\:\\:testTableExportWithNonExistingDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Synapse/WhereFilterTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:__construct\\(\\) has parameter \\$workspace with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:countRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:countRows\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:createTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$columns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:describeTableColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:describeTableColumns\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:disconnect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:dropTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:dropTable\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:dropTableColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$column with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:dropTableIfExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:dropTableIfExists\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:fetchAll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$orderBy with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$style with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:getTableColumns\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:toIdentifier\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:toIdentifier\\(\\) has parameter \\$item with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$table\\)\\: Unexpected token \"\\$table\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_values expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\ExasolWorkspaceBackend\\:\\:\\$db \\(Doctrine\\\\DBAL\\\\Connection\\) does not accept Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/ExasolWorkspaceBackend.php
+
+		-
+			message: "#^Cannot assign offset 'length' to array\\|string\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/InputMappingConverter.php
+
+		-
+			message: "#^Cannot assign offset 'type' to array\\|string\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/Backend/InputMappingConverter.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\InputMappingConverter\\:\\:convertColumnOrType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/InputMappingConverter.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\InputMappingConverter\\:\\:convertColumnOrType\\(\\) has parameter \\$backendType with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/InputMappingConverter.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\InputMappingConverter\\:\\:convertColumnOrType\\(\\) has parameter \\$column with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/InputMappingConverter.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\InputMappingConverter\\:\\:convertColumnsDefinition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/InputMappingConverter.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\InputMappingConverter\\:\\:convertColumnsDefinition\\(\\) has parameter \\$backendType with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/InputMappingConverter.php
+
+		-
+			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, array\\|string given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/InputMappingConverter.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\LegacyInputMappingConverter\\:\\:convertColumnsDefinition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/LegacyInputMappingConverter.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\LegacyInputMappingConverter\\:\\:convertColumnsDefinition\\(\\) has parameter \\$backendType with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/LegacyInputMappingConverter.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:__construct\\(\\) has parameter \\$workspace with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:countRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:countRows\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:createTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$columns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:describeTableColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:describeTableColumns\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:dropTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:dropTable\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:dropTableColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$column with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:dropTableIfExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:dropTableIfExists\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:fetchAll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$orderBy with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$style with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:getTableColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:getTableColumns\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:getTables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:toIdentifier\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:toIdentifier\\(\\) has parameter \\$item with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:\\$db has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\RedshiftWorkspaceBackend\\:\\:\\$schema has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:__construct\\(\\) has parameter \\$workspace with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:countRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:countRows\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:createTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$columns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:describeTableColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:describeTableColumns\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:dropTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:dropTable\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:dropTableColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$column with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:dropTableIfExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:dropTableIfExists\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:fetchAll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$orderBy with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$style with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:getTableColumns\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:toIdentifier\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:toIdentifier\\(\\) has parameter \\$item with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$table\\)\\: Unexpected token \"\\$table\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:\\$db has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend\\:\\:\\$schema has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SnowflakeWorkspaceBackend.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\:\\:getDatabasePlatform\\(\\)\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:__construct\\(\\) has parameter \\$workspace with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:countRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:countRows\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:createTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$columns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:describeTableColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:describeTableColumns\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:disconnect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:dropTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:dropTable\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:dropTableColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$column with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:dropTableIfExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:dropTableIfExists\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:fetchAll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$orderBy with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$style with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:getTableColumns\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:toIdentifier\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:toIdentifier\\(\\) has parameter \\$item with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$table\\)\\: Unexpected token \"\\$table\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_values expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SynapseWorkspaceBackend\\:\\:\\$db \\(Doctrine\\\\DBAL\\\\Connection\\) does not accept Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/SynapseWorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:countRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:countRows\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:createTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$columns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:createTable\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:describeTableColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:describeTableColumns\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:dropTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:dropTable\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:dropTableColumn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$column with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:dropTableColumn\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:dropTableIfExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:dropTableIfExists\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:getTableColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:getTableColumns\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:getTables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:toIdentifier\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:toIdentifier\\(\\) has parameter \\$item with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackend.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackendFactory\\:\\:createWorkspaceBackend\\(\\) has parameter \\$workspace with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackendFactory.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$workspace\\)\\: Unexpected token \"\\$workspace\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/Workspaces/Backend/WorkspaceBackendFactory.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\BranchComponentsWorkspacesTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/BranchComponentsWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\BranchComponentsWorkspacesTest\\:\\:testWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/BranchComponentsWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ComponentsWorkspacesTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ComponentsWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ComponentsWorkspacesTest\\:\\:testWorkspaceCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ComponentsWorkspacesTest.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\:\\:getDatabasePlatform\\(\\)\\.$#"
+			count: 4
+			path: tests/Backend/Workspaces/ExasolWorkspacesUnloadTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 7
+			path: tests/Backend/Workspaces/ExasolWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ExasolWorkspacesUnloadTest\\:\\:testCopyImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ExasolWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ExasolWorkspacesUnloadTest\\:\\:testCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ExasolWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ExasolWorkspacesUnloadTest\\:\\:testCreateTableFromWorkspaceWithInvalidColumnNames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ExasolWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ExasolWorkspacesUnloadTest\\:\\:testImportFromWorkspaceWithInvalidColumnNames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ExasolWorkspacesUnloadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tableId of method Keboola\\\\StorageApi\\\\Client\\:\\:getTableDataPreview\\(\\) expects string, mixed given\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/ExasolWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:dataTypesDiffDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:testLoadedPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadDataTypes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadDataTypes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$shouldFail with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesExasolTest.php
+
+		-
+			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:conversionUserErrorDataTypesDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:dataTypesErrorDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:notExistingColumnUserErrorDataTypesDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testDataTypeConversionUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testDataTypeConversionUserError\\(\\) has parameter \\$dataTypesDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testDataTypeForNotExistingColumnUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testDataTypeForNotExistingColumnUserError\\(\\) has parameter \\$dataTypesDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testDataTypes\\(\\) has parameter \\$dataTypesDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testDottedDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testDuplicateDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testIncrementalAdditionalColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadDataTypes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadDataTypes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testIncrementalMissingColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testInvalidBucketPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testInvalidColumnsStringIgnore\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testInvalidDataTypeUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testInvalidExtendedDataTypeUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testInvalidInputs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testLoadIncrementalWithColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testRowsParameter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testSecondsFilter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testSourceTableNotFound\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testTableAlreadyExistsShouldThrowUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has parameter \\$expectedResult with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testWorkspaceLoadColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testWorkspaceLoadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:testWorkspaceTablesPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesLoadTest\\:\\:validDataTypesDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dataTypesDefinition\\)\\: Unexpected token \"\\$dataTypesDefinition\", expected type at offset 65$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dataTypesDefinition\\)\\: Unexpected token \"\\$dataTypesDefinition\", expected type at offset 79$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dataTypesDefinition\\)\\: Unexpected token \"\\$dataTypesDefinition\", expected type at offset 86$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedResult\\)\\: Unexpected token \"\\$expectedResult\", expected type at offset 47$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$exportOptions\\)\\: Unexpected token \"\\$exportOptions\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesRedshiftTest\\:\\:columnCompressionDataTypesDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesRedshiftTest\\:\\:testColumnCompression\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesRedshiftTest\\:\\:testColumnCompression\\(\\) has parameter \\$dataTypesDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesRedshiftTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesRedshiftTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesRedshiftTest\\:\\:testLoadedPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dataTypesDefinition\\)\\: Unexpected token \"\\$dataTypesDefinition\", expected type at offset 77$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:dataTypesDiffDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:testLoadedPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadDataTypes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadDataTypes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$shouldFail with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:dataTypesDiffDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:testLoadedPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadDataTypes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadDataTypes with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$shouldFail with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\LegacyWorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/LegacyWorkspacesSynapseTest.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\:\\:getDatabasePlatform\\(\\)\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'key' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 4
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromExasolWorkspaceTest\\:\\:assertMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromExasolWorkspaceTest\\:\\:assertMetadata\\(\\) has parameter \\$expectedKeyValues with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromExasolWorkspaceTest\\:\\:assertMetadata\\(\\) has parameter \\$metadata with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromExasolWorkspaceTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromExasolWorkspaceTest\\:\\:testCopyImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromExasolWorkspaceTest\\:\\:testCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromExasolWorkspaceTest\\:\\:testMetadataManipulationRestrictions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function reset expects array\\|object, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/MetadataFromExasolWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromRedshiftWorkspaceTest\\:\\:assertMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromRedshiftWorkspaceTest\\:\\:assertMetadata\\(\\) has parameter \\$expectedKeyValues with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromRedshiftWorkspaceTest\\:\\:assertMetadata\\(\\) has parameter \\$metadata with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromRedshiftWorkspaceTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromRedshiftWorkspaceTest\\:\\:testCopyImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromRedshiftWorkspaceTest\\:\\:testCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromRedshiftWorkspaceTest\\:\\:testCreateTableFromWorkspaceWithUnsupportedDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromRedshiftWorkspaceTest\\:\\:testWriteTableFromWorkspaceWithUnsupportedDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromRedshiftWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:assertMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:assertMetadata\\(\\) has parameter \\$expectedKeyValues with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:assertMetadata\\(\\) has parameter \\$metadata with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:testCopyImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:testCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:testCreateTableFromWorkspaceWithSnowflakeBug\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:testIncrementalLoadUpdateDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSnowflakeWorkspaceTest\\:\\:testWriteTableFromWorkspaceWithSnowflakeBug\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSnowflakeWorkspaceTest.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\:\\:getDatabasePlatform\\(\\)\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'key' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 4
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSynapseWorkspaceTest\\:\\:assertMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSynapseWorkspaceTest\\:\\:assertMetadata\\(\\) has parameter \\$expectedKeyValues with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSynapseWorkspaceTest\\:\\:assertMetadata\\(\\) has parameter \\$metadata with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSynapseWorkspaceTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSynapseWorkspaceTest\\:\\:testCopyImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSynapseWorkspaceTest\\:\\:testCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\MetadataFromSynapseWorkspaceTest\\:\\:testMetadataManipulationRestrictions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function reset expects array\\|object, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/MetadataFromSynapseWorkspaceTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ParallelWorkspacesTestCase\\:\\:deleteOldTestWorkspaces\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ParallelWorkspacesTestCase\\:\\:listTestWorkspaces\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ParallelWorkspacesTestCase\\:\\:listWorkspaceJobs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ParallelWorkspacesTestCase\\:\\:listWorkspaceJobs\\(\\) has parameter \\$workspaceId with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ParallelWorkspacesTestCase\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\ReadOnlyUserTest\\:\\:testWorkspaceRestrictionsForReadOnlyUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/ReadOnlyUserTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 4
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:assertDataInWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceCreate\\(\\) has parameter \\$backendSize with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceCreate\\(\\) has parameter \\$expectedBackendSize with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceCreate\\(\\) has parameter \\$expectedWarehouseSuffix with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceCreateError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceCreateRequestObjectError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceLoadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceLoadLinkedDataFromProjectWithDynamicBackends\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:testWorkspaceLoadLinkedDataFromProjectWithoutDynamicBackends\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:workspaceCreateData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:workspaceCreateRequestObjectErrorData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$backend of method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SnowflakeDynamicBackendsTest\\:\\:assertDataInWorkspace\\(\\) expects Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\SnowflakeWorkspaceBackend, Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend given\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/SnowflakeDynamicBackendsTest.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\:\\:getDatabasePlatform\\(\\)\\.$#"
+			count: 4
+			path: tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 7
+			path: tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SynapseWorkspacesUnloadTest\\:\\:testCopyImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SynapseWorkspacesUnloadTest\\:\\:testCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SynapseWorkspacesUnloadTest\\:\\:testCreateTableFromWorkspaceWithInvalidColumnNames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\SynapseWorkspacesUnloadTest\\:\\:testImportFromWorkspaceWithInvalidColumnNames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tableId of method Keboola\\\\StorageApi\\\\Client\\:\\:getTableDataPreview\\(\\) expects string, mixed given\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/SynapseWorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:dataTypesDiffDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testCreateNotSupportedBackend\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testLoadDataTypesDefaults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testLoadIncremental\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testLoadIncrementalAndPreserve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testLoadedPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testOutBytesMetricsWithLoadWorkspaceWithRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testOutBytesMetricsWithLoadWorkspaceWithSeconds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$shouldFail with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesExasolTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesExasolTest.php
+
+		-
+			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 6
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:columnsErrorDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:conversionUserErrorColumnsDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:notExistingColumnUserErrorColumnsDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDataTypeConversionUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDataTypeConversionUserError\\(\\) has parameter \\$columnsDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDataTypeForNotExistingColumnUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDataTypeForNotExistingColumnUserError\\(\\) has parameter \\$columnsDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDataTypes\\(\\) has parameter \\$columnsDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDataTypes\\(\\) has parameter \\$expectedColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDottedDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testDuplicateDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testIncrementalAdditionalColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadDataColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadDataColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testIncrementalMissingColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testInvalidBucketPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testInvalidExtendedColumnUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testInvalidInputs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testLoadIncrementalWithColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testLoadIncrementalWithColumnsReorder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testLoadWithWrongInput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testRowsParameter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testSecondsFilter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testSourceTableNotFound\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testTableAlreadyExistsAndOverwrite\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has parameter \\$expectedResult with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testWorkspaceExportFilters\\(\\) has parameter \\$exportOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testWorkspaceLoadAliasTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testWorkspaceLoadColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testWorkspaceLoadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:testWorkspaceTablesPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:validColumnsDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesLoadTest\\:\\:workspaceExportFiltersData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$columnsDefinition\\)\\: Unexpected token \"\\$columnsDefinition\", expected type at offset 63$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$columnsDefinition\\)\\: Unexpected token \"\\$columnsDefinition\", expected type at offset 77$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$columnsDefinition\\)\\: Unexpected token \"\\$columnsDefinition\", expected type at offset 84$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$expectedResult\\)\\: Unexpected token \"\\$expectedResult\", expected type at offset 47$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$exportOptions\\)\\: Unexpected token \"\\$exportOptions\", expected type at offset 18$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$csvString of static method Keboola\\\\StorageApi\\\\Client\\:\\:parseCsv\\(\\) expects string, string\\|false given\\.$#"
+			count: 5
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 4
+			path: tests/Backend/Workspaces/WorkspacesLoadTest.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\:\\:prepare\\(\\)\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Cannot access offset 'distkey' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Cannot access offset 'reldiststyle' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Cannot access offset 'sortkey' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 5
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:columnCompressionDataTypesDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:distTypeData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testColumnCompression\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testColumnCompression\\(\\) has parameter \\$columnsDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testCreateNotSupportedBackend\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadDataTypesDefaults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadIncremental\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadIncrementalAndPreserve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadedDist\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadedDist\\(\\) has parameter \\$dist with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadedPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testLoadedSortKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testOutBytesMetricsWithLoadWorkspaceWithRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRedshiftTest\\:\\:testOutBytesMetricsWithLoadWorkspaceWithSeconds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$columnsDefinition\\)\\: Unexpected token \"\\$columnsDefinition\", expected type at offset 77$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dist\\)\\: Unexpected token \"\\$dist\", expected type at offset 53$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRedshiftTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 3 parameters, 1 required\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:columnsErrorDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testDataTypes\\(\\) has parameter \\$columnsDefinition with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testDottedDestination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testIncrementalAdditionalColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadDataColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadDataColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testIncrementalMissingColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:testLoadIncremental\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesRenameLoadTest\\:\\:validColumnsDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$columnsDefinition\\)\\: Unexpected token \"\\$columnsDefinition\", expected type at offset 63$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesRenameLoadTest.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\:\\:fetchAll\\(\\)\\.$#"
+			count: 4
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Connection\\|Keboola\\\\Db\\\\Import\\\\Snowflake\\\\Connection\\|PDO\\:\\:quoteIdentifier\\(\\)\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:dataTypesDiffDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testClientSessionKeepAlive\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testCreateNotSupportedBackend\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testLoadDataTypesDefaults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testLoadIncremental\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testLoadIncrementalAndPreserve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testLoadedPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testOutBytesMetricsWithLoadWorkspaceWithRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testOutBytesMetricsWithLoadWorkspaceWithSeconds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testStatementTimeout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testTransientTables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$shouldFail with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSnowflakeTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+
+		-
+			message: "#^Call to an undefined method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:getSchemaReflection\\(\\)\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Call to an undefined method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:getTableReflection\\(\\)\\.$#"
+			count: 10
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Call to an undefined method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:getViewReflection\\(\\)\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\Backend\\\\WorkspaceBackend\\:\\:fetchAll\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:dataTypesDiffDefinitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testCreateNotSupportedBackend\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testLoadDataTypesDefaults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testLoadIncremental\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testLoadIncrementalAndPreserve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testLoadIncrementalNotNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testLoadIncrementalNullable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testLoadedPrimaryKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testOutBytesMetricsWithLoadWorkspaceWithRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testOutBytesMetricsWithLoadWorkspaceWithSeconds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testTableDistributionKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testTableLoadAsView\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$firstLoadColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$secondLoadColumns with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$shouldFail with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesSynapseTest\\:\\:testsIncrementalDataTypesDiff\\(\\) has parameter \\$table with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesSynapseTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:assertCredentialsShouldNotWork\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:dropOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:testDropNonExistingWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:testDropNonExistingWorkspace\\(\\) has parameter \\$dropOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:testDropWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:testDropWorkspace\\(\\) has parameter \\$dropOptions with no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:testWorkspaceCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:testWorkspacePasswordReset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dropOptions\\)\\: Unexpected token \"\\$dropOptions\", expected type at offset 51$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$dropOptions\\)\\: Unexpected token \"\\$dropOptions\", expected type at offset 52$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTest\\:\\:\\$RETRY_FAIL_MESSAGE has no type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTestCase\\:\\:deleteAllWorkspaces\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesTestCase\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesTestCase.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 8
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesUnloadTest\\:\\:testCopyImport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesUnloadTest\\:\\:testCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesUnloadTest\\:\\:testCreateTableFromWorkspaceWithInvalidColumnNames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesUnloadTest\\:\\:testImportFromWorkspaceWithInvalidColumnNames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesUnloadTest\\:\\:testImportFromWorkspaceWithInvalidTableNames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Backend\\\\Workspaces\\\\WorkspacesUnloadTest\\:\\:testTableCloneCaseSensitiveThrowsUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tableId of method Keboola\\\\StorageApi\\\\Client\\:\\:getTableDataPreview\\(\\) expects string, mixed given\\.$#"
+			count: 3
+			path: tests/Backend/Workspaces/WorkspacesUnloadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\ClientTestCase\\:\\:getBranchAwareClient\\(\\) has parameter \\$branchId with no type specified\\.$#"
+			count: 1
+			path: tests/ClientTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\ClientTestCase\\:\\:getBranchAwareDefaultClient\\(\\) has parameter \\$branchId with no type specified\\.$#"
+			count: 1
+			path: tests/ClientTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchAwareClientTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchAwareClientTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchAwareClientTest\\:\\:testClientWithDefaultBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchAwareClientTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchAwareClientTest\\:\\:testInvalidBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchAwareClientTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchBucketsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchBucketsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchBucketsTest\\:\\:testDropAllDevBucketsWhenDropBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchBucketsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:bucketExists\\(\\) expects string, bool\\|string given\\.$#"
+			count: 3
+			path: tests/Common/BranchBucketsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:getBucket\\(\\) expects string, bool\\|string given\\.$#"
+			count: 1
+			path: tests/Common/BranchBucketsTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 9
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 22
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testComponentConfigRowUpdateNoNewVersionIsCreatedIfNothingChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testComponentConfigRowVersionRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testComponentConfigRowsListAndConfigRowVersionsList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testConfigurationRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testDeleteBranchConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testDeleteBranchConfigurationRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testManipulationWithComponentConfigurations\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testResetToDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testRestoreBranchConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testRowChangesAfterConfigurationCopy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testRowChangesAfterRowCopy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testRowChangesAfterRowRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:testVersionIncreaseWhenUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:withoutKeysChangingInBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchComponentTest\\:\\:withoutKeysChangingInBranch\\(\\) has parameter \\$branch with no type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchComponentTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Common/BranchEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchEventsTest\\:\\:testDevBranchEventCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchEventsTest\\:\\:waitForListEvents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchEventsTest\\:\\:waitForListEvents\\(\\) has parameter \\$query with no type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchEventsTest.php
+
+		-
+			message: "#^Cannot access offset 'defaultBackend' on mixed\\.$#"
+			count: 2
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 2
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchWorkspacesTest\\:\\:assertCredentialsShouldNotWork\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchWorkspacesTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchWorkspacesTest\\:\\:testWorkspaceCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchWorkspacesTest\\:\\:testWorkspacePasswordReset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Common\\\\BranchWorkspacesTest\\:\\:\\$RETRY_FAIL_MESSAGE has no type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Common\\\\BranchWorkspacesTest\\:\\:\\$branchId has no type specified\\.$#"
+			count: 1
+			path: tests/Common/BranchWorkspacesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\CommonTest\\:\\:testAwsRetries\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/CommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\CommonTest\\:\\:testParseCsv\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/CommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\CommonTest\\:\\:testUrlShouldBeRequired\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/CommonTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testConfigurationChange\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testConfigurationCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testConfigurationDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testConfigurationRestore\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testConfigurationVersionCopy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testConfigurationVersionRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testRowsChange\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testRowsCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testRowsDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testRowsVersionCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsEventsTest\\:\\:testRowsVersionRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsEventsTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 2
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 3
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Cannot access property \\$configuration on mixed\\.$#"
+			count: 4
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Cannot access property \\$id on mixed\\.$#"
+			count: 3
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Cannot access property \\$state on mixed\\.$#"
+			count: 2
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:dumpTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:dumpTable\\(\\) has parameter \\$expandNestedTables with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:dumpTable\\(\\) has parameter \\$out with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:dumpTable\\(\\) has parameter \\$tableData with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testChangeDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigCreateIdAutoCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigCreateWithConfigurationJson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigCreateWithStateJson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigDeletedRowId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRenew\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRestore\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRestrictionsForReadOnlyUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowCreateDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowCreateIsDisabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowCreateName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowStateUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowUpdateConfigEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowUpdateConfigEmptyWithEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowUpdateDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowUpdateIsDisabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowUpdateName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowUpdateNoNewVersionIsCreatedIfNothingChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowVersionCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowVersionRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigRowsListAndConfigRowVersionsList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigUpdateChangeDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigUpdateConfigEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigUpdateEmptyStateJson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigUpdateEmptyWithEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigUpdateVersioning\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigUpdateWithRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigsVersionsCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigsVersionsList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigsVersionsRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testComponentConfigurationJsonDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testConfigurationDescriptionDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testConfigurationNameAndDescriptionShouldNotBeTrimmed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testConfigurationNameShouldBeRequired\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testConfigurationRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testConfigurationRowNameAndDescriptionShouldNotBeTrimmed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testConfigurationStateUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testCopyResetsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testDuplicateConfigShouldNotBeCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testGetComponentConfigurations\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testGetComponentConfigurationsWithConfigAndRows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testGetComponentDetail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testListComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testListConfigs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testNonJsonConfigurationShouldNotBeAllowed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testNonJsonStateShouldNotBeAllowed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testRevertingConfigRowVersionWillNotCreateEmptyConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testRollbackPreservesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testRowChangesAfterConfigurationCopy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testRowChangesAfterConfigurationRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testRowChangesAfterRowCopy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testRowChangesAfterRowRollback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testStateAttributeNotPresentInVersions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testTokenWithComponentAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testTokenWithManageAllBucketsShouldHaveAccessToComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testUpdateConfigWithoutIdShouldNotBeAllowed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ComponentsTest\\:\\:testUpdateRowWithoutIdShouldNotBeAllowed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 2
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$return of function print_r expects bool, int given\\.$#"
+			count: 1
+			path: tests/Common/ComponentsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:assertMetadataEquals\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:createConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:createConfiguration\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:createConfiguration\\(\\) has parameter \\$components with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:createConfiguration\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:createConfiguration\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:testAddMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:testAddMetadataEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:testConfigMetadataRestrictionsForReadOnlyUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:testCreateBranchCopyMetadataToTheDevBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:testDeleteMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:testDeleteMetadataEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:testResetToDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationMetadataTest\\:\\:testUpdateMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationMetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testAttributeExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testAttributeNotPresentInVersions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testAttributeValueCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testAttributeValueUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testCopyPreservesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testDeletedRowCopyPreservesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testDeletedRowRollbackPreservesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testRollbackPreservesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testRowCopyResetsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testRowRollbackPreservesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowStateTest\\:\\:testVersionUnchangedAfterSettingAttribute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowStateTest.php
+
+		-
+			message: "#^Cannot access property \\$changeDescription on mixed\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Cannot access property \\$configuration on mixed\\.$#"
+			count: 5
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Cannot access property \\$id on mixed\\.$#"
+			count: 4
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Cannot access property \\$isDisabled on mixed\\.$#"
+			count: 3
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Cannot access property \\$name on mixed\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Cannot access property \\$state on mixed\\.$#"
+			count: 5
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:isDisabledProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:provideComponentsClientAndGuzzleClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:testConfigurationCopyCreateWithSameRowId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:testConfigurationRowIsDisabledBooleanValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:testConfigurationRowJsonDataTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:testConfigurationRowReturnsSingleRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:testConfigurationRowThrowsNotFoundException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:testCreateConfigurationRowIsDisabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:testCreateConfigurationRowIsDisabled\\(\\) has parameter \\$expectedIsDisabled with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowTest\\:\\:testCreateConfigurationRowIsDisabled\\(\\) has parameter \\$isDisabled with no type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testAddRowToSorted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testAddRowToUnsorted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testAttributeExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testAttributeValuesForOneSortedRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testAttributeValuesForOneUnsortedRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testReorder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testReorderMissingRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testReorderNonexistingRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testRowDeleteSorted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testRowDeleteUnsored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testVersionChangeWhenRowsSortOrderIsManipulated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testVersionCopy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testVersionRollbackToSorted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testVersionRollbackToUnsorted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testVersionsAttributeExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ConfigurationRowsSortOrderTest\\:\\:testVersionsAttributeValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ConfigurationRowsSortOrderTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 2
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 2
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\DevBranchesTest\\:\\:assertAccessForbiddenException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\DevBranchesTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\DevBranchesTest\\:\\:testAdminRoleBranchesPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\DevBranchesTest\\:\\:testBranchCreateAndDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\DevBranchesTest\\:\\:testCannotDeleteDefaultBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\DevBranchesTest\\:\\:testGuestRoleBranchesPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\DevBranchesTest\\:\\:testNonAdminTokenRestrictions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\DevBranchesTest\\:\\:testReadOnlyRoleBranchesPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/DevBranchesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsAttachmentTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsAttachmentTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsAttachmentTest\\:\\:testImportEventAttachment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsAttachmentTest.php
+
+		-
+			message: "#^Cannot access property \\$params on mixed\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Cannot access property \\$performance on mixed\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Cannot access property \\$results on mixed\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:invalidQueries\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:largeEventWithinMaxSizeLimitDataProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testCreateInvalidUTF8\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testEmptyEventsSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testEventCompatibility\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testEventCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testEventCreateWithoutParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testEventList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testEventListingMaxLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testEventsFiltering\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testEventsSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testInvalidSearchSyntaxUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testInvalidSearchSyntaxUserError\\(\\) has parameter \\$query with no type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testInvalidType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testLargeEventOverLimitShouldNotBeCreated\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testLargeEventWithinMaxSizeLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testLargeEventWithinMaxSizeLimit\\(\\) has parameter \\$messageLength with no type specified\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$messageLength\\)\\: Unexpected token \"\\$messageLength\", expected type at offset 80$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$query\\)\\: Unexpected token \"\\$query\", expected type at offset 54$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of method Keboola\\\\StorageApi\\\\Client\\:\\:listEvents\\(\\) expects array, int given\\.$#"
+			count: 1
+			path: tests/Common/EventsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\ExceptionsTest\\:\\:testException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/ExceptionsTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 2
+			path: tests/Common/FilesLegacyFormUploadsTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 6
+			path: tests/Common/FilesLegacyFormUploadsTest.php
+
+		-
+			message: "#^Cannot access offset 'region' on mixed\\.$#"
+			count: 4
+			path: tests/Common/FilesLegacyFormUploadsTest.php
+
+		-
+			message: "#^Cannot call method getStatusCode\\(\\) on Psr\\\\Http\\\\Message\\\\ResponseInterface\\|null\\.$#"
+			count: 1
+			path: tests/Common/FilesLegacyFormUploadsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\FilesLegacyFormUploadsTest\\:\\:testEncryptionMustBeSetWhenEnabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/FilesLegacyFormUploadsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\FilesLegacyFormUploadsTest\\:\\:testFormUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/FilesLegacyFormUploadsTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 2
+			path: tests/Common/FilesLegacyFormUploadsTest.php
+
+		-
+			message: "#^Call to an undefined method Keboola\\\\StorageApi\\\\Client\\|PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\:\\:getServiceUrl\\(\\)\\.$#"
+			count: 4
+			path: tests/Common/GetServiceUrlTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\GetServiceUrlTest\\:\\:testInvalidApiIndexResponseThrowsException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/GetServiceUrlTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\GetServiceUrlTest\\:\\:testInvalidServiceNameThrowsException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/GetServiceUrlTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\GetServiceUrlTest\\:\\:testServiceUrlIsReturned\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/GetServiceUrlTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\GetServiceUrlTest\\:\\:testServiceWithoutUrlThrowsException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/GetServiceUrlTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: tests/Common/GetToFileTest.php
+
+		-
+			message: "#^Cannot access property \\$configurations on mixed\\.$#"
+			count: 1
+			path: tests/Common/GetToFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\GetToFileTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/GetToFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\GetToFileTest\\:\\:testGetToFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/GetToFileTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function GuzzleHttp\\\\json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Common/GetToFileTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sha1 expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Common/GetToFileTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Common\\\\GetToFileTest\\:\\:\\$downloadPath has no type specified\\.$#"
+			count: 1
+			path: tests/Common/GetToFileTest.php
+
+		-
+			message: "#^Call to an undefined method PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\:\\:handleAsyncTasks\\(\\)\\.$#"
+			count: 2
+			path: tests/Common/HandleAsyncTasksTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\HandleAsyncTasksTest\\:\\:testWriteTableAsyncError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/HandleAsyncTasksTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\HandleAsyncTasksTest\\:\\:testWriteTableAsyncSuccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/HandleAsyncTasksTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\IndexTest\\:\\:testFailWebalizeDisplayName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/IndexTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\IndexTest\\:\\:testIndex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/IndexTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\IndexTest\\:\\:testIndexExclude\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/IndexTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\IndexTest\\:\\:testSuccessfullyWebalizeDisplayName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/IndexTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\JobPollDelayTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/JobPollDelayTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\JobPollDelayTest\\:\\:testAlternateJobPollDelay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/JobPollDelayTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\JobPollDelayTest\\:\\:testInvalidJobPollDelay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/JobPollDelayTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\JobsListTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/JobsListTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\JobsListTest\\:\\:testJobsListing\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/JobsListTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\LoggingTest\\:\\:testAwsLogger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/LoggingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\LoggingTest\\:\\:testLogger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/LoggingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MaintenanceTest\\:\\:testMaintenance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MaintenanceTest.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 4
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 15
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Cannot access offset 'key' on mixed\\.$#"
+			count: 6
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Cannot access offset 'provider' on mixed\\.$#"
+			count: 9
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Cannot access offset 'timestamp' on mixed\\.$#"
+			count: 15
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Cannot access offset 'value' on mixed\\.$#"
+			count: 22
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 45
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 12
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:apiEndpoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:deleteMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:deleteMetadata\\(\\) has parameter \\$apiEndpoint with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:deleteMetadata\\(\\) has parameter \\$metadataId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:deleteMetadata\\(\\) has parameter \\$objId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:postMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:postMetadata\\(\\) has parameter \\$apiEndpoint with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:postMetadata\\(\\) has parameter \\$metadata with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:postMetadata\\(\\) has parameter \\$objId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:prepareTokenWithReadPrivilegeForBucket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:prepareTokenWithReadPrivilegeForBucket\\(\\) has parameter \\$bucketId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testBucketMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testBucketMetadataForTokenWithReadPrivilege\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testColumnMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testColumnMetadataForTokenWithReadPrivilege\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadata\\(\\) has parameter \\$apiEndpoint with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadata\\(\\) has parameter \\$object with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadataWhenMetadataIsNotArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadataWhenMetadataIsNotArray\\(\\) has parameter \\$apiEndpoint with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadataWhenMetadataIsNotArray\\(\\) has parameter \\$object with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadataWhenMetadataIsNotPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadataWhenMetadataIsNotPresent\\(\\) has parameter \\$apiEndpoint with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidMetadataWhenMetadataIsNotPresent\\(\\) has parameter \\$object with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testInvalidProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testMetadata40xs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testMetadata40xs\\(\\) has parameter \\$apiEndpoint with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testMetadata40xs\\(\\) has parameter \\$object with no type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testTableColumnDeleteWithMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testTableDeleteWithMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testTableMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testTableMetadataForTokenWithReadPrivilege\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testTryToRemoveForeignData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testTryToRemoveForeignMetadataFromTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\MetadataTest\\:\\:testUpdateTimestamp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function reset expects array\\|object, mixed given\\.$#"
+			count: 6
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$time of function strtotime expects string, mixed given\\.$#"
+			count: 6
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
+			count: 6
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
+			count: 14
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 14
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertRegExp\\(\\) expects string, mixed given\\.$#"
+			count: 3
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$name of method Keboola\\\\StorageApi\\\\Client\\:\\:createAliasTable\\(\\) expects null, string given\\.$#"
+			count: 2
+			path: tests/Common/MetadataTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\QueueJobsTest\\:\\:invalidQueueCreateTableOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/QueueJobsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\QueueJobsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/QueueJobsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\QueueJobsTest\\:\\:testQueueCreateTableFromFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/QueueJobsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\QueueJobsTest\\:\\:testQueueCreateTableFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/QueueJobsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\QueueJobsTest\\:\\:testQueueCreateTableInvalidName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/QueueJobsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\QueueJobsTest\\:\\:testQueueTableExport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/QueueJobsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\QueueJobsTest\\:\\:testQueueTableImportFromFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/QueueJobsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\QueueJobsTest\\:\\:testQueueTableImportFromWorkspace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/QueueJobsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\RunIdTest\\:\\:createEvent\\(\\) has parameter \\$runId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/RunIdTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\RunIdTest\\:\\:testRunIdCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/RunIdTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\RunIdTest\\:\\:testRunIdCreateFromPrevious\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/RunIdTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\RunIdTest\\:\\:testRunIdFiltering\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/RunIdTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$runId\\)\\: Unexpected token \"\\$runId\", expected type at offset 18$#"
+			count: 1
+			path: tests/Common/RunIdTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$previousRunId of method Keboola\\\\StorageApi\\\\Client\\:\\:generateRunId\\(\\) expects null, string given\\.$#"
+			count: 3
+			path: tests/Common/RunIdTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:assertMetadataHasKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:assertMetadataHasKeys\\(\\) has parameter \\$listConfigurationMetadata with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:assertSearchResponseEquals\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:assertSearchResponseEquals\\(\\) has parameter \\$actual with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:assertSearchResponseEquals\\(\\) has parameter \\$expected with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:createConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:createConfiguration\\(\\) has parameter \\$componentId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:createConfiguration\\(\\) has parameter \\$components with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:createConfiguration\\(\\) has parameter \\$configurationId with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:createConfiguration\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:filterIdAndTimestampFromMetadataArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:sortResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:sortResponse\\(\\) has parameter \\$expected with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:sortResponse\\(\\) has parameter \\$sortKey with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:testSearchComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:testSearchComponentsEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchComponentsConfigurationsTest\\:\\:testSearchThrowsErrorWhenIsCalledWithoutBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchComponentsConfigurationsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchTablesTest\\:\\:_initTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchTablesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchTablesTest\\:\\:_initTable\\(\\) has parameter \\$stage with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchTablesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchTablesTest\\:\\:_initTable\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchTablesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchTablesTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchTablesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchTablesTest\\:\\:testSearchTables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchTablesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchTablesTest\\:\\:testSearchTablesEmptyRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchTablesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchTablesTest\\:\\:testSearchTablesNoResult\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchTablesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SearchTablesTest\\:\\:testSearchThrowsErrorWhenIsCalledWithBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SearchTablesTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SimpleJobPollDelayTest\\:\\:testSimpleJobPollDelayDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SimpleJobPollDelayTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SimpleJobPollDelayTest\\:\\:testSimpleJobPollDelayParam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SimpleJobPollDelayTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 2
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Cannot access offset 'entries' on mixed\\.$#"
+			count: 3
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 2
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SlicedFilesUploadTest\\:\\:testUploadSlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SlicedFilesUploadTest\\:\\:testUploadSlicedFileChunks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SlicedFilesUploadTest\\:\\:testUploadSlicedFileEmptyParts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\SlicedFilesUploadTest\\:\\:uploadSlicedData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function filesize expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 3
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 3
+			path: tests/Common/SlicedFilesUploadTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\StatsTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/StatsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\StatsTest\\:\\:testEmptyStatsResults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/StatsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\StatsTest\\:\\:testRunIdStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/StatsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\StatsTest\\:\\:testStatsMissingParam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/StatsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:invalidAttributes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testListTables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testListTablesIncludeColumnMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testListTablesIncludeMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testListTablesWithColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testListTablesWithIncludeParam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testNullAtributesReplace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testNullAttributeValueSet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testSomeTablesWithMetadataSomeWithout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testTableAttributes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testTableAttributesClear\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testTableAttributesReplace\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testTableAttributesReplaceValidation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testTableAttributesReplaceValidation\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testTableExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TablesListingTest\\:\\:testTableListingIncludeAll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$attributes\\)\\: Unexpected token \"\\$attributes\", expected type at offset 18$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$value of method Keboola\\\\StorageApi\\\\Client\\:\\:setTableAttribute\\(\\) expects string, null given\\.$#"
+			count: 1
+			path: tests/Common/TablesListingTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TicketsTest\\:\\:testGenerator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TicketsTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensShareTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensShareTest\\:\\:testMasterTokenShouldNotBeShareable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensShareTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensShareTest\\:\\:testTokenShare\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensShareTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:shareToken\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Common/TokensShareTest.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'admin' on mixed\\.$#"
+			count: 7
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'bucketPermissions' on mixed\\.$#"
+			count: 5
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'canManageBuckets' on mixed\\.$#"
+			count: 4
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'canManageTokens' on mixed\\.$#"
+			count: 3
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'canPurgeTrash' on mixed\\.$#"
+			count: 4
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'canReadAllFileUploa…' on mixed\\.$#"
+			count: 4
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'canUseDirectAccess' on mixed\\.$#"
+			count: 4
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'dataSizeBytes' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 3
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'expires' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'features' on mixed\\.$#"
+			count: 2
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'hasRedshift' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 10
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'isDisabled' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'isExpired' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'isMasterToken' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'isOrganizationMember' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'limits' on mixed\\.$#"
+			count: 2
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 2
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'owner' on mixed\\.$#"
+			count: 5
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'payAsYouGo' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'purchasedCredits' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'refreshed' on mixed\\.$#"
+			count: 2
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'role' on mixed\\.$#"
+			count: 4
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'rowsCount' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'token' on mixed\\.$#"
+			count: 2
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'value' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:assertMasterTokenVisibility\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:clearComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:getGuestClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:initTestConfigurations\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:initTokens\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:limitedTokenOptionsData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:provideInvalidOptionsForGuestUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testAdminRoleTokenSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testAllBucketsTokenPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testAssignNonExistingBucketPermissionShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testAssignNonExistingBucketShouldFail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testBucketPermissionUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testBucketReadTokenPermission\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testBucketWriteTokenPermission\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testDeprecatedMethods\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testExpiredToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testGetToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testGuestRoleTokenSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testGuestTokenCreateLimitedToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testGuestUserSuppliesInvalidOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testInvalidToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testInvalidTokenWhenTokenIsFalse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testInvalidTokenWhenTokenIsString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testKeenReadTokensRetrieve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testNoBucketTokenPermission\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testPayGoTokenProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testReadOnlyRoleBucketsPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testReadOnlyRoleTokenSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testReadOnlyUserCannotCreateLimitedToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testShareRoleTokenSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenComponentAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenComponentAccessError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenDefaultOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenDrop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenEvents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenGetWhenTokenIsString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenMaximalOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenRefresh\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenRefreshWhenTokenIsString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenRefreshesSelf\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenUpdateKeepsCanManageBucketsFlag\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenWithExpiration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenWithoutCanPurgeTrashPermission\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenWithoutTokensManagePermissionCanListAndViewOnlySelf\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenWithoutTokensManagePermissionCanListOnlyOwnTokenEvents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:testTokenWithoutTokensManagePermissionCannotRefreshOtherTokens\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function reset expects array\\|object, mixed given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$currentToken of method Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:assertMasterTokenVisibility\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:dropToken\\(\\) expects int, false given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:dropToken\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:getToken\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:getToken\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Keboola\\\\StorageApi\\\\Tokens\\:\\:refreshToken\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_keys expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tokenId of method Keboola\\\\StorageApi\\\\Client\\:\\:dropToken\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tokenId of method Keboola\\\\StorageApi\\\\Client\\:\\:getToken\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tokenId of method Keboola\\\\StorageApi\\\\Client\\:\\:listTokenEvents\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tokenId of method Keboola\\\\StorageApi\\\\Client\\:\\:refreshToken\\(\\) expects string\\|null, int given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
+			count: 34
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayNotHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 2
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\Common\\\\TokensTest\\:\\:\\$inBucketId is never read, only written\\.$#"
+			count: 1
+			path: tests/Common/TokensTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:deleteKeyProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testCreateTrigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testDeleteTrigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testInvalidToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testListAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testMissingParameters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testMissingParameters\\(\\) has parameter \\$keyToDelete with no type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testPreventTokenDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testTokenWithExpiration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testTriggersRestrictionsForReadOnlyUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testUpdateTrigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Common\\\\TriggersTest\\:\\:testUpdateTwoTables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Common/TriggersTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Downloader\\\\AbsUrlParserTest\\:\\:testParseAbsUrlAzure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Downloader/AbsUrlParserTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Downloader\\\\AbsUrlParserTest\\:\\:testParseAbsUrlHttps\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Downloader/AbsUrlParserTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AwsFileTest\\:\\:encryptedData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AwsFileTest\\:\\:testFileUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AwsFileTest\\:\\:testFileUpload\\(\\) has parameter \\$filePath with no type specified\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AwsFileTest\\:\\:testFileUploadUsingFederationToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AwsFileTest\\:\\:testFileUploadUsingFederationToken\\(\\) has parameter \\$encrypted with no type specified\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AwsFileTest\\:\\:testGetFileFederationToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AwsFileTest\\:\\:testRequireEncryptionForSliced\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AwsFileTest\\:\\:uploadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$encrypted\\)\\: Unexpected token \"\\$encrypted\", expected type at offset 53$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 1
+			path: tests/File/AwsFileTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Cannot access offset 'entries' on mixed\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AzureFileTest\\:\\:generateFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AzureFileTest\\:\\:testFileUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AzureFileTest\\:\\:testFileUpload\\(\\) has parameter \\$filePath with no type specified\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AzureFileTest\\:\\:testUploadSlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AzureFileTest\\:\\:uploadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\AzureFileTest\\:\\:uploadSlicedData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 1
+			path: tests/File/AzureFileTest.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:invalidIdDataProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testDownloadFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testEmptyFileUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFileDelete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFileList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFileListFilterByRunId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFileListFilterBySinceIdMaxId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFileListSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFileUploadCompress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFileUploadLargeFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFilesListFilterByInvalidValues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFilesListFilterByTags\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFilesPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testFilesPermissionsCanReadAllFiles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testGetFileWithoutCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testInvalidFileId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testInvalidFileId\\(\\) has parameter \\$fileId with no type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testNotExistingFileUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testReadOnlyRoleFilesPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testSetTagsFromArrayWithGaps\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testSyntaxErrorInQueryShouldReturnUserError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testTagging\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testUploadAndDownloadSlicedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\File\\\\CommonFileTest\\:\\:testsDuplicateTagsShouldBeDeduped\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fputs expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$zp of function gzread expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/File/CommonFileTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\FileUploadTransferOptionsTest\\:\\:testGetDefaults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/FileUploadTransferOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\FileUploadTransferOptionsTest\\:\\:testSetInvalidChunkSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/FileUploadTransferOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\FileUploadTransferOptionsTest\\:\\:testSetInvalidMaxRetriesPerChunk\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/FileUploadTransferOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\FileUploadTransferOptionsTest\\:\\:testSetInvalidMultiFileConcurrency\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/FileUploadTransferOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\FileUploadTransferOptionsTest\\:\\:testSetInvalidSingleFileConcurrency\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/FileUploadTransferOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\FileUploadTransferOptionsTest\\:\\:testSetters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/FileUploadTransferOptionsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$multiFileConcurrency of method Keboola\\\\StorageApi\\\\Options\\\\FileUploadTransferOptions\\:\\:setMultiFileConcurrency\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests/Options/FileUploadTransferOptionsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$singleFileConcurrency of method Keboola\\\\StorageApi\\\\Options\\\\FileUploadTransferOptions\\:\\:setSingleFileConcurrency\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests/Options/FileUploadTransferOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\SearchTablesOptionsTest\\:\\:testCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/SearchTablesOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\SearchTablesOptionsTest\\:\\:testFluentInterface\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/SearchTablesOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\Options\\\\SearchTablesOptionsTest\\:\\:testGetDefaults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Options/SearchTablesOptionsTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\S3Uploader\\\\ChunkerTest\\:\\:testAssociativeArrayChunker\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/S3Uploader/ChunkerTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\S3Uploader\\\\ChunkerTest\\:\\:testSettersAndGetters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/S3Uploader/ChunkerTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\S3Uploader\\\\ChunkerTest\\:\\:testSimpleChunker\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/S3Uploader/ChunkerTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\S3Uploader\\\\PromiseResultHandlerTest\\:\\:testGetRejected\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/S3Uploader/PromiseResultHandlerTest.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\S3Uploader\\\\PromiseResultHandlerTest\\:\\:testGetRejectedException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/S3Uploader/PromiseResultHandlerTest.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 5
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:_initEmptyTestBuckets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:_initEmptyTestBuckets\\(\\) has parameter \\$stages with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:_readCsv\\(\\) has parameter \\$delimiter with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:_readCsv\\(\\) has parameter \\$enclosure with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:_readCsv\\(\\) has parameter \\$escape with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:_readCsv\\(\\) has parameter \\$path with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsExceptKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsIgnoreKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsSorted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsSorted\\(\\) has parameter \\$actual with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsSorted\\(\\) has parameter \\$expected with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsSorted\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertArrayEqualsSorted\\(\\) has parameter \\$sortKey with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertEvent\\(\\) has parameter \\$event with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertEvent\\(\\) has parameter \\$expectedEventMessage with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertEvent\\(\\) has parameter \\$expectedEventName with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertEvent\\(\\) has parameter \\$expectedObjectId with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertEvent\\(\\) has parameter \\$expectedObjectName with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertEvent\\(\\) has parameter \\$expectedObjectType with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertEvent\\(\\) has parameter \\$expectedParams with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertLinesEqualsSorted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertLinesEqualsSorted\\(\\) has parameter \\$actual with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertLinesEqualsSorted\\(\\) has parameter \\$expected with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:assertLinesEqualsSorted\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:cleanupConfigurations\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createAndWaitForEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createAndWaitForFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createAndWaitForFile\\(\\) has parameter \\$path with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createOrReuseDevBranch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createOrReuseDevBranch\\(\\) has parameter \\$useExistingBranch with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createTableWithRandomData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createTableWithRandomData\\(\\) has parameter \\$charsInCell with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createTableWithRandomData\\(\\) has parameter \\$columns with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createTableWithRandomData\\(\\) has parameter \\$rows with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createTableWithRandomData\\(\\) has parameter \\$tableName with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:deleteBranchesByPrefix\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:dropBucketIfExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:dropBucketIfExists\\(\\) has parameter \\$async with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:findLastEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:generateBranchNameForParallelTest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:generateBranchNameForParallelTest\\(\\) has parameter \\$suffix with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:getDefaultBranchId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:getExportFilePathForTest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:getExportFilePathForTest\\(\\) has parameter \\$fileName with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:getTestBucketId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:getTestBucketId\\(\\) has parameter \\$stage with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:getTestBucketName\\(\\) has parameter \\$testName with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:initEmptyBucket\\(\\) has parameter \\$description with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:initEmptyBucket\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:initEmptyBucket\\(\\) has parameter \\$stage with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:initEmptyTestBucketsForParallelTests\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:initEmptyTestBucketsForParallelTests\\(\\) has parameter \\$stages with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:initEvents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:listEvents\\(\\) has parameter \\$expectedObjectId with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:listJobsByRunId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:listJobsByRunId\\(\\) has parameter \\$runId with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:listTestBucketsForParallelTests\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:listTestBucketsForParallelTests\\(\\) has parameter \\$stages with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:provideBranchAwareComponentsClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:provideComponentsClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:provideComponentsGuzzleClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:setUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:tableExportFiltersData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:throwExceptionIfNotDeleted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:waitForFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:waitForFile\\(\\) has parameter \\$fileId with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:waitForFile\\(\\) has parameter \\$sapiClient with no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$name\\)\\: Unexpected token \"\\$name\", expected type at offset 55$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$path\\)\\: Unexpected token \"\\$path\", expected type at offset 18$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$stage\\)\\: Unexpected token \"\\$stage\", expected type at offset 75$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$testName\\)\\: Unexpected token \"\\$testName\", expected type at offset 18$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fgetcsv expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$tokenId of method Keboola\\\\StorageApi\\\\Client\\:\\:listTokenEvents\\(\\) expects int, mixed given\\.$#"
+			count: 2
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\StorageApiTestCase\\:\\:\\$_bucketIds has no type specified\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Property Keboola\\\\Test\\\\StorageApiTestCase\\:\\:\\$tokenId \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: tests/StorageApiTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_exists expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/bootstrap.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/bootstrap.php
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13211,16 +13211,6 @@ parameters:
 			path: tests/StorageApiTestCase.php
 
 		-
-			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createOrReuseDevBranch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/StorageApiTestCase.php
-
-		-
-			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createOrReuseDevBranch\\(\\) has parameter \\$useExistingBranch with no type specified\\.$#"
-			count: 1
-			path: tests/StorageApiTestCase.php
-
-		-
 			message: "#^Method Keboola\\\\Test\\\\StorageApiTestCase\\:\\:createTableWithRandomData\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/StorageApiTestCase.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,14 @@
 parameters:
+    tmpDir: cache/.phpstan
+    parallel:
+        processTimeout: 300.0
+    checkMissingIterableValueType: false
     ignoreErrors:
         - '#Constant STORAGE_API_[_A-Z0-9]+ not found.#'
         - '#Constant SUITE_NAME not found.#'
         - '#Constant TRAVIS_BUILD_ID not found.#'
         - '#Constant REDSHIFT_NODE_COUNT not found.#'
-    excludes_analyse:
+    excludePaths:
         - vendor
+includes:
+    - phpstan-baseline.neon

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1935,7 +1935,7 @@ class Client
 
     /**
      * Get a single file
-     * @param string $fileId
+     * @param string|int $fileId
      * @return array
      */
     public function getFile($fileId, GetFileOptions $options = null)

--- a/tests/Backend/Mixed/StorageApiSharingTestCase.php
+++ b/tests/Backend/Mixed/StorageApiSharingTestCase.php
@@ -118,7 +118,7 @@ abstract class StorageApiSharingTestCase extends StorageApiTestCase
      * @param $stage
      * @return bool|string
      */
-    protected function initEmptyBucket($name, $stage, $backend)
+    protected function initEmptyBucketForSharingTest($name, $stage, $backend)
     {
         if ($this->_client->bucketExists("$stage.c-$name")) {
             $this->_client->dropBucket(
@@ -172,7 +172,7 @@ abstract class StorageApiSharingTestCase extends StorageApiTestCase
         // recreate buckets in firs project
         $this->_bucketIds = [];
         foreach ([self::STAGE_OUT, self::STAGE_IN] as $stage) {
-            $this->_bucketIds[$stage] = $this->initEmptyBucket('API-sharing', $stage, $backend);
+            $this->_bucketIds[$stage] = $this->initEmptyBucketForSharingTest('API-sharing', $stage, $backend);
         }
 
         return $this->_bucketIds;

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -731,6 +731,9 @@ abstract class StorageApiTestCase extends ClientTestCase
         ];
     }
 
+    /**
+     * @return array
+     */
     protected function getExistingBranchForTestCase(self $that)
     {
         $branchName = $this->generateDevBranchNameForDataProvider($that);
@@ -751,6 +754,9 @@ abstract class StorageApiTestCase extends ClientTestCase
         return $branch;
     }
 
+    /**
+     * @return array
+     */
     protected function createDevBranchForTestCase(self $that)
     {
         $branchName = $this->generateDevBranchNameForDataProvider($that);
@@ -879,6 +885,9 @@ abstract class StorageApiTestCase extends ClientTestCase
         }
     }
 
+    /**
+     * @return string
+     */
     private function generateDevBranchNameForDataProvider(StorageApiTestCase $that)
     {
         $providedToken = $that->_client->verifyToken();


### PR DESCRIPTION
Jira: KBC-1931

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---

There are no "low hanging fruits" here unfortunately. We need to start fixing the typehints as we go and get phpstan failures in new tests. Most of the methods are historically set to "mixed" even though they return array or string or int. That needs to slowly be fixed first. 