### PR TITLE
PS-3719 Log complete response when request fails

### DIFF
--- a/src/Keboola/StorageApi/Client/LogMessageFormatter.php
+++ b/src/Keboola/StorageApi/Client/LogMessageFormatter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StorageApi\Client;
+
+use GuzzleHttp\MessageFormatterInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class LogMessageFormatter implements MessageFormatterInterface
+{
+    public function format(
+        RequestInterface $request,
+        ?ResponseInterface $response = null,
+        ?Throwable $error = null
+    ): string {
+        $message =
+            $request->getMethod() . ' ' .
+            $request->getUri() . ' ' .
+            ($response ? $response->getStatusCode() : 'NULL')
+        ;
+
+        if ($error !== null) {
+            // json_encode is a simple way to make the response single-line
+            $encodedResponse = $response ? json_encode((string) $response->getBody()) : 'NULL';
+
+            $message .= ' ' . $encodedResponse;
+        }
+
+        return $message;
+    }
+}

--- a/tests-unit/Keboola/StorageApi/Client/LogMessageFormatterTest.php
+++ b/tests-unit/Keboola/StorageApi/Client/LogMessageFormatterTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\UnitTest\Keboola\StorageApi\Client;
+
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Keboola\StorageApi\Client\LogMessageFormatter;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class LogMessageFormatterTest extends TestCase
+{
+    /** @dataProvider provideFormatterTestData */
+    public function testFormatter(
+        RequestInterface $request,
+        ?ResponseInterface $response,
+        ?Throwable $error,
+        string $expectedMessage
+    ): void {
+        $formatter = new LogMessageFormatter();
+        $message = $formatter->format($request, $response, $error);
+
+        self::assertSame($expectedMessage, $message);
+    }
+
+    public function provideFormatterTestData(): iterable
+    {
+        yield 'request with complex URL' => [
+            'request' => new Request(
+                'GET',
+                'http://example.com/path?query=value#fragment',
+                [],
+                'request body',
+            ),
+            'response' => new Response(
+                201,
+                [],
+                'response body',
+            ),
+            'error' => null,
+            'message' => 'GET http://example.com/path?query=value#fragment 201',
+        ];
+
+        yield 'POST request' => [
+            'request' => new Request(
+                'POST',
+                'http://example.com/path',
+                [],
+                'request body',
+            ),
+            'response' => new Response(
+                201,
+                [],
+                'response body',
+            ),
+            'error' => null,
+            'message' => 'POST http://example.com/path 201',
+        ];
+
+        yield 'failed request without error' => [
+            'request' => new Request(
+                'GET',
+                'http://example.com/path',
+                [],
+                'request body',
+                '1.0',
+            ),
+            'response' => new Response(
+                500,
+                [],
+                'response body',
+            ),
+            'error' => null,
+            'message' => 'GET http://example.com/path 500',
+        ];
+
+        yield 'failed request' => [
+            'request' => new Request(
+                'GET',
+                'http://example.com/path',
+                [],
+                'request body',
+                '1.0',
+            ),
+            'response' => new Response(
+                400,
+                [],
+                'response',
+            ),
+            'error' => new ClientException('invalid request', new Request('GET', ''), new Response()),
+            'message' => 'GET http://example.com/path 400 "response"',
+        ];
+
+        $longResponse = str_repeat('X', 4*1024*1024);
+        yield 'failed request with long response' => [
+            'request' => new Request(
+                'GET',
+                'http://example.com/path',
+                [],
+                'request body',
+                '1.0',
+            ),
+            'response' => new Response(
+                400,
+                [],
+                $longResponse,
+            ),
+            'error' => new ClientException('invalid request', new Request('GET', ''), new Response()),
+            'message' => 'GET http://example.com/path 400 "'.$longResponse.'"',
+        ];
+
+        yield 'failed request with multi-line response body' => [
+            'request' => new Request(
+                'GET',
+                'http://example.com/path',
+                [],
+                'request body',
+                '1.0',
+            ),
+            'response' => new Response(
+                400,
+                [],
+                '{
+    "hello": "world"
+}
+',
+            ),
+            'error' => new ClientException('invalid request', new Request('GET', ''), new Response()),
+            'message' => 'GET http://example.com/path 400 "{\n    \"hello\": \"world\"\n}\n"',
+        ];
+
+        yield 'error without response' => [
+            'request' => new Request(
+                'GET',
+                'http://example.com/path',
+                [],
+                'request body',
+                '1.0',
+            ),
+            'response' => null,
+            'error' => new ConnectException('failed to cnonect', new Request('GET', '')),
+            'message' => 'GET http://example.com/path NULL NULL',
+        ];
+
+        yield 'error with success response' => [
+            'request' => new Request(
+                'GET',
+                'http://example.com/path',
+                [],
+                'request body',
+                '1.0',
+            ),
+            'response' => new Response(
+                201,
+                [],
+                'response',
+            ),
+            'error' => new ClientException('something has failed', new Request('GET', ''), new Response()),
+            'message' => 'GET http://example.com/path 201 "response"',
+        ];
+    }
+}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PS-3719

Pokud aktualne failne request na Connection, nedovime se u 4xx cely duvod, protoze v logu se objevi jen message z Exception, kterou Guzzle truncatuje https://github.com/guzzle/guzzle/blob/master/src/Exception/RequestException.php#L96. Resit se to da pres `log` middleware, kterou uz pouzivame, ale neni vhodne nakonfigurovana.

* `log` middleware je potreba zaregistrovat tak, aby se pri response vykonala az po `http_errors`, takze to dostane jako failnutou promise a zaloguje message jako `error`, ne `debug` (a na produkci se tim padem do PT propisou jen failnuty requesty) https://github.com/guzzle/guzzle/blob/master/src/Middleware.php#L210
* standardni `MessageFormatter` z Guzzle neumi dat ruznou message pro failnuty request, response body ale chceme posilat do logu jen u failnutych requestu, takze jsem udelal custom formatter
* puvodni format obsahoval z meho pohledu zbytecne informace, ktere jsou asi uzitecne na serveru, ale ne klientovy, ze ktereho request sel - hostname, user agent, timestamp

Nove by to tedy melo fungovat tak, ze:
* kazdy request se posila do loggeru (to platilo i do ted)
* response se stavem < 400 se posle jako `debug`, takze na produkci nebude zalogovana, ma format `{method} {uri} {status}`, takze treba `GET http://example.com/path?query 200`
* response se stavem >= 400 se posle jako `error`, takze na produkci se zaloguje, ma format `{method} {uri} {status} {body}`, takze treba `GET http://example.com/path?query 200 "{\"error\": \"foo\"}"`
* response body se protahuje skrz `json_encode`, ne proto, ze by to byl JSON, ale protoze je AFAIK nejjednodussi zpusob, jak z toho udelat single-line text, aby se response nerozlozila na vic zaznamu v PT

V cem by se to dalo mozna jeste vylepsit je preci jen tam nejaky truncate te response nechat - kdyby prisel 1MB response, co se stane? Zobrazi se to v PT? Orizne to PT? Zahodi to PT? Zahodi/orizne to uz neco u nas na infra? Zatim ale bylo cilem "neorezavat response", tak jsem nad tim zbytecne nespkuloval, asi proste uvidime.

Rad bych aby na review kouknul jak nekdo z Conneciton (protoze SAPI client), tak PS (protoze stejna vec se bude delat i na nasich API klientech).