### PR TITLE
PS-3719 Do not truncate error response inside thrown exception

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -119,6 +119,7 @@ class Client
      *     - awsRetries: number of aws client retries
      *     - logger: instance of Psr\Log\LoggerInterface
      *     - jobPollRetryDelay: callable method which determines wait period for job polling
+     *     - handler: custom Guzzle handler, allows mocking responses in tests
      */
     public function __construct(array $config = [])
     {
@@ -160,14 +161,15 @@ class Client
             $this->setJobPollRetryDelay(createSimpleJobPollDelay());
         }
 
-        $this->initClient();
+        $this->initClient($config);
         $this->tokens = new Tokens($this);
     }
 
-    private function initClient()
+    private function initClient(array $config)
     {
         $handlerStack = HandlerStack::create([
             'backoffMaxTries' => $this->backoffMaxTries,
+            'handler' => $config['handler'] ?? null,
         ]);
 
         $handlerStack->push((RequestTimeoutMiddleware::factory()));

--- a/tests/Common/ExceptionsTest.php
+++ b/tests/Common/ExceptionsTest.php
@@ -10,10 +10,33 @@
  */
 namespace Keboola\Test\Common;
 
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Keboola\StorageApi\ClientException;
 use Keboola\Test\StorageApiTestCase;
 
 class ExceptionsTest extends StorageApiTestCase
 {
+    public function testLongErrorResponseIsNotTruncated(): void
+    {
+        $responseBody = str_repeat('X', 1024*1024);
+
+        $mockHandler = new MockHandler([
+            new Response(400, [], $responseBody),
+        ]);
+
+        $client = $this->getClient([
+            'token' => 'foo',
+            'url' => 'http://example.com',
+            'handler' => $mockHandler,
+        ]);
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage($responseBody);
+
+        $client->apiGet('/');
+    }
+
     public function testException(): void
     {
         $this->expectException(\Keboola\StorageApi\ClientException::class);


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PS-3719
Replaces: https://github.com/keboola/storage-api-php-client/pull/863

Puvodne navrhovanou variantu s tim posilat to do logu jsme nakonec zavrhli, protoze by se tam pak objevovaly i requesty, kde se ocekava, ze muze failnout (zkus neco fetchnout z API a pokud to nexistuje, zalozi se to apod.). Truncatovani nejde uplne vypnout, ale nastavil jsem tam odhadem max. delku 1MiB, to by mohlo byt dost pro jakoukoliv rozumnou reponse.

Soucasti je rozsireni configu klienta o `handler` parametr, kterym jde procpat vlastni Guzzle handler, aby slo v testech mockovat response.
