### PR TITLE
fix test: be sure that create time of copied row is different

### DIFF
--- a/tests/Common/BranchComponentTest.php
+++ b/tests/Common/BranchComponentTest.php
@@ -292,6 +292,8 @@ class BranchComponentTest extends StorageApiTestCase
                 ->setName('Main 1 Row 1')
                 ->setRowId('main-1-row-1')
         );
+        // be sure that create time of copied row is different
+        sleep(1);
 
         $deletedConfigurationOptions = (new Configuration())
             ->setComponentId($componentId)


### PR DESCRIPTION
Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
