### PR TITLE
follow up KBC-2540: default timeout set to 120...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,7 @@
 		"keboola/retry": "^0.5.0",
 		"phpstan/phpstan": "~1.3.3",
 		"phpstan/phpstan-phpunit": "^1.0",
-		"bshaffer/phpunit-retry-annotations": "dev-master",
-		"monolog/monolog": "^1.27"
+		"bshaffer/phpunit-retry-annotations": "dev-master"
     },
 	"scripts": {
 		"phpcs": "phpcs -n .",

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1403,7 +1403,7 @@ class Client
         $url = "tables/{$tableId}/data-preview";
         $url .= '?' . http_build_query($this->prepareExportOptions($options));
 
-        return $this->apiGet($url);
+        return $this->apiGet($url, null, [Client::REQUEST_OPTION_EXTENDED_TIMEOUT => true]);
     }
 
     /**

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -2218,9 +2218,7 @@ class Client
      */
     public function apiPost($url, $postData = null, $handleAsyncTask = true, $requestOptions = [])
     {
-        $requestOptions = array_filter($requestOptions, function ($key) {
-            return in_array($key, self::ALLOWED_REQUEST_OPTIONS);
-        }, ARRAY_FILTER_USE_KEY);
+        $requestOptions = $this->filterRequestOptions($requestOptions);
         $requestOptions['form_params'] = $postData;
         return $this->request('post', $url, $requestOptions, null, $handleAsyncTask);
     }
@@ -2647,5 +2645,16 @@ class Client
     public function isAwsDebug()
     {
         return $this->awsDebug;
+    }
+
+    /**
+     * @param array $requestOptions
+     * @return array
+     */
+    private function filterRequestOptions($requestOptions)
+    {
+        return array_filter($requestOptions, function ($key) {
+            return in_array($key, self::ALLOWED_REQUEST_OPTIONS);
+        }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -6,12 +6,10 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
-use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\Client\RequestTimeoutMiddleware;
 use Keboola\StorageApi\Downloader\BlobClientFactory;
 use Keboola\StorageApi\Options\BucketUpdateOptions;
 use Keboola\StorageApi\Options\Components\SearchComponentConfigurationsOptions;
-use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\FileUploadTransferOptions;
 use Keboola\StorageApi\Options\GetFileOptions;
 use Keboola\StorageApi\Options\IndexOptions;
@@ -22,12 +20,14 @@ use Keboola\StorageApi\Options\TokenCreateOptions;
 use Keboola\StorageApi\Options\TokenUpdateOptions;
 use MicrosoftAzure\Storage\Blob\Models\CommitBlobBlocksOptions;
 use MicrosoftAzure\Storage\Blob\Models\CreateBlockBlobOptions;
-use Monolog\Handler\ErrorLogHandler;
-use Monolog\Logger;
+use MicrosoftAzure\Storage\Common\Models\ServiceOptions;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 use Symfony\Component\Filesystem\Filesystem;
+use Keboola\Csv\CsvFile;
+use Keboola\StorageApi\Options\FileUploadOptions;
 
 class Client
 {
@@ -143,9 +143,7 @@ class Client
         }
 
         if (!isset($config['logger'])) {
-            $logger = new Logger('my_logger');
-            $logger->pushHandler(new ErrorLogHandler());
-            $config['logger'] = $logger;
+            $config['logger'] = new NullLogger();
         }
         $this->setLogger($config['logger']);
 
@@ -165,7 +163,7 @@ class Client
             'backoffMaxTries' => $this->backoffMaxTries,
         ]);
 
-        $handlerStack->push((RequestTimeoutMiddleware::factory($this->logger)));
+        $handlerStack->push((RequestTimeoutMiddleware::factory()));
         $handlerStack->push(Middleware::log(
             $this->logger,
             new MessageFormatter("{hostname} {req_header_User-Agent} - [{ts}] \"{method} {resource} {protocol}/{version}\" {code} {res_header_Content-Length}"),

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -1245,7 +1245,7 @@ class Client
 
     public function listJobs($options = [])
     {
-        return $this->apiGet("jobs?" . http_build_query($options));
+        return $this->apiGet("jobs?" . http_build_query($options), null, [Client::REQUEST_OPTION_EXTENDED_TIMEOUT=>true]);
     }
 
     /**
@@ -2200,11 +2200,13 @@ class Client
      *
      * @param string $url
      * @param string null $fileName
+     * @param array $requestOptions
      * @return mixed|string|array
      */
-    public function apiGet($url, $fileName = null)
+    public function apiGet($url, $fileName = null, $requestOptions = [])
     {
-        return $this->request('GET', $url, array(), $fileName);
+        $requestOptions = $this->filterRequestOptions($requestOptions);
+        return $this->request('GET', $url, $requestOptions, $fileName);
     }
 
     /**

--- a/src/Keboola/StorageApi/Client/RequestTimeoutMiddleware.php
+++ b/src/Keboola/StorageApi/Client/RequestTimeoutMiddleware.php
@@ -9,7 +9,7 @@ use function GuzzleHttp\Psr7\str;
 
 class RequestTimeoutMiddleware
 {
-    const REQUEST_TIMEOUT_DEFAULT = 60;
+    const REQUEST_TIMEOUT_DEFAULT = 120;
     const REQUEST_TIMEOUT_EXTENDED = 7200;
 
     /** @var LoggerInterface */

--- a/src/Keboola/StorageApi/Client/RequestTimeoutMiddleware.php
+++ b/src/Keboola/StorageApi/Client/RequestTimeoutMiddleware.php
@@ -4,35 +4,28 @@ namespace Keboola\StorageApi\Client;
 
 use Keboola\StorageApi\Client;
 use Psr\Http\Message\RequestInterface;
-use Psr\Log\LoggerInterface;
-use function GuzzleHttp\Psr7\str;
 
 class RequestTimeoutMiddleware
 {
     const REQUEST_TIMEOUT_DEFAULT = 120;
     const REQUEST_TIMEOUT_EXTENDED = 7200;
 
-    /** @var LoggerInterface */
-    private $logger;
-
     /** @var callable */
     private $nextHandler;
 
     private function __construct(
-        callable $nextHandler,
-        LoggerInterface $logger
+        callable $nextHandler
     ) {
-        $this->logger = $logger;
         $this->nextHandler = $nextHandler;
     }
 
     /**
      * @return callable
      */
-    public static function factory(LoggerInterface $logger)
+    public static function factory()
     {
-        return function (callable $handler) use ($logger) {
-            return new self($handler, $logger);
+        return function (callable $handler) {
+            return new self($handler);
         };
     }
 
@@ -54,7 +47,6 @@ class RequestTimeoutMiddleware
         if ($isExtendedTimeout) {
             $options['timeout'] = self::REQUEST_TIMEOUT_EXTENDED;
         }
-        $this->logger->debug(sprintf('Request "%s %s" timeout set to "%ss"', $request->getMethod(), $request->getUri()->getPath(), $options['timeout']));
         return $nextHander($request, $options);
     }
 }

--- a/src/Keboola/StorageApi/Components.php
+++ b/src/Keboola/StorageApi/Components.php
@@ -330,7 +330,9 @@ class Components
     {
         return $this->client->apiPost(
             "components/{$componentId}/configs/{$configurationId}/workspaces",
-            $options
+            $options,
+            true,
+            [Client::REQUEST_OPTION_EXTENDED_TIMEOUT => true]
         );
     }
 

--- a/tests-unit/Client/RequestTimeoutMiddlewareTest.php
+++ b/tests-unit/Client/RequestTimeoutMiddlewareTest.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Psr7\Request;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\Client\RequestTimeoutMiddleware;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
 
 class RequestTimeoutMiddlewareTest extends TestCase
 {
@@ -20,7 +19,7 @@ class RequestTimeoutMiddlewareTest extends TestCase
         };
         $requestMock = new Request('GET', '/lorem-ipsum');
 
-        $middleware = RequestTimeoutMiddleware::factory(new NullLogger())($assertingHandler);
+        $middleware = RequestTimeoutMiddleware::factory()($assertingHandler);
 
         $middleware($requestMock, []);
     }
@@ -35,7 +34,7 @@ class RequestTimeoutMiddlewareTest extends TestCase
         };
         $requestMock = new Request('GET', '/lorem-ipsum');
 
-        $middleware = RequestTimeoutMiddleware::factory(new NullLogger())($assertingHandler);
+        $middleware = RequestTimeoutMiddleware::factory()($assertingHandler);
 
         $middleware($requestMock, ['timeout' => 300]);
     }
@@ -50,7 +49,7 @@ class RequestTimeoutMiddlewareTest extends TestCase
         };
         $requestMock = new Request('DELETE', '/lorem-ipsum');
 
