### PR TITLE
KBC-2866 skip maintenance url page

### DIFF
--- a/tests/Common/MaintenanceTest.php
+++ b/tests/Common/MaintenanceTest.php
@@ -16,6 +16,7 @@ class MaintenanceTest extends StorageApiTestCase
 
     public function testMaintenance(): void
     {
+        self::markTestSkipped("Maintenance page isnt set up for e2e testing yet");
         try {
             $client = $this->getClient([
                 'token' => STORAGE_API_TOKEN,

--- a/tests/Common/MaintenanceTest.php
+++ b/tests/Common/MaintenanceTest.php
@@ -17,22 +17,22 @@ class MaintenanceTest extends StorageApiTestCase
     public function testMaintenance(): void
     {
         self::markTestSkipped('Maintenance page isnt set up for e2e testing yet');
-        try {
-            $client = $this->getClient([
-                'token' => STORAGE_API_TOKEN,
-                'url' => STORAGE_API_MAINTENANCE_URL,
-                'backoffMaxTries' => 2,
-            ]);
-            $client->verifyToken();
-            $this->fail('maintenance exception should be thrown');
-        } catch (\Keboola\StorageApi\MaintenanceException $e) {
-            $this->assertNotEmpty($e->getRetryAfter());
-            $this->assertEquals('MAINTENANCE', $e->getStringCode());
-            $this->assertEquals(503, $e->getCode());
-            $params = $e->getContextParams();
-            $this->assertEquals('maintenance', $params['status']);
-            $this->assertArrayHasKey('reason', $params);
-            $this->assertArrayHasKey('estimatedEndTime', $params);
-        }
+//        try {
+//            $client = $this->getClient([
+//                'token' => STORAGE_API_TOKEN,
+//                'url' => STORAGE_API_MAINTENANCE_URL,
+//                'backoffMaxTries' => 2,
+//            ]);
+//            $client->verifyToken();
+//            $this->fail('maintenance exception should be thrown');
+//        } catch (\Keboola\StorageApi\MaintenanceException $e) {
+//            $this->assertNotEmpty($e->getRetryAfter());
+//            $this->assertEquals('MAINTENANCE', $e->getStringCode());
+//            $this->assertEquals(503, $e->getCode());
+//            $params = $e->getContextParams();
+//            $this->assertEquals('maintenance', $params['status']);
+//            $this->assertArrayHasKey('reason', $params);
+//            $this->assertArrayHasKey('estimatedEndTime', $params);
+//        }
     }
 }

--- a/tests/Common/MaintenanceTest.php
+++ b/tests/Common/MaintenanceTest.php
@@ -16,7 +16,7 @@ class MaintenanceTest extends StorageApiTestCase
 
     public function testMaintenance(): void
     {
-        self::markTestSkipped("Maintenance page isnt set up for e2e testing yet");
+        self::markTestSkipped('Maintenance page isnt set up for e2e testing yet');
         try {
             $client = $this->getClient([
                 'token' => STORAGE_API_TOKEN,


### PR DESCRIPTION
Jira: KBC-2866

maintenance page test will be skipped because maintenance URL won't be defined for new e2e yet -> https://keboola.atlassian.net/browse/KBC-2953

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
