### PR TITLE
Add retry when bq request fails

### DIFF
--- a/tests/Backend/Workspaces/Backend/BigQueryClientHandler.php
+++ b/tests/Backend/Workspaces/Backend/BigQueryClientHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Test\Backend\Workspaces\Backend;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class BigQueryClientHandler
+{
+    private Client $client;
+    private int $maxRetries;
+
+    public function __construct(Client $client, int $maxRetries = 3)
+    {
+        $this->client = $client;
+        $this->maxRetries = $maxRetries;
+    }
+
+    public function __invoke(RequestInterface $request, array $options): ResponseInterface
+    {
+        $retries = 0;
+        do {
+            try {
+                return $this->client->send($request);
+            } catch (RequestException $e) {
+                if ($retries >= $this->maxRetries) {
+                    throw $e;
+                }
+                echo sprintf('Retrying (%s/%s)' . PHP_EOL, $retries + 1, $this->maxRetries);
+            }
+            usleep(500000); // wait for 0.5 seconds before retrying
+            $retries++;
+        } while ($retries <= $this->maxRetries);
+        throw new \LogicException('Max retries exceeded');
+    }
+}

--- a/tests/Backend/Workspaces/Backend/BigqueryWorkspaceBackend.php
+++ b/tests/Backend/Workspaces/Backend/BigqueryWorkspaceBackend.php
@@ -3,6 +3,7 @@
 namespace Keboola\Test\Backend\Workspaces\Backend;
 
 use Google\Cloud\BigQuery\BigQueryClient;
+use GuzzleHttp\Client;
 use Keboola\Datatype\Definition\Bigquery;
 use Keboola\StorageApi\Exception;
 use Keboola\TableBackendUtils\Column\Bigquery\BigqueryColumn;
@@ -23,8 +24,11 @@ class BigqueryWorkspaceBackend implements WorkspaceBackend
      */
     public function __construct(array $workspace)
     {
+        $handler = new BigQueryClientHandler(new Client());
+
         $bqClient = new BigQueryClient([
             'keyFile' => $workspace['connection']['credentials'],
+            'httpHandler' => $handler,
         ]);
 
         assert($bqClient instanceof BigQueryClient);


### PR DESCRIPTION
Jira: CT-894
KBC: XXX

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

V sapi klientovy v testoch sa pouziva tiez bq client a stane sa v testoch obcas ze BQ trva okial sa prejavia nejake permission tak pridavam vlastny retry handler. Skusi to 3x a potom vypise pripadne tu chybu
<img width="1254" alt="Screenshot 2023-03-01 at 12 55 55" src="https://user-images.githubusercontent.com/6448364/222132726-46c38d0c-22da-489c-8e1f-4f7830e4ac87.png">
