### PR TITLE
Kbc 2718 app err when linked bucket already exist

### DIFF
--- a/tests/Backend/Mixed/SharingTest.php
+++ b/tests/Backend/Mixed/SharingTest.php
@@ -52,23 +52,24 @@ class SharingTest extends StorageApiSharingTestCase
     public function testTryLinkBucketWithSameNameAsAlreadyCreatedBucketThrowUserException(bool $isAsync): void
     {
         $this->initTestBuckets(self::BACKEND_SNOWFLAKE);
-        $this->dropBucketIfExists($this->_client2, 'out.c-opportunity');
+        $bucketNameToShare = $this->getTestBucketName($this->generateDescriptionForTestObject()) . '-toShare';
+        $this->dropBucketIfExists($this->_client2, 'out.c-' . $bucketNameToShare);
 
-        $bucketToShare = $this->_client2->createBucket('opportunity', self::STAGE_OUT);
+        $bucketToShare = $this->_client2->createBucket($bucketNameToShare, self::STAGE_OUT);
         $this->_client2->shareOrganizationProjectBucket($bucketToShare);
 
         $sharedBuckets = $this->_client->listSharedBuckets();
         $this->assertCount(1, $sharedBuckets);
-        $opportunityBucket = reset($sharedBuckets);
-
+        $sharedBucket = reset($sharedBuckets);
+        $this->assertSame($bucketNameToShare, $sharedBucket['displayName']);
         // linking with existing name API-sharing
         try {
             // API-sharing bucket is created by initTestBuckets() for all the clients=projects
             $this->_client->linkBucket(
                 self::BUCKET_API_SHARING,
                 self::STAGE_IN,
-                $opportunityBucket['project']['id'],
-                $opportunityBucket['id'],
+                $sharedBucket['project']['id'],
+                $sharedBucket['id'],
                 null,
                 $isAsync
             );
@@ -84,8 +85,8 @@ class SharingTest extends StorageApiSharingTestCase
             $this->_client->linkBucket(
                 'not-important',
                 self::STAGE_IN,
-                $opportunityBucket['project']['id'],
-                $opportunityBucket['id'],
+                $sharedBucket['project']['id'],
+                $sharedBucket['id'],
                 self::BUCKET_API_SHARING,
                 $isAsync
             );

--- a/tests/Backend/Mixed/SharingTest.php
+++ b/tests/Backend/Mixed/SharingTest.php
@@ -153,7 +153,8 @@ class SharingTest extends StorageApiSharingTestCase
                 self::STAGE_IN,
                 $sharedBuckets[0]['project']['id'],
                 $sharedBuckets[0]['id'],
-                $displayName
+                $displayName,
+                $isAsync
             );
             $this->fail('bucket can\'t be linked with same displayName');
         } catch (ClientException $e) {
@@ -168,7 +169,8 @@ class SharingTest extends StorageApiSharingTestCase
                 self::STAGE_IN,
                 $sharedBuckets[0]['project']['id'],
                 $sharedBuckets[0]['id'],
-                '&&&&&&'
+                '&&&&&&',
+                $isAsync
             );
             $this->fail('bucket can\'t be linked with same displayName');
         } catch (ClientException $e) {

--- a/tests/Backend/Mixed/StorageApiSharingTestCase.php
+++ b/tests/Backend/Mixed/StorageApiSharingTestCase.php
@@ -11,6 +11,7 @@ use Keboola\Test\StorageApiTestCase;
 abstract class StorageApiSharingTestCase extends StorageApiTestCase
 {
     const TEST_METADATA_PROVIDER = 'test-metadata-provider';
+    public const BUCKET_API_SHARING = 'API-sharing';
 
     /** @var Client */
     protected $_client2;
@@ -172,7 +173,7 @@ abstract class StorageApiSharingTestCase extends StorageApiTestCase
         // recreate buckets in firs project
         $this->_bucketIds = [];
         foreach ([self::STAGE_OUT, self::STAGE_IN] as $stage) {
-            $this->_bucketIds[$stage] = $this->initEmptyBucketForSharingTest('API-sharing', $stage, $backend);
+            $this->_bucketIds[$stage] = $this->initEmptyBucketForSharingTest(self::BUCKET_API_SHARING, $stage, $backend);
         }
 
         return $this->_bucketIds;


### PR DESCRIPTION
Jira: KBC-2718
Connection https://github.com/keboola/connection/pull/3910

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
