### PR TITLE
Make event assertions robust

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3147,7 +3147,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$bucketId of method Keboola\\\\StorageApi\\\\Client\\:\\:bucketExists\\(\\) expects string, mixed given\\.$#"
-			count: 5
+			count: 3
 			path: tests/Backend/Mixed/SharingTest.php
 
 		-
@@ -5072,11 +5072,6 @@ parameters:
 
 		-
 			message: "#^Method Keboola\\\\Test\\\\Common\\\\EventsTest\\:\\:testLargeEventWithinMaxSizeLimit\\(\\) has parameter \\$messageLength with no type specified\\.$#"
-			count: 1
-			path: tests/Common/EventsTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$params of method Keboola\\\\StorageApi\\\\Client\\:\\:listEvents\\(\\) expects array, int given\\.$#"
 			count: 1
 			path: tests/Common/EventsTest.php
 

--- a/tests/Backend/CommonPart1/CreateTableWithConfigurationTest.php
+++ b/tests/Backend/CommonPart1/CreateTableWithConfigurationTest.php
@@ -10,6 +10,7 @@ use Keboola\StorageApi\Options\TableWithConfigurationOptions;
 use Keboola\Test\Backend\TableWithConfigurationUtils;
 use Keboola\Test\ClientProvider\ClientProvider;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 use Keboola\Test\Utils\EventTesterUtils;
 
 class CreateTableWithConfigurationTest extends StorageApiTestCase
@@ -110,16 +111,29 @@ class CreateTableWithConfigurationTest extends StorageApiTestCase
             ],
         ], $table);
 
-        // check events
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationMigrated', $tableId, 10);
-        $this->assertCount(1, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
 
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableCreated', $tableId, 10);
-        $this->assertCount(1, $events);
-        $event = reset($events);
-        $this->assertArrayHasKey('params', $event);
-        $this->assertArrayHasKey('columns', $event['params']);
-        $this->assertEqualsIgnoringCase(['id', 'name'], $event['params']['columns']);
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationMigrated')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+            $event = reset($events);
+            $this->assertArrayHasKey('params', $event);
+            $this->assertArrayHasKey('columns', $event['params']);
+            $this->assertEqualsIgnoringCase(['id', 'name'], $event['params']['columns']);
+        };
+
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableCreated')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 
     public function testTableCreateWithMeaningFullQueryAsSecond(): void
@@ -173,19 +187,32 @@ class CreateTableWithConfigurationTest extends StorageApiTestCase
         ], $table);
 
         // check events
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationMigrated', $tableId, 10);
-        $this->assertCount(2, $events);
-        $event = end($events);
-        $this->assertArrayHasKey('params', $event);
-        $this->assertArrayHasKey('executedQuery', $event['params']);
-        $this->assertSame('SELECT 1', $event['params']['executedQuery']);
-        $event = prev($events);
-        $this->assertArrayHasKey('params', $event);
-        $this->assertArrayHasKey('executedQuery', $event['params']);
-        $this->assertStringContainsString('CREATE TABLE', $event['params']['executedQuery']);
+        $assertCallback = function ($events) {
+            $this->assertCount(2, $events);
+            $event = end($events);
+            $this->assertArrayHasKey('params', $event);
+            $this->assertArrayHasKey('executedQuery', $event['params']);
+            $this->assertSame('SELECT 1', $event['params']['executedQuery']);
+            $event = prev($events);
+            $this->assertArrayHasKey('params', $event);
+            $this->assertArrayHasKey('executedQuery', $event['params']);
+            $this->assertStringContainsString('CREATE TABLE', $event['params']['executedQuery']);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationMigrated')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
 
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableCreated', $tableId, 10);
-        $this->assertCount(1, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableCreated')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 
     public function testTableCreateWithToothLessQuery(): void
@@ -213,9 +240,16 @@ class CreateTableWithConfigurationTest extends StorageApiTestCase
             $configurationOptions
         );
 
-        // check events
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationMigrated', null, 10);
-        $this->assertCount(1, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $objectId = $this->getTestBucketId() . '.custom-table-1';
+
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationMigrated')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($objectId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
 
         $this->expectExceptionMessage('There were no events');
         $this->listEventsFilteredByName($this->client, 'storage.tableCreated', null, 10);
@@ -321,22 +355,43 @@ class CreateTableWithConfigurationTest extends StorageApiTestCase
         }
 
         // check events
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationMigrated', null, 10);
-        $this->assertCount(1, $events);
-        $event = reset($events);
-        $this->assertArrayHasKey('params', $event);
-        $this->assertArrayHasKey('executedQuery', $event['params']);
-        $this->assertStringContainsString('CREATE TABLE', $event['params']['executedQuery']);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+            $event = reset($events);
+            $this->assertArrayHasKey('params', $event);
+            $this->assertArrayHasKey('executedQuery', $event['params']);
+            $this->assertStringContainsString('CREATE TABLE', $event['params']['executedQuery']);
+        };
+        $objectId = $this->getTestBucketId() . '.custom-table-1';
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationMigrated')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($objectId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
 
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationMigrationFailed', null, 10);
-        $this->assertCount(1, $events);
-        $event = reset($events);
-        $this->assertArrayHasKey('params', $event);
-        $this->assertArrayHasKey('executedQuery', $event['params']);
-        $this->assertSame('ASD', $event['params']['executedQuery']);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+            $event = reset($events);
+            $this->assertArrayHasKey('params', $event);
+            $this->assertArrayHasKey('executedQuery', $event['params']);
+            $this->assertSame('ASD', $event['params']['executedQuery']);
+        };
+        $objectId = $this->getTestBucketId() . '.custom-table-1';
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationMigrationFailed')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($objectId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
 
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableCreated', null, 10);
-        $this->assertCount(1, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $objectId = $this->getTestBucketId() . '.custom-table-1';
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationMigrationFailed')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($objectId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 
     public function testCreateAndDeleteTableWithMigration(): void

--- a/tests/Backend/CommonPart1/MigrateTableWithConfigurationTest.php
+++ b/tests/Backend/CommonPart1/MigrateTableWithConfigurationTest.php
@@ -10,6 +10,7 @@ use Keboola\StorageApi\Options\TableWithConfigurationOptions;
 use Keboola\Test\Backend\TableWithConfigurationUtils;
 use Keboola\Test\ClientProvider\ClientProvider;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 use Keboola\Test\Utils\EventTesterUtils;
 
 class MigrateTableWithConfigurationTest extends StorageApiTestCase
@@ -99,7 +100,14 @@ class MigrateTableWithConfigurationTest extends StorageApiTestCase
         ], $table);
 
         // check events
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationMigrated', $tableId, 10);
-        $this->assertCount(2, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(2, $events);
+        };
+
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationMigrated')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 }

--- a/tests/Backend/CommonPart1/RegisterBucketTest.php
+++ b/tests/Backend/CommonPart1/RegisterBucketTest.php
@@ -8,6 +8,7 @@ use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\Workspaces\Backend\SnowflakeWorkspaceBackend;
 use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class RegisterBucketTest extends StorageApiTestCase
 {
@@ -19,6 +20,7 @@ class RegisterBucketTest extends StorageApiTestCase
 
     public function testRegisterBucket(): void
     {
+        $this->initEvents($this->_client);
         $token = $this->_client->verifyToken();
 
         if (!in_array('input-mapping-read-only-storage', $token['owner']['features'])) {
@@ -72,7 +74,14 @@ class RegisterBucketTest extends StorageApiTestCase
             'snowflake',
             'Iam-your-workspace'
         );
-        $this->assertEvents($runId, ['storage.bucketCreated']);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.bucketCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
         $bucket = $this->_client->getBucket($idOfBucket);
         $this->assertTrue($bucket['hasExternalSchema']);
@@ -88,7 +97,24 @@ class RegisterBucketTest extends StorageApiTestCase
 
         $runId = $this->setRunId();
         $this->_client->refreshBucket($idOfBucket);
-        $this->assertEvents($runId, ['storage.tableCreated', 'storage.bucketRefreshed']);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.bucketRefreshed')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
         $tables = $this->_client->listTables($idOfBucket);
         $this->assertCount(1, $tables);
@@ -125,10 +151,24 @@ class RegisterBucketTest extends StorageApiTestCase
 
         $runId = $this->setRunId();
         $this->_client->refreshBucket($idOfBucket);
-        $this->assertEvents($runId, [
-            'storage.tableCreated',
-            'storage.bucketRefreshed',
-        ]);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.bucketRefreshed')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
         $tables = $this->_client->listTables($idOfBucket);
         $this->assertCount(2, $tables);
@@ -140,12 +180,42 @@ class RegisterBucketTest extends StorageApiTestCase
 
         $runId = $this->setRunId();
         $this->_client->refreshBucket($idOfBucket);
-        $this->assertEvents($runId, [
-            'storage.tableDeleted',
-            'storage.tableCreated',
-            'storage.tableColumnsUpdated',
-            'storage.bucketRefreshed',
-        ]);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableDeleted')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableColumnsUpdated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.bucketRefreshed')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
         $tables = $this->_client->listTables($idOfBucket);
         $this->assertCount(2, $tables);
@@ -224,10 +294,24 @@ class RegisterBucketTest extends StorageApiTestCase
             'snowflake',
             'Iam-from-external-db-ext'
         );
-        $this->assertEvents($runId, [
-            'storage.bucketCreated',
-            'storage.tableCreated',
-        ]);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.bucketCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
+
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
         $bucket = $this->_client->getBucket($idOfBucket);
         $this->assertTrue($bucket['hasExternalSchema']);
@@ -293,28 +377,5 @@ class RegisterBucketTest extends StorageApiTestCase
         $runId = $this->_client->generateRunId();
         $this->_client->setRunId($runId);
         return $runId;
-    }
-
-    /**
-     * @param string[] $expectedEventsNames
-     */
-    private function assertEvents(string $runId, array $expectedEventsNames): void
-    {
-        // block until async events are processed, processing in order is not guaranteed but it should work most of time
-        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
-
-        $events = $this->_client->listEvents([
-            'runId' => $runId,
-        ]);
-
-        $eventsNames = [];
-        foreach ($events as $event) {
-            if ($event['event'] === 'ext.dummy.') {
-                continue;
-            }
-            $eventsNames[] = $event['event'];
-        }
-
-        $this->assertSame([], array_diff($expectedEventsNames, $eventsNames));
     }
 }

--- a/tests/Backend/CommonPart1/TableWithConfigurationLoadFromWorkspaceTest.php
+++ b/tests/Backend/CommonPart1/TableWithConfigurationLoadFromWorkspaceTest.php
@@ -9,6 +9,7 @@ use Keboola\Test\Backend\WorkspaceConnectionTrait;
 use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 use Keboola\Test\Backend\Workspaces\ParallelWorkspacesTestCase;
 use Keboola\Test\ClientProvider\ClientProvider;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class TableWithConfigurationLoadFromWorkspaceTest extends ParallelWorkspacesTestCase
 {
@@ -151,12 +152,23 @@ JSON;
             ],
         ], $table);
 
