### PR TITLE
Increase S3 download/upload timeout

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1603,7 +1603,7 @@ class Client
             'region' => $prepareResult['region'],
             'http' => [
                 'connect_timeout' => 10,
-                'timeout' => 120,
+                'timeout' => 500,
             ],
             'debug' => false,
             'credentials' => [
@@ -1858,8 +1858,9 @@ class Client
             'region' => $fileInfo['region'],
             'retries' => 40,
             'http' => [
+                'read_timeout' => 10,
                 'connect_timeout' => 10,
-                'timeout' => 120,
+                'timeout' => 500,
             ],
             'credentials' => [
                 'key' => $fileInfo['credentials']['AccessKeyId'],


### PR DESCRIPTION
https://keboola.slack.com/archives/CQB468K63/p1645717611035819
https://keboola.zendesk.com/agent/tickets/21409
Stejne reseni se delalo tu: https://github.com/keboola/storage-api-php-client/pull/739

Snazi se stahnout 12GB soubor pres IM z S3, pada na timeoutu po necelych 6GB. Timeout chyti retry a vysledek je job, ktery failne po ~90 minutach s errorem, ze request timeout 120sec :) 

Zaroven jsem upravil i timeout pro upload, aby to bylo v obou smerech totozne.
