### PR TITLE
Try retry lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,12 @@
 	"config": {
 		"lock": false
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/keboola/phpunit-retry-annotations"
+		}
+	],
 	"autoload": {
 		"psr-0": {
 			"Keboola\\StorageApi": "src/"
@@ -41,7 +47,8 @@
 		"ext-pdo": "*",
 		"keboola/retry": "^0.5.0",
 		"phpstan/phpstan": "~1.3.3",
-		"phpstan/phpstan-phpunit": "^1.0"
+		"phpstan/phpstan-phpunit": "^1.0",
+		"bshaffer/phpunit-retry-annotations": "dev-master"
     },
 	"scripts": {
 		"phpcs": "phpcs -n .",

--- a/tests/ClientTestCase.php
+++ b/tests/ClientTestCase.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 class ClientTestCase extends TestCase
 {
+    use \PHPUnitRetry\RetryTrait;
+
     /**
      * @return Client
      */


### PR DESCRIPTION
Jira: KBC-2177

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---

Forkol som libku ktora to mala implementovane a len som zmenil https://github.com/keboola/phpunit-retry-annotations/commit/7e0422f073073d06848166396448810a509664ce aby to robilo defaultne retry 2x. Pridal som som sem este commit kde to sa to da otestovat ze to robi retry to potom zmazem https://github.com/keboola/storage-api-php-client/pull/760/commits/a74d68b67a4b984ceea408e2cd998506d6837ee9

1. `docker-compose run --rm dev composer install`
2. `source ./set-env.sh &&  docker-compose run --rm dev vendor/bin/phpunit --testsuite common`  - spusti len jeden test ktory nahodne failuje v logu je vidiet ze to urobi retry a test prejde ked sa to podari v dvoch retryoch
3. `source ./set-env.sh &&  docker-compose run --rm dev ./vendor/bin/paratest --testsuite common` - bohuzial v paratestoch to nevypise ten retry ale da sa vyskusat ze to robi retry.

Preslo mi to zatial 2x po sebe https://app.travis-ci.com/github/keboola/connection/builds/246579429, https://app.travis-ci.com/github/keboola/connection/builds/246596775 este to tagnem 1x a zalozim task aby sme ukladali nejaky file s tym ktore testy robili retry