### PR TITLE
KBC-3024 empty string configuration is considered as null

### DIFF
--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -3640,6 +3640,22 @@ class ComponentsTest extends StorageApiTestCase
         $this->assertArrayEqualsExceptKeys($originalConfigRow, $rollbackedConfigRow, ['version', 'changeDescription']);
     }
 
+    public function testCreateConfigurationWithEmptyStringIdWillGenerateTheId(): void
+    {
+        $components = new \Keboola\StorageApi\Components($this->client);
+        $configuration = new \Keboola\StorageApi\Options\Components\Configuration();
+        $componentId = 'wr-db';
+        $configurationId = '';
+        $configuration
+            ->setComponentId($componentId)
+            ->setConfigurationId($configurationId)
+            ->setName('Main');
+
+        $configurationResponse = $components->addConfiguration($configuration);
+
+        $this->assertNotEmpty($configurationResponse['id']);
+    }
+
     /**
      * @dataProvider provideComponentsClientType
      */


### PR DESCRIPTION
Jira: KBC-3024
Connection: https://github.com/keboola/connection/pull/4053

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
