### PR TITLE
PS-3095: manually call GC in S3 multipart file upload

### DIFF
--- a/src/Keboola/StorageApi/S3Uploader.php
+++ b/src/Keboola/StorageApi/S3Uploader.php
@@ -193,6 +193,9 @@ class S3Uploader
             'Key' => $key,
             'ACL' => $acl,
             'concurrency' => $concurrency,
+            'before_upload' => function(\Aws\Command $command) {
+                gc_collect_cycles();
+            },
         ];
         if (!empty($state)) {
             $uploaderOptions['state'] = $state;
@@ -205,12 +208,13 @@ class S3Uploader
             $beforeInitiateCommands['ServerSideEncryption'] = $encryption;
         }
         if ($beforeInitiateCommands) {
-            $uploaderOptions['before_initiate'] = function ($command) use ($beforeInitiateCommands) {
+            $uploaderOptions['before_initiate'] = function (\Aws\Command $command) use ($beforeInitiateCommands) {
                 foreach ($beforeInitiateCommands as $key => $value) {
                     $command[$key] = $value;
                 }
             };
         }
+
         return new \Aws\S3\MultipartUploader($this->s3Client, $filePath, $uploaderOptions);
     }
 }

--- a/src/Keboola/StorageApi/S3Uploader.php
+++ b/src/Keboola/StorageApi/S3Uploader.php
@@ -193,7 +193,7 @@ class S3Uploader
             'Key' => $key,
             'ACL' => $acl,
             'concurrency' => $concurrency,
-            'before_upload' => function(\Aws\Command $command) {
+            'before_upload' => function (\Aws\Command $command) {
                 gc_collect_cycles();
             },
         ];


### PR DESCRIPTION
Jira: PS-3095

Explicitly call PHP garbage collection between uploads of parts of file in multi part upload in S3Uploader.

See https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-multipart-upload.html
in part **Manual Garbage Collection Between Part Uploads**

Not sure if this can be tested somehow :) 
