### PR TITLE
test runId with the same parent runId do not return parent stats

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10787,6 +10787,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$previousRunId of method Keboola\\\\StorageApi\\\\Client\\:\\:generateRunId\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: tests/Common/StatsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$previousRunId of method Keboola\\\\StorageApi\\\\Client\\:\\:generateRunId\\(\\) expects null, string given\\.$#"
 			count: 3
 			path: tests/Common/RunIdTest.php
 


### PR DESCRIPTION
Jira: KBC-2538
MainPR: https://github.com/keboola/connection/pull/3704
Before asking for review make sure that:

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

---
