### PR TITLE
Optimize Client->getServiceUrl()

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -193,7 +193,9 @@ class Client
      */
     public function getServiceUrl($serviceName)
     {
-        $indexResult = $this->indexAction();
+        $options = new IndexOptions();
+        $options->setExclude(['components']);
+        $indexResult = $this->indexAction($options);
 
         if (!isset($indexResult['services']) || !is_array($indexResult['services'])) {
             throw new ClientException('API index is missing "services" section');


### PR DESCRIPTION
No BC break, just an optimization of Client->getServiceUrl() that needs only 'services' part of the index result.
