### PR TITLE
KBC-1726 consolidate branch event test

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9426,11 +9426,6 @@ parameters:
 			path: tests/Common/BranchComponentTest.php
 
 		-
-			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchEventsTest\\:\\:testDevBranchEventCreated\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/Common/BranchEventsTest.php
-
-		-
 			message: "#^Method Keboola\\\\Test\\\\Common\\\\BranchEventsTest\\:\\:waitForListEvents\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Common/BranchEventsTest.php


### PR DESCRIPTION
Jira: KBC-1726

Class BranchEventTest was a good candidate to be consolidated. But all tested usecases are branch-related so the tests stay in there.

It contained one test method with three different usecases -> I have split the cases to independent methods 