### PR TITLE
PS-3279 Support Guzzle 7, Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,9 @@
 	"require": {
 		"php": ">=5.6",
 		"keboola/csv": "~1.1.3",
-		"guzzlehttp/guzzle": "~6.0",
-		"symfony/filesystem": "^5.0||^4.0||^3.0||~2.3",
-		"symfony/process": "^5.0||^4.0||^3.0||~2.3",
+		"guzzlehttp/guzzle": "~7.0||~6.0",
+		"symfony/filesystem": "^6.0||^5.0||^4.0||^3.0||~2.3",
+		"symfony/process": "^6.0||^5.0||^4.0||^3.0||~2.3",
 		"aws/aws-sdk-php": "~3.2",
 		"psr/log": "~1.0",
         "microsoft/azure-storage-blob": "^1.4"


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PS-3279
Related to https://github.com/keboola/kbc-manage-api-php-client/pull/185

Allow using with Guzzle 7 & Symfony 6 components.

There should be no BC in Symfony components. Guzzle has some breaking changes (https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#60-to-70) but everything seems to work for me so far.