### PR TITLE
do not generate composer.lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
 	"description": "Keboola Storage API PHP CLient",
 	"homepage": "http://keboola.com",
 	"license": "MIT",
+	"config": {
+		"lock": false
+	},
 	"autoload": {
 		"psr-0": {
 			"Keboola\\StorageApi": "src/"


### PR DESCRIPTION
`composer.lock` neni verzovany, ale stale se generuje a rychle zastarava. Proto ho prestaneme generovat.

ℹ️  Kazdy si ho musi lokalne smazat, pokud chce mit aktualni balicky.

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
