### PR TITLE
fix risky test by adding some assert

### DIFF
--- a/tests/Common/TokensShareTest.php
+++ b/tests/Common/TokensShareTest.php
@@ -21,7 +21,12 @@ class TokensShareTest extends StorageApiTestCase
 
     public function testTokenShare()
     {
+        $this->initEvents($this->_client);
         $newToken = $this->tokens->createToken(new TokenCreateOptions());
         $this->tokens->shareToken($newToken['id'], 'test@devel.keboola.com', 'Hi');
+        $events = $this->listEvents($this->_client, 'storage.tokenShared');
+        $this->assertGreaterThanOrEqual(1, count($events));
+        $this->assertSame('storage.tokenShared', $events[0]['event']);
+        $this->assertSame('test@devel.keboola.com', $events[0]['params']['recipientEmail']);
     }
 }


### PR DESCRIPTION
```
18:35:48-UTC - common                             -	There was 1 risky test:
18:35:48-UTC - common                             -	
18:35:48-UTC - common                             -	1) Keboola\Test\Common\TokensShareTest::testTokenShare
18:35:48-UTC - common                             -	This test did not perform any assertions
18:35:48-UTC - common                             -	
18:35:48-UTC - common                             -	/code/tests/Common/TokensShareTest.php:22
```

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