-        // check events
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationImportQuery', $tableId, 50);
-        $this->assertCount(8, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(8, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationImportQuery')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
 
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableImportDone', $tableId, 10);
-        $this->assertCount(1, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableImportDone')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 
     public function testLoadIncrementalFromWorkspaceToTable(): void

--- a/tests/Backend/CommonPart1/TableWithConfigurationLoadTest.php
+++ b/tests/Backend/CommonPart1/TableWithConfigurationLoadTest.php
@@ -10,6 +10,7 @@ use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\Test\Backend\TableWithConfigurationUtils;
 use Keboola\Test\ClientProvider\ClientProvider;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class TableWithConfigurationLoadTest extends StorageApiTestCase
 {
@@ -134,11 +135,23 @@ JSON;
         ], $table);
 
         // check events
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationImportQuery', $tableId, 50);
-        $this->assertCount(8, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(8, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationImportQuery')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
 
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableImportDone', $tableId, 10);
-        $this->assertCount(1, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableImportDone')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 
     public function testLoadFromFileToTableOnError(): void
@@ -451,10 +464,22 @@ JSON;
         ], $table);
 
         // check events
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableWithConfigurationImportQuery', $tableId, 50);
-        $this->assertCount(9, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(9, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableWithConfigurationImportQuery')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
 
-        $events = $this->listEventsFilteredByName($this->client, 'storage.tableImportDone', $tableId, 10);
-        $this->assertCount(1, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableImportDone')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($tableId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 }

--- a/tests/Backend/Mixed/SharingTest.php
+++ b/tests/Backend/Mixed/SharingTest.php
@@ -14,6 +14,7 @@ use Keboola\StorageApi\Options\TokenUpdateOptions;
 use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
 use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class SharingTest extends StorageApiSharingTestCase
 {
@@ -101,6 +102,8 @@ class SharingTest extends StorageApiSharingTestCase
     /** @dataProvider syncAsyncProvider */
     public function testOrganizationPublicSharing($isAsync): void
     {
+        $this->initEvents($this->_client2);
+
         $this->initTestBuckets(self::BACKEND_SNOWFLAKE);
         $bucketId = reset($this->_bucketIds);
 
@@ -283,6 +286,7 @@ class SharingTest extends StorageApiSharingTestCase
             );
         }
 
+        /** @var string $linkedBucketId */
         $linkedBucketId = $client->linkBucket(
             'organization-project-test',
             self::STAGE_IN,
@@ -296,19 +300,23 @@ class SharingTest extends StorageApiSharingTestCase
 
         $this->_client->forceUnlinkBucket($bucketId, $linkedBucketProjectId);
 
-        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
-        $events = $this->_client2->listEvents([
-            'limit' => 1,
-            'q' => 'objectId:' . $linkedBucketId . ' AND objectType:bucket AND project.id:' . $linkedBucketProjectId,
-        ]);
-
-        $this->assertSame('storage.bucketForceUnlinked', $events[0]['event']);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+            $this->assertSame('storage.bucketForceUnlinked', $events[0]['event']);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.bucketForceUnlinked')
+            ->setObjectId($linkedBucketId)
+            ->setObjectType('bucket')
+            ->setProjectId($linkedBucketProjectId);
+        $this->assertEventWithRetries($this->_client2, $assertCallback, $query, 1);
 
         $bucket = $this->_client->getBucket($bucketId);
         $this->assertArrayHasKey('linkedBy', $bucket);
         $this->assertCount(1, $bucket['linkedBy']);
         $this->assertFalse($client->bucketExists($linkedBucketId));
 
+        /** @var string $linkedBucketId */
         $linkedBucketId = $client->linkBucket(
             'organization-project-test',
             self::STAGE_IN,
@@ -322,13 +330,17 @@ class SharingTest extends StorageApiSharingTestCase
 
         $this->_client->forceUnlinkBucket($bucketId, $linkedBucketProjectId, ['async' => true]);
 
-        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
-        $events = $this->_client2->listEvents([
-            'limit' => 1,
-            'q' => 'objectId:' . $linkedBucketId . ' AND objectType:bucket AND project.id:' . $linkedBucketProjectId,
-        ]);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+            $this->assertSame('storage.bucketForceUnlinked', $events[0]['event']);
+        };
 
-        $this->assertSame('storage.bucketForceUnlinked', $events[0]['event']);
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.bucketForceUnlinked')
+            ->setObjectId($linkedBucketId)
+            ->setObjectType('bucket')
+            ->setProjectId($linkedBucketProjectId);
+        $this->assertEventWithRetries($this->_client2, $assertCallback, $query, 1);
 
         $bucket = $this->_client->getBucket($bucketId);
         $this->assertArrayHasKey('linkedBy', $bucket);

--- a/tests/Backend/MixedSnowflakeExasol/SharingTest.php
+++ b/tests/Backend/MixedSnowflakeExasol/SharingTest.php
@@ -9,6 +9,7 @@ use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\Mixed\StorageApiSharingTestCase;
 use Keboola\Test\Backend\WorkspaceConnectionTrait;
 use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class SharingTest extends StorageApiSharingTestCase
 {
@@ -62,6 +63,8 @@ class SharingTest extends StorageApiSharingTestCase
         $workspaceBackend,
         $expectedLoadType
     ): void {
+        $this->initEvents($this->_client2);
+
         //setup test tables
         $this->deleteAllWorkspaces();
         $this->initTestBuckets($sharingBackend);
@@ -158,17 +161,17 @@ class SharingTest extends StorageApiSharingTestCase
 
         $workspaces->loadWorkspaceData($workspace['id'], ['input' => $input]);
 
-        $this->createAndWaitForEvent(
-            (new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'),
-            $this->_client2
-        );
-
-        $events = $this->_client2->listEvents(['runId' => $runId, 'q' => 'storage.workspaceLoaded',]);
-        self::assertCount(3, $events);
-
-        foreach ($events as $event) {
-            self::assertSame($expectedLoadType, $event['results']['loadType']);
-        }
+        $assertCallback = function ($events) use ($expectedLoadType) {
+            $this->assertCount(3, $events);
+            foreach ($events as $event) {
+                self::assertSame($expectedLoadType, $event['results']['loadType']);
+            }
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.workspaceLoaded')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client2, $assertCallback, $query);
 
         $afterJobs = $this->_client2->listJobs();
 
@@ -219,14 +222,15 @@ class SharingTest extends StorageApiSharingTestCase
         $mapping3 = ['source' => str_replace($bucketId, $linkedId, $table3Id), 'destination' => 'table3'];
         $workspaces->loadWorkspaceData($workspace['id'], ['input' => [$mapping3], 'preserve' => true]);
 
-        $this->createAndWaitForEvent(
-            (new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'),
-            $this->_client2
-        );
-
-        $events = $this->_client2->listEvents(['runId' => $runId, 'q' => 'storage.workspaceLoaded',]);
-        self::assertCount(1, $events);
-        self::assertSame($expectedLoadType, $events[0]['results']['loadType']);
+        $assertCallback = function ($events) use ($expectedLoadType) {
+            self::assertCount(1, $events);
+            self::assertSame($expectedLoadType, $events[0]['results']['loadType']);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.workspaceLoaded')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client2, $assertCallback, $query);
 
         $tables = $backend->getTables();
 
@@ -242,14 +246,15 @@ class SharingTest extends StorageApiSharingTestCase
 
         $workspaces->loadWorkspaceData($workspace['id'], ['input' => [$mapping3]]);
 
-        $this->createAndWaitForEvent(
-            (new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'),
-            $this->_client2
-        );
-
-        $events = $this->_client2->listEvents(['runId' => $runId, 'q' => 'storage.workspaceLoaded',]);
-        self::assertCount(1, $events);
-        self::assertSame($expectedLoadType, $events[0]['results']['loadType']);
+        $assertCallback = function ($events) use ($expectedLoadType) {
+            self::assertCount(1, $events);
+            self::assertSame($expectedLoadType, $events[0]['results']['loadType']);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.workspaceLoaded')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client2, $assertCallback, $query);
 
         $tables = $backend->getTables();
         self::assertCount(1, $tables);

--- a/tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
+++ b/tests/Backend/Snowflake/CloneIntoWorkspaceTest.php
@@ -12,6 +12,7 @@ use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\Workspaces\Backend\SnowflakeWorkspaceBackend;
 use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 use Keboola\Test\Backend\Workspaces\WorkspacesTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class CloneIntoWorkspaceTest extends WorkspacesTestCase
 {
@@ -24,6 +25,8 @@ class CloneIntoWorkspaceTest extends WorkspacesTestCase
      */
     public function testClone($aliasNestingLevel): void
     {
+        $this->initEvents($this->_client);
+
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
         $sourceTableId = $this->createTableFromFile(
             $this->_client,
@@ -50,22 +53,25 @@ class CloneIntoWorkspaceTest extends WorkspacesTestCase
         ]);
 
         // test that events are properly created
+        $assertCallback = function ($events) use ($runId, $sourceTableId) {
+            $this->assertCount(1, $events);
+            $cloneEvent = array_pop($events);
+            $this->assertSame('storage.workspaceTableCloned', $cloneEvent['event']);
+            $this->assertSame($runId, $cloneEvent['runId']);
+            $this->assertSame('storage', $cloneEvent['component']);
+            $this->assertSame($sourceTableId, $cloneEvent['objectId']);
+            $this->assertArrayHasKey('params', $cloneEvent);
+            $this->assertSame($sourceTableId, $cloneEvent['params']['source']);
+            $this->assertSame('languagesDetails', $cloneEvent['params']['destination']);
+            $this->assertArrayHasKey('workspace', $cloneEvent['params']);
+        };
 
-        // block until async events are processed, processing in order is not guaranteed but it should work most of time
-        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
-        $events = $this->_client->listEvents([
-            'runId' => $runId,
-        ]);
-        // there are two events, dummy (0) and the clone event (1)
-        $cloneEvent = array_pop($events);
-        $this->assertSame('storage.workspaceTableCloned', $cloneEvent['event']);
-        $this->assertSame($runId, $cloneEvent['runId']);
-        $this->assertSame('storage', $cloneEvent['component']);
-        $this->assertSame($sourceTableId, $cloneEvent['objectId']);
-        $this->assertArrayHasKey('params', $cloneEvent);
-        $this->assertSame($sourceTableId, $cloneEvent['params']['source']);
-        $this->assertSame('languagesDetails', $cloneEvent['params']['destination']);
-        $this->assertArrayHasKey('workspace', $cloneEvent['params']);
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.workspaceTableCloned')
+            ->setTokenId($this->tokenId)
+            ->setObjectId($sourceTableId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
         // test that stats are generated
         $stats = $this->_client->getStats((new \Keboola\StorageApi\Options\StatsOptions())->setRunId($runId));

--- a/tests/Backend/Synapse/CreateTableTest.php
+++ b/tests/Backend/Synapse/CreateTableTest.php
@@ -7,6 +7,7 @@ use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Metadata;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class CreateTableTest extends StorageApiTestCase
 {
@@ -141,6 +142,8 @@ class CreateTableTest extends StorageApiTestCase
 
     public function testCreateTableDefinition(): void
     {
+        $this->initEvents($this->_client);
+
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $runId = $this->_client->generateRunId();
@@ -148,50 +151,51 @@ class CreateTableTest extends StorageApiTestCase
 
         $tableId = $this->_client->createTableDefinition($bucketId, self::TABLE_DEFINITION);
 
-        // block until async events are processed, processing in order is not guaranteed but it should work most of time
-        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
-
         //check that the job has started
-        $events = $this->_client->listEvents([
-            'runId' => $runId,
-        ]);
+        $assertCallback = function ($events) use ($runId) {
+            $this->assertCount(1, $events);
+            $workspaceCreatedEvent = array_pop($events);
+            $this->assertSame($runId, $workspaceCreatedEvent['runId']);
+            $this->assertSame('storage.tableCreated', $workspaceCreatedEvent['event']);
+            $this->assertSame('storage', $workspaceCreatedEvent['component']);
 
-        $workspaceCreatedEvent = array_pop($events);
-        $this->assertSame($runId, $workspaceCreatedEvent['runId']);
-        $this->assertSame('storage.tableCreated', $workspaceCreatedEvent['event']);
-        $this->assertSame('storage', $workspaceCreatedEvent['component']);
+            // event params validation
+            $eventParams = $workspaceCreatedEvent['params'];
 
-        // event params validation
-        $eventParams = $workspaceCreatedEvent['params'];
-
-        $this->assertSame(['id'], $eventParams['primaryKey']);
-        $this->assertSame(
-            [
-                'id',
-                'name',
-            ],
-            $eventParams['columns']
-        );
-        $this->assertSame(
-            [
-                'id' => [
-                    'type' => 'INT',
-                    'length' => null,
-                    'nullable' => true,
+            $this->assertSame(['id'], $eventParams['primaryKey']);
+            $this->assertSame(
+                [
+                    'id',
+                    'name',
                 ],
-                'name' => [
-                    'type' => 'NVARCHAR',
-                    'length' => null,
-                    'nullable' => true,
+                $eventParams['columns']
+            );
+            $this->assertSame(
+                [
+                    'id' => [
+                        'type' => 'INT',
+                        'length' => null,
+                        'nullable' => true,
+                    ],
+                    'name' => [
+                        'type' => 'NVARCHAR',
+                        'length' => null,
+                        'nullable' => true,
+                    ],
                 ],
-            ],
-            $eventParams['columnsTypes']
-        );
-        $this->assertFalse($eventParams['syntheticPrimaryKeyEnabled']);
-        $this->assertSame(['id'], $eventParams['distributionKey']);
-        $this->assertSame('HASH', $eventParams['distribution']);
-        $this->assertSame('CLUSTERED INDEX', $eventParams['indexType']);
-        $this->assertSame(['id'], $eventParams['indexKey']);
+                $eventParams['columnsTypes']
+            );
+            $this->assertFalse($eventParams['syntheticPrimaryKeyEnabled']);
+            $this->assertSame(['id'], $eventParams['distributionKey']);
+            $this->assertSame('HASH', $eventParams['distribution']);
+            $this->assertSame('CLUSTERED INDEX', $eventParams['indexType']);
+            $this->assertSame(['id'], $eventParams['indexKey']);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
         // table properties validation
         $table = $this->_client->getTable($tableId);
@@ -227,6 +231,8 @@ class CreateTableTest extends StorageApiTestCase
 
     public function testCreateTableDefinitionNoPrimaryKey(): void
     {
+        $this->initEvents($this->_client);
+
         $bucketId = $this->getTestBucketId(self::STAGE_IN);
 
         $runId = $this->_client->generateRunId();
@@ -252,26 +258,26 @@ class CreateTableTest extends StorageApiTestCase
 
         $this->_client->createTableDefinition($bucketId, $definition);
 
-        // block until async events are processed, processing in order is not guaranteed but it should work most of time
-        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
+        $assertCallback = function ($events) use ($runId) {
+            $this->assertCount(1, $events);
+            $workspaceCreatedEvent = array_pop($events);
+            self::assertSame($runId, $workspaceCreatedEvent['runId']);
+            self::assertSame('storage.tableCreated', $workspaceCreatedEvent['event']);
+            self::assertSame('storage', $workspaceCreatedEvent['component']);
 
-        //check that the job has started
-        $events = $this->_client->listEvents([
-            'runId' => $runId,
-        ]);
+            // event params validation
+            $eventParams = $workspaceCreatedEvent['params'];
 
-        $workspaceCreatedEvent = array_pop($events);
-        self::assertSame($runId, $workspaceCreatedEvent['runId']);
-        self::assertSame('storage.tableCreated', $workspaceCreatedEvent['event']);
-        self::assertSame('storage', $workspaceCreatedEvent['component']);
-
-        // event params validation
-        $eventParams = $workspaceCreatedEvent['params'];
-
-        // empty PK's
-        self::assertSame([], $eventParams['primaryKey']);
-        self::assertSame([], $eventParams['distributionKey']);
-        self::assertSame('ROUND_ROBIN', $eventParams['distribution']);
+            // empty PK's
+            self::assertSame([], $eventParams['primaryKey']);
+            self::assertSame([], $eventParams['distributionKey']);
+            self::assertSame('ROUND_ROBIN', $eventParams['distribution']);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tableCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
     }
 
     public function testColumnTypesInTableDefinition(): void

--- a/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
+++ b/tests/Backend/Workspaces/LegacyWorkspacesLoadTest.php
@@ -10,6 +10,7 @@ use Keboola\StorageApi\Options\TokenCreateOptions;
 use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\Workspaces\Backend\LegacyInputMappingConverter;
 use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
 {
@@ -53,6 +54,8 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
 
     public function testWorkspaceLoadData(): void
     {
+        $this->initEvents($this->workspaceSapiClient);
+
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
         $workspace = $this->initTestWorkspace();
@@ -133,24 +136,26 @@ class LegacyWorkspacesLoadTest extends ParallelWorkspacesTestCase
         $this->assertCount(1, $tables);
         $this->assertContains($backend->toIdentifier('table3'), $tables);
 
-        // block until async events are processed, processing in order is not guaranteed but it should work most of time
-        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
+        $assertCallback = function ($events) use ($runId, $table1_id) {
+            $this->assertCount(1, $events);
+            // there are two events, dummy (0) and the clone event (1)
+            $loadEvent = array_pop($events);
 
-        $events = $this->_client->listEvents([
-            'runId' => $runId,
-        ]);
+            $this->assertSame('storage.workspaceLoaded', $loadEvent['event']);
+            $this->assertSame($runId, $loadEvent['runId']);
+            $this->assertSame('storage', $loadEvent['component']);
+            $this->assertArrayHasKey('params', $loadEvent);
+            $this->assertSame($table1_id, $loadEvent['params']['source']);
+            $this->assertSame('table3', $loadEvent['params']['destination']);
+            $this->assertArrayHasKey('columns', $loadEvent['params']);
+            $this->assertArrayHasKey('workspace', $loadEvent['params']);
+        };
 
-        // there are two events, dummy (0) and the clone event (1)
-        $loadEvent = array_pop($events);
-
-        $this->assertSame('storage.workspaceLoaded', $loadEvent['event']);
-        $this->assertSame($runId, $loadEvent['runId']);
-        $this->assertSame('storage', $loadEvent['component']);
-        $this->assertArrayHasKey('params', $loadEvent);
-        $this->assertSame($table1_id, $loadEvent['params']['source']);
-        $this->assertSame('table3', $loadEvent['params']['destination']);
-        $this->assertArrayHasKey('columns', $loadEvent['params']);
-        $this->assertArrayHasKey('workspace', $loadEvent['params']);
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.workspaceLoaded')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
     }
 
     public function dataTypesErrorDefinitions()

--- a/tests/Backend/Workspaces/WorkspacesTest.php
+++ b/tests/Backend/Workspaces/WorkspacesTest.php
@@ -10,6 +10,7 @@ use Keboola\Test\Backend\WorkspaceConnectionTrait;
 use Keboola\Test\Backend\WorkspaceCredentialsAssertTrait;
 use Keboola\Test\Backend\Workspaces\Backend\TeradataWorkspaceBackend;
 use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class WorkspacesTest extends ParallelWorkspacesTestCase
 {
@@ -34,6 +35,8 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
      */
     public function testWorkspaceCreate(bool $async): void
     {
+        $this->initEvents($this->workspaceSapiClient);
+
         $workspaces = new Workspaces($this->workspaceSapiClient);
 
         foreach ($this->listTestWorkspaces($this->_client) as $workspace) {
@@ -93,22 +96,30 @@ class WorkspacesTest extends ParallelWorkspacesTestCase
 
         $workspaces->deleteWorkspace($workspace['id'], [], true);
 
-        // block until async events are processed, processing in order is not guaranteed but it should work most of time
-        $this->createAndWaitForEvent((new \Keboola\StorageApi\Event())->setComponent('dummy')->setMessage('dummy'));
+        $assertCallback = function ($events) use ($runId) {
+            $this->assertCount(1, $events);
+            $workspaceCreatedEvent = array_pop($events);
+            $this->assertSame($runId, $workspaceCreatedEvent['runId']);
+            $this->assertSame('storage.workspaceCreated', $workspaceCreatedEvent['event']);
+            $this->assertSame('storage', $workspaceCreatedEvent['component']);
+        };
 
-        $events = $this->_client->listEvents([
-            'runId' => $runId,
-        ]);
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.workspaceCreated')->setRunId($runId);
 
-        $workspaceCreatedEvent = array_pop($events);
-        $this->assertSame($runId, $workspaceCreatedEvent['runId']);
-        $this->assertSame('storage.workspaceCreated', $workspaceCreatedEvent['event']);
-        $this->assertSame('storage', $workspaceCreatedEvent['component']);
+        $this->assertEventWithRetries($this->workspaceSapiClient, $assertCallback, $query);
 
-        $workspaceDeletedEvent = array_pop($events);
-        $this->assertSame($runId, $workspaceDeletedEvent['runId']);
-        $this->assertSame('storage.workspaceDeleted', $workspaceDeletedEvent['event']);
-        $this->assertSame('storage', $workspaceDeletedEvent['component']);
+        $assertCallback = function ($events) use ($runId) {
+            $this->assertCount(1, $events);
+            $workspaceDeletedEvent = array_pop($events);
+            $this->assertSame($runId, $workspaceDeletedEvent['runId']);
+            $this->assertSame('storage.workspaceDeleted', $workspaceDeletedEvent['event']);
+            $this->assertSame('storage', $workspaceDeletedEvent['component']);
+        };
+
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.workspaceDeleted')->setRunId($runId);
+        $this->assertEventWithRetries($this->workspaceSapiClient, $assertCallback, $query);
         $this->assertCredentialsShouldNotWork($connection);
     }
 

--- a/tests/Common/ComponentsTest.php
+++ b/tests/Common/ComponentsTest.php
@@ -16,6 +16,7 @@ use Keboola\StorageApi\Options\Components\ListConfigurationRowVersionsOptions;
 use Keboola\StorageApi\Options\TokenCreateOptions;
 use Keboola\Test\ClientProvider\ClientProvider;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\BufferedOutput;
 use function json_decode;
@@ -1321,6 +1322,7 @@ class ComponentsTest extends StorageApiTestCase
      */
     public function testConfigurationRollback($clientName): void
     {
+        $this->initEvents($this->client);
         $componentsApi = new \Keboola\StorageApi\Components($this->client);
 
         // create configuration
@@ -1358,18 +1360,18 @@ class ComponentsTest extends StorageApiTestCase
         // rollback to version 2 - conf V6
         // second row should be missing, and first row should be rolled back to first version
         $componentsApi->rollbackConfiguration('wr-db', $configurationV1['id'], 2);
-        $this->createAndWaitForEvent((new Event())->setComponent('dummy')->setMessage('dummy'));
 
-        $lastEvent = [];
         if ($clientName === ClientProvider::DEV_BRANCH) {
-            $events = $this->client->listEvents([
-                'component' => 'storage',
-                'q' => 'storage.componentConfigurationRolledBack',
-            ]);
-            $lastEvent = $events[0];
             /** @var BranchAwareClient $branchClient */
             $branchClient = $this->client;
-            $this->assertEquals($branchClient->getCurrentBranchId(), $lastEvent['idBranch']);
+            $assertCallback = function ($events) use ($branchClient) {
+                $this->assertCount(1, $events);
+                $this->assertEquals($branchClient->getCurrentBranchId(), $events[0]['idBranch']);
+            };
+            $query = new EventsQueryBuilder();
+            $query->setEvent('storage.componentConfigurationRolledBack')
+                ->setComponent('storage');
+            $this->assertEventWithRetries($this->client, $assertCallback, $query);
         }
 
         $rollbackedConfiguration = $componentsApi->getConfiguration('wr-db', $configurationV1['id']);
@@ -1409,19 +1411,18 @@ class ComponentsTest extends StorageApiTestCase
 
         // rollback to version 5 - conf V7
         $componentsApi->rollbackConfiguration('wr-db', $configurationV1['id'], 5, 'custom description');
-        $this->createAndWaitForEvent((new Event())->setComponent('dummy')->setMessage('dummy'));
 
         if ($clientName === ClientProvider::DEV_BRANCH) {
-            $events = $this->client->listEvents([
-                'component' => 'storage',
-                'q' => 'storage.componentConfigurationRolledBack',
-                'sinceId' => $lastEvent['id'],
-            ]);
-            $lastEvent = $events[0];
-
             /** @var BranchAwareClient $branchClient */
             $branchClient = $this->client;
-            $this->assertEquals($branchClient->getCurrentBranchId(), $lastEvent['idBranch']);
+            $assertCallback = function ($events) use ($branchClient) {
+                $this->assertCount(2, $events);
+                $this->assertEquals($branchClient->getCurrentBranchId(), $events[0]['idBranch']);
+            };
+            $query = new EventsQueryBuilder();
+            $query->setEvent('storage.componentConfigurationRolledBack')
+                ->setComponent('storage');
+            $this->assertEventWithRetries($this->client, $assertCallback, $query);
         }
 
         $rollbackedConfiguration = $componentsApi->getConfiguration('wr-db', $configurationV1['id']);

--- a/tests/Common/ConfigurationMetadataTest.php
+++ b/tests/Common/ConfigurationMetadataTest.php
@@ -10,6 +10,7 @@ use Keboola\StorageApi\Options\Components\ListConfigurationMetadataOptions;
 use Keboola\Test\ClientProvider\ClientProvider;
 use Keboola\Test\Utils\ComponentsConfigurationUtils;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 use Keboola\Test\Utils\EventTesterUtils;
 use Keboola\Test\Utils\MetadataUtils;
 
@@ -231,24 +232,28 @@ class ConfigurationMetadataTest extends StorageApiTestCase
             ->setMetadata(self::TEST_METADATA);
         $components->addConfigurationMetadata($configurationMetadataOptions);
 
-        $events = $this->listEvents($this->client, 'storage.componentConfigurationMetadataSet');
-
-        self::assertSame(self::TEST_METADATA, $events[0]['results']['metadata']);
-
-        $this->assertEvent(
-            $events[0],
-            'storage.componentConfigurationMetadataSet',
-            'Component configuration metadata set "Component metadata event" (wr-db)',
-            $configurationOptions->getConfigurationId(),
-            'Component metadata event',
-            'componentConfiguration',
-            [
-                'component' => 'wr-db',
-                'configurationId' => $configurationOptions->getConfigurationId(),
-                'name' => 'Component metadata event',
-                'version' => 1,
-            ]
-        );
+        $assertCallback = function ($events) use ($configurationOptions) {
+            $this->assertCount(1, $events);
+            self::assertSame(self::TEST_METADATA, $events[0]['results']['metadata']);
+            $this->assertEvent(
+                $events[0],
+                'storage.componentConfigurationMetadataSet',
+                'Component configuration metadata set "Component metadata event" (wr-db)',
+                $configurationOptions->getConfigurationId(),
+                'Component metadata event',
+                'componentConfiguration',
+                [
+                    'component' => 'wr-db',
+                    'configurationId' => $configurationOptions->getConfigurationId(),
+                    'name' => 'Component metadata event',
+                    'version' => 1,
+                ]
+            );
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.componentConfigurationMetadataSet')
+            ->setTokenId($this->tokenId);
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 
     public function testCreateBranchCopyMetadataToTheDevBranch(): void
@@ -550,6 +555,7 @@ class ConfigurationMetadataTest extends StorageApiTestCase
         $defaultBranchId = $this->getDefaultBranchId($this);
 
         $branchClient = $this->getBranchAwareDefaultClient($defaultBranchId);
+        $this->initEvents($branchClient);
         $components = new Components($branchClient);
 
         $configurationOptions = $this->createConfiguration(
@@ -565,26 +571,31 @@ class ConfigurationMetadataTest extends StorageApiTestCase
 
         $components->deleteConfigurationMetadata('wr-db', 'component-metadata-events-test', $newMetadata[0]['id']);
 
-        $events = $this->listEvents($branchClient, 'storage.componentConfigurationMetadataDeleted');
-
-        $this->assertEvent(
-            $events[0],
-            'storage.componentConfigurationMetadataDeleted',
-            sprintf(
-                'Deleted component configuration metadata id "%s" with key "KBC.SomeEnity.metadataKey"',
-                (int) $newMetadata[0]['id']
-            ),
-            $configurationOptions->getConfigurationId(),
-            'Component metadata events',
-            'componentConfiguration',
-            [
-                'component' => 'wr-db',
-                'configurationId' => $configurationOptions->getConfigurationId(),
-                'name' => 'Component metadata events',
-                'version' => 1,
-                'metadataId' => (int) $newMetadata[0]['id'],
-                'key' => 'KBC.SomeEnity.metadataKey',
-            ]
-        );
+        $assertCallback = function ($events) use ($configurationOptions, $newMetadata) {
+            $this->assertCount(1, $events);
+            $this->assertEvent(
+                $events[0],
+                'storage.componentConfigurationMetadataDeleted',
+                sprintf(
+                    'Deleted component configuration metadata id "%s" with key "KBC.SomeEnity.metadataKey"',
+                    (int) $newMetadata[0]['id']
+                ),
+                $configurationOptions->getConfigurationId(),
+                'Component metadata events',
+                'componentConfiguration',
+                [
+                    'component' => 'wr-db',
+                    'configurationId' => $configurationOptions->getConfigurationId(),
+                    'name' => 'Component metadata events',
+                    'version' => 1,
+                    'metadataId' => (int) $newMetadata[0]['id'],
+                    'key' => 'KBC.SomeEnity.metadataKey',
+                ]
+            );
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.componentConfigurationMetadataDeleted')
+            ->setTokenId($this->tokenId);
+        $this->assertEventWithRetries($branchClient, $assertCallback, $query);
     }
 }

--- a/tests/Common/EventsTest.php
+++ b/tests/Common/EventsTest.php
@@ -13,6 +13,7 @@ namespace Keboola\Test\Common;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Event;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 
 class EventsTest extends StorageApiTestCase
 {
@@ -212,22 +213,20 @@ class EventsTest extends StorageApiTestCase
 
     public function testEventList(): void
     {
+        $this->initEvents($this->_client);
         // at least one event should be generated
         $this->_client->listBuckets();
 
-        $events = $this->_client->listEvents(1);
-        $this->assertCount(1, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
     }
 
     public function testEventsFiltering(): void
     {
-        $events = $this->_client->listEvents([
-            'limit' => 100,
-            'offset' => 0,
-        ]);
-
-        $lastEvent = reset($events);
-        $lastEventId = $lastEvent['id'];
+        $this->initEvents($this->_client);
 
         // we have assign runId to isolate testing events,
         // because if someone displays navigation in KBC "bucketListed" event is created
@@ -246,27 +245,29 @@ class EventsTest extends StorageApiTestCase
         $event->setMessage('another');
         $this->createAndWaitForEvent($event);
 
-        $events = $this->_client->listEvents([
-            'sinceId' => $lastEventId,
-            'runId' => $runId,
-        ]);
+        $assertCallback = function ($events) {
+            $this->assertCount(3, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
-        $this->assertCount(3, $events);
-
-        $events = $this->_client->listEvents([
-            'sinceId' => $lastEventId,
-            'component' => 'transformation',
-        ]);
-        $this->assertCount(1, $events, 'filter by component');
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events, 'filter by component');
+        };
+        $query = new EventsQueryBuilder();
+        $query->setComponent('transformation');
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
 
         $event->setRunId('rundId2');
         $this->createAndWaitForEvent($event);
 
-        $events = $this->_client->listEvents([
-            'sinceId' => $lastEventId,
-            'runId' => $runId,
-        ]);
-        $this->assertCount(3, $events);
+        $assertCallback = function ($events) {
+            $this->assertCount(3, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
     }
 
     public function testEventsSearch(): void

--- a/tests/Common/SearchComponentsConfigurationsTest.php
+++ b/tests/Common/SearchComponentsConfigurationsTest.php
@@ -10,6 +10,7 @@ use Keboola\StorageApi\Options\Components\SearchComponentConfigurationsOptions;
 use Keboola\Test\ClientProvider\ClientProvider;
 use Keboola\Test\Utils\ComponentsConfigurationUtils;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 use Keboola\Test\Utils\EventTesterUtils;
 
 class SearchComponentsConfigurationsTest extends StorageApiTestCase
@@ -312,6 +313,7 @@ class SearchComponentsConfigurationsTest extends StorageApiTestCase
      */
     public function testSearchComponentsEvent(): void
     {
+        $this->initEvents($this->client);
         $components = new Components($this->client);
         $configurationOptions = $this->createConfiguration(
             $components,
@@ -328,25 +330,30 @@ class SearchComponentsConfigurationsTest extends StorageApiTestCase
             ->setInclude(['filteredMetadata'])
             ->setMetadataKeys(['KBC.SomeEnity.metadataKey']));
 
-        $events = $this->listEvents($this->client, 'storage.componentsSearched');
-        /** @var array $event */
-        $event = reset($events);
-        self::assertArrayHasKey('event', $event);
-        self::assertEquals('storage.componentsSearched', $event['event']);
-        self::assertArrayHasKey('message', $event);
-        self::assertEquals('Components were searched', $event['message']);
-        self::assertArrayHasKey('token', $event);
-        self::assertEquals($this->tokenId, $event['token']['id']);
-        self::assertArrayHasKey('params', $event);
-        self::assertSame(
-            [
-                'idComponent' => null,
-                'configurationId' => 'component-search-metadata-events-test',
-                'metadataKeys' => ['KBC.SomeEnity.metadataKey'],
-                'include' => ['filteredMetadata'],
-            ],
-            $event['params']
-        );
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+            /** @var array $event */
+            $event = reset($events);
+            self::assertArrayHasKey('event', $event);
+            self::assertEquals('storage.componentsSearched', $event['event']);
+            self::assertArrayHasKey('message', $event);
+            self::assertEquals('Components were searched', $event['message']);
+            self::assertArrayHasKey('token', $event);
+            self::assertEquals($this->tokenId, $event['token']['id']);
+            self::assertArrayHasKey('params', $event);
+            self::assertSame(
+                [
+                    'idComponent' => null,
+                    'configurationId' => 'component-search-metadata-events-test',
+                    'metadataKeys' => ['KBC.SomeEnity.metadataKey'],
+                    'include' => ['filteredMetadata'],
+                ],
+                $event['params']
+            );
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.componentsSearched');
+        $this->assertEventWithRetries($this->client, $assertCallback, $query);
     }
 
 

--- a/tests/Common/TokensShareTest.php
+++ b/tests/Common/TokensShareTest.php
@@ -4,6 +4,7 @@ namespace Keboola\Test\Common;
 
 use Keboola\StorageApi\Options\TokenCreateOptions;
 use Keboola\Test\StorageApiTestCase;
+use Keboola\Test\Utils\EventsQueryBuilder;
 use Keboola\Test\Utils\EventTesterUtils;
 
 class TokensShareTest extends StorageApiTestCase
@@ -26,9 +27,15 @@ class TokensShareTest extends StorageApiTestCase
         $this->initEvents($this->_client);
         $newToken = $this->tokens->createToken(new TokenCreateOptions());
         $this->tokens->shareToken($newToken['id'], 'test@devel.keboola.com', 'Hi');
-        $events = $this->listEvents($this->_client, 'storage.tokenShared');
-        $this->assertGreaterThanOrEqual(1, count($events));
-        $this->assertSame('storage.tokenShared', $events[0]['event']);
-        $this->assertSame('test@devel.keboola.com', $events[0]['params']['recipientEmail']);
+
+        $assertCallback = function ($events) {
+            $this->assertGreaterThanOrEqual(1, count($events));
+            $this->assertSame('storage.tokenShared', $events[0]['event']);
+            $this->assertSame('test@devel.keboola.com', $events[0]['params']['recipientEmail']);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.tokenShared')
+            ->setTokenId($this->tokenId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
     }
 }

--- a/tests/Utils/EventTesterUtils.php
+++ b/tests/Utils/EventTesterUtils.php
@@ -94,6 +94,23 @@ trait EventTesterUtils
         });
     }
 
+    public function assertEventWithRetries(
+        Client $client,
+        callable $assertCallback,
+        EventsQueryBuilder $query,
+        int $limit = 10
+    ): void {
+        $query = $query->generateQuery();
+
+        $apiCall = fn() => $client->listEvents([
+                'sinceId' => $this->lastEventId,
+                'limit' => $limit,
+                'q' => $query,
+            ]);
+
+        $this->retryWithCallback($apiCall, $assertCallback);
+    }
+
     /**
      * @param int|string|null $expectedObjectId
      */

--- a/tests/Utils/EventsQueryBuilder.php
+++ b/tests/Utils/EventsQueryBuilder.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Test\Utils;
+
+class EventsQueryBuilder
+{
+    private array $params = [];
+
+    public function setTokenId(string $tokenId): self
+    {
+        $this->params[] = 'token.id:'. $tokenId;
+
+        return $this;
+    }
+
+    public function setEvent(string $event): self
+    {
+        $this->params[] = 'event:' . $event;
+
+        return $this;
+    }
+
+    public function setObjectId(string $objectId): self
+    {
+        $this->params[] = 'objectId:' . $objectId;
+
+        return $this;
+    }
+
+    public function setIdBranch(string $idBranch): self
+    {
+        $this->params[] = 'idBranch:' . $idBranch;
+
+        return $this;
+    }
+
+    public function setComponent(string $component): self
+    {
+        $this->params[] = 'component:' . $component;
+
+        return $this;
+    }
+
+    public function setRunId(string $runId): self
+    {
+        $this->params[] = 'runId:' . $runId;
+
+        return $this;
+    }
+
+    public function setProjectId(string $projectId): self
+    {
+        $this->params[] = 'project.id:' . $projectId;
+
+        return $this;
+    }
+
+    public function setObjectType(string $objectType): self
+    {
+        $this->params[] = 'objectType:' . $objectType;
+
+        return $this;
+    }
+
+    public function generateQuery(): string
+    {
+        return implode(' AND ', $this->params);
+    }
+}

--- a/tests/Utils/EventsQueryBuilderTest.php
+++ b/tests/Utils/EventsQueryBuilderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Test\Utils;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+
+class EventsQueryBuilderTest extends TestCase
+{
+    /**
+     * @dataProvider eventsQueryBuilderProvider
+     */
+    public function testBuildQuery(EventsQueryBuilder $queryBuilder, string $expectedQuery): void
+    {
+        $this->assertSame($expectedQuery, $queryBuilder->generateQuery());
+    }
+
+    public function eventsQueryBuilderProvider(): Generator
+    {
+        yield 'tokenId and runId' => [
+            (new EventsQueryBuilder())->setTokenId('1234-1234')->setRunId('123'),
+            'token.id:1234-1234 AND runId:123',
+        ];
+
+        yield 'one parameter' => [
+            (new EventsQueryBuilder())->setRunId('123'),
+            'runId:123',
+        ];
+
+        yield 'all parameters' => [
+            (new EventsQueryBuilder())
+                ->setTokenId('123-token')
+                ->setEvent('storage.createBucket')
+                ->setObjectId('obj-123')
+                ->setIdBranch('branch-123')
+                ->setComponent('wr-db')
+                ->setRunId('123')
+                ->setProjectId('project-123')
+                ->setObjectType('obj-123'),
+            'token.id:123-token AND event:storage.createBucket AND objectId:obj-123 AND idBranch:branch-123'
+            . ' AND component:wr-db AND runId:123 AND project.id:project-123 AND objectType:obj-123',
+        ];
+
+        yield 'other random params' => [
+            (new EventsQueryBuilder())->setProjectId('1234-1234')->setEvent('123'),
+            'project.id:1234-1234 AND event:123',
+        ];
+    }
+}


### PR DESCRIPTION
Jira: CT-791

Pridavam novu metodu ktora robi retry pokial sa nesplni assert v anonymnej metode ktoru posielam do tejto metody (je tam obmedzeny pocet retries). Dalej tuto metodu pouzivam na miestach kde testujeme eventy co by malo pomoct tomu aby testy padali na tom ze eventu nenajde alebo najde na miesto pozadovanej dummy eventu.  

Tu presiel tag kde nepadli ziadne testy na eventach https://dev.azure.com/keboola-dev/Connection%20build/_build/results?buildId=29885&view=logs&j=ae13dfb3-00c3-5552-9b00-63e26024fcba&t=b561c83b-ef20-59aa-7385-caea4d938bd8

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
