### PR TITLE
fix new phpstan: instead of assert force correct type

### DIFF
--- a/tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
+++ b/tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php
@@ -179,10 +179,8 @@ class RedshiftWorkspaceBackend implements WorkspaceBackend
             [$primary, $primaryPosition, $identity] = [false, null, false];
             if ($row[$contype] == 'p') {
                 $primary = true;
-                assert($row[$conkey] !== null);
-                $primaryPosition = array_search($row[$attnum], explode(',', $row[$conkey])) + 1;
-                assert($row[$default_value] !== null);
-                $identity = (bool) (preg_match('/^nextval/', $row[$default_value]));
+                $primaryPosition = array_search($row[$attnum], explode(',', (string) $row[$conkey])) + 1;
+                $identity = (bool) (preg_match('/^nextval/', (string) $row[$default_value]));
             }
             $desc[$row[$colname]] = [
                 'SCHEMA_NAME' => $row[$nspname],


### PR DESCRIPTION
Po [posledni uprave](https://github.com/keboola/storage-api-php-client/pull/916/commits/e1e6629db495e3b69d9696653d7b28be303537d1) spadly testy pro Redshift:
```
13:16:10-UTC - paratest-backend-redshift-part-1   -	There were 2 errors:
13:16:10-UTC - paratest-backend-redshift-part-1   -	
13:16:10-UTC - paratest-backend-redshift-part-1   -	1) Keboola\Test\Backend\Workspaces\LegacyWorkspacesRedshiftTest::testLoadedPrimaryKeys
13:16:10-UTC - paratest-backend-redshift-part-1   -	assert(): assert($row[$default_***] !== null) failed
13:16:10-UTC - paratest-backend-redshift-part-1   -	
13:16:10-UTC - paratest-backend-redshift-part-1   -	/code/tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php:184
13:16:10-UTC - paratest-backend-redshift-part-1   -	/code/tests/Backend/Workspaces/LegacyWorkspacesRedshiftTest.php:103
13:16:10-UTC - paratest-backend-redshift-part-1   -	/code/vendor/keboola/phpunit-retry-annotations/src/RetryTrait.php:32
13:16:10-UTC - paratest-backend-redshift-part-1   -	
13:16:10-UTC - paratest-backend-redshift-part-1   -	2) Keboola\Test\Backend\Workspaces\WorkspacesRedshiftTest::testLoadedPrimaryKeys
13:16:10-UTC - paratest-backend-redshift-part-1   -	assert(): assert($row[$default_***] !== null) failed
13:16:10-UTC - paratest-backend-redshift-part-1   -	
13:16:10-UTC - paratest-backend-redshift-part-1   -	/code/tests/Backend/Workspaces/Backend/RedshiftWorkspaceBackend.php:184
13:16:10-UTC - paratest-backend-redshift-part-1   -	/code/tests/Backend/Workspaces/WorkspacesRedshiftTest.php:271
13:16:10-UTC - paratest-backend-redshift-part-1   -	/code/vendor/keboola/phpunit-retry-annotations/src/RetryTrait.php:32
```

Vysledky to dava stejne i pro `null`, viz https://3v4l.org/l1WLI.
## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