-        $middleware = RequestTimeoutMiddleware::factory(new NullLogger())($assertingHandler);
+        $middleware = RequestTimeoutMiddleware::factory()($assertingHandler);
 
         $middleware($requestMock, []);
     }
@@ -65,7 +64,7 @@ class RequestTimeoutMiddlewareTest extends TestCase
         };
         $requestMock = new Request('DELETE', '/lorem-ipsum');
 
-        $middleware = RequestTimeoutMiddleware::factory(new NullLogger())($assertingHandler);
+        $middleware = RequestTimeoutMiddleware::factory()($assertingHandler);
 
         $middleware($requestMock, [Client::REQUEST_OPTION_EXTENDED_TIMEOUT => true, 'timeout' => 123]);
     }

--- a/tests-unit/Client/RequestTimeoutMiddlewareTest.php
+++ b/tests-unit/Client/RequestTimeoutMiddlewareTest.php
@@ -61,7 +61,7 @@ class RequestTimeoutMiddlewareTest extends TestCase
     public function testWillSetManualExtendedTimeout()
     {
         $assertingHandler = function ($request, $options) {
-            $this->assertSame(RequestTimeoutMiddleware::REQUEST_TIMEOUT_DEFAULT, $options['timeout']);
+            $this->assertSame(RequestTimeoutMiddleware::REQUEST_TIMEOUT_EXTENDED, $options['timeout']);
         };
         $requestMock = new Request('DELETE', '/lorem-ipsum');
 

--- a/tests-unit/Client/RequestTimeoutMiddlewareTest.php
+++ b/tests-unit/Client/RequestTimeoutMiddlewareTest.php
@@ -16,7 +16,7 @@ class RequestTimeoutMiddlewareTest extends TestCase
     public function testWillSetDefaultTimeout()
     {
         $assertingHandler = function ($request, $options) {
-            $this->assertSame(60, $options['timeout']);
+            $this->assertSame(RequestTimeoutMiddleware::REQUEST_TIMEOUT_DEFAULT, $options['timeout']);
         };
         $requestMock = new Request('GET', '/lorem-ipsum');
 
@@ -31,7 +31,7 @@ class RequestTimeoutMiddlewareTest extends TestCase
     public function testWillOverrideTimeout()
     {
         $assertingHandler = function ($request, $options) {
-            $this->assertSame(60, $options['timeout']);
+            $this->assertSame(RequestTimeoutMiddleware::REQUEST_TIMEOUT_DEFAULT, $options['timeout']);
         };
         $requestMock = new Request('GET', '/lorem-ipsum');
 
@@ -46,7 +46,7 @@ class RequestTimeoutMiddlewareTest extends TestCase
     public function testWillSetDeleteTimeout()
     {
         $assertingHandler = function ($request, $options) {
-            $this->assertSame(7200, $options['timeout']);
+            $this->assertSame(RequestTimeoutMiddleware::REQUEST_TIMEOUT_EXTENDED, $options['timeout']);
         };
         $requestMock = new Request('DELETE', '/lorem-ipsum');
 
@@ -58,10 +58,10 @@ class RequestTimeoutMiddlewareTest extends TestCase
     /**
      * @return void
      */
-    public function testWillSetManualExtenededTimeout()
+    public function testWillSetManualExtendedTimeout()
     {
         $assertingHandler = function ($request, $options) {
-            $this->assertSame(7200, $options['timeout']);
+            $this->assertSame(RequestTimeoutMiddleware::REQUEST_TIMEOUT_DEFAULT, $options['timeout']);
         };
         $requestMock = new Request('DELETE', '/lorem-ipsum');
 


### PR DESCRIPTION
- Default timeout set to 120 
- Added extended timeout to Components::createConfigurationWorkspace

Jira: KBC-2540

Ako si [Martin vsimol](https://keboola.slack.com/archives/C03BPTX4YGG/p1649796402908979?thread_ts=1649761385.687579&cid=C03BPTX4YGG), niektore requesty trvaju dlhsie ako minutu a POST na configuration/workspace musi mat extended timeout.

[Requesty v DataDogu](https://app.datadoghq.eu/apm/traces?query=%40_top_level%3A1%20service%3Aconnection%20operation_name%3Azf1.request%20-env%3Aconnection-testing%20-resource_name%3A%22workspaces%40delete%20storageApiVersioned2%22&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_duration.by_service%2Cenv&historicalData=true&messageDisplay=inline&sort=desc&spanViewType=metadata&start=1649227908397&end=1649832708397&paused=false) 

Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
