### PR TITLE
Test for snflk only.

### DIFF
--- a/tests/Backend/CommonPart1/CreateTableTest.php
+++ b/tests/Backend/CommonPart1/CreateTableTest.php
@@ -109,6 +109,10 @@ class CreateTableTest extends StorageApiTestCase
 
     public function testLoadWithInvalidCSVColumns(): void
     {
+        if ($this->getDefaultBackend($this->_client) !== self::BACKEND_SNOWFLAKE) {
+            $this->markTestSkipped('tmp tested for snflk only');
+        }
+
         $testBucketName = $this->getTestBucketName($this->getTestBucketId());
         $testBucketStage = self::STAGE_IN;
         $testBucketId = $testBucketStage . '.c-' . $testBucketName;


### PR DESCRIPTION
Inc 6455

test for snflk only. There is no change in connection for other backends. Problem is that we run this test against other backends even they are not optimized for it yet.