### PR TITLE
remove snapshotId from import-async, endpoint is not supporting this

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1823,7 +1823,6 @@ Asynchronous imports requested on the same table will be serialized.
 The actual data must be provided in one of the following attributes:
 
 - **dataFileId**,
-- **snapshotId**,
 - **dataWorkspaceId** and **dataObject** (older "dataTableName" is deprecated)
 
 An imported file can be sliced into multiple chunks; the conditions described in [File Uploads](#reference/files) must be satisfied.
@@ -1849,7 +1848,6 @@ Further information can be found in the [Developers Documentation](https://devel
 
 + Attributes
     + dataFileId (optional) - Id of the file stored in [File Uploads](#reference/files); all gzipped and sliced files are supported.
-    + snapshotId (optional) - Id of a table snapshot - a table will be created from the snapshot.
     + dataWorkspaceId (optional) - Load from the table [workspace](#reference/workspaces). Use with the **dataTableName** attribute.
     + dataTableName (optional) - (deprecated use dataObject) Load from the table in the [workspace](#reference/workspaces).
     + dataObject (optional) - Load from the table/file in the [workspace](#reference/workspaces).


### PR DESCRIPTION
Endpoint import-async does not support import from snapshot.

Slack: https://keboola.slack.com/archives/CFVRE56UA/p1636118198133100

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
