### PR TITLE
CT-910 register external table

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2188,7 +2188,7 @@ Lists tables in a given bucket.
                     "isAlias": false,
                     "isAliasable": true,
                     "isTyped": false,
-                    "tableKind": "table",
+                    "tableType": "table",
                     "metadata": [
                         {
                             "id": "206180828",
@@ -2224,7 +2224,7 @@ Lists tables in a given bucket.
                     "isAlias": true,
                     "isAliasable": true,
                     "isTyped": false,
-                    "tableKind": "table",
+                    "tableType": "table",
                     "sourceTable": {
                         "id": "in.c-keboola-ex-db-snowflake-528221294.datatypes",
                         "uri": "https://connection.keboola.com/v2/storage/tables/in.c-keboola-ex-db-snowflake-528221294.datatypes",
@@ -3345,7 +3345,7 @@ Obtains information about a table.
                 "isAlias": true,
                 "isAliasable": true,
                 "isTyped": false,
-                "tableKind": "table",
+                "tableType": "table",
                 "definition": {
                     "primaryKeysNames": [],
                     "columns": [
@@ -3466,7 +3466,7 @@ Synchronous call response (async=false)
                 "isAlias": true,
                 "isAliasable": true,
                 "isTyped": false,
-                "tableKind": "table",
+                "tableType": "table",
                 "sourceTable": {
                     "id": "in.c-application-testing.cashier-data",
                     "uri": "https://connection.keboola.com/v2/storage/tables/in.c-application-testing.cashier-data",
@@ -3656,7 +3656,7 @@ attributes and information about the containing bucket.
                     "isAlias": false,
                     "isAliasable": true,
                     "isTyped": false,
-                    "tableKind": "table",
+                    "tableType": "table",
                     "columns": [
                         "time_spent_in_shop",
                         "number_of_items",
@@ -3711,7 +3711,7 @@ attributes and information about the containing bucket.
                     "isAlias": true,
                     "isAliasable": true,
                     "isTyped": false,
-                    "tableKind": "table",
+                    "tableType": "table",
                     "sourceTable": {
                         "id": "in.c-application-testing.cashier-data",
                         "uri": "https:\/\/connection.keboola.com\/v2\/storage\/tables\/in.c-application-testing.cashier-data",
@@ -8045,7 +8045,7 @@ attributes and information about the containing bucket. At least one of paramete
                     "isAlias": false,
                     "isAliasable": true,
                     "isTyped": false,
-                    "tableKind": "table",
+                    "tableType": "table",
                     "columns": [
                         "time_spent_in_shop",
                         "number_of_items"
@@ -8093,7 +8093,7 @@ attributes and information about the containing bucket. At least one of paramete
                     "isAlias": true,
                     "isAliasable": true,
                     "isTyped": false,
-                    "tableKind": "table",
+                    "tableType": "table",
                     "sourceTable": {
                         "id": "in.c-application-testing.cashier-data",
                         "uri": "https:\/\/connection.keboola.com\/v2\/storage\/tables\/in.c-application-testing.cashier-data",

--- a/apiary.apib
+++ b/apiary.apib
@@ -2188,6 +2188,7 @@ Lists tables in a given bucket.
                     "isAlias": false,
                     "isAliasable": true,
                     "isTyped": false,
+                    "tableKind": "table",
                     "metadata": [
                         {
                             "id": "206180828",
@@ -2223,6 +2224,7 @@ Lists tables in a given bucket.
                     "isAlias": true,
                     "isAliasable": true,
                     "isTyped": false,
+                    "tableKind": "table",
                     "sourceTable": {
                         "id": "in.c-keboola-ex-db-snowflake-528221294.datatypes",
                         "uri": "https://connection.keboola.com/v2/storage/tables/in.c-keboola-ex-db-snowflake-528221294.datatypes",
@@ -3343,6 +3345,7 @@ Obtains information about a table.
                 "isAlias": true,
                 "isAliasable": true,
                 "isTyped": false,
+                "tableKind": "table",
                 "definition": {
                     "primaryKeysNames": [],
                     "columns": [
@@ -3463,6 +3466,7 @@ Synchronous call response (async=false)
                 "isAlias": true,
                 "isAliasable": true,
                 "isTyped": false,
+                "tableKind": "table",
                 "sourceTable": {
                     "id": "in.c-application-testing.cashier-data",
                     "uri": "https://connection.keboola.com/v2/storage/tables/in.c-application-testing.cashier-data",
@@ -3652,6 +3656,7 @@ attributes and information about the containing bucket.
                     "isAlias": false,
                     "isAliasable": true,
                     "isTyped": false,
+                    "tableKind": "table",
                     "columns": [
                         "time_spent_in_shop",
                         "number_of_items",
@@ -3706,6 +3711,7 @@ attributes and information about the containing bucket.
                     "isAlias": true,
                     "isAliasable": true,
                     "isTyped": false,
+                    "tableKind": "table",
                     "sourceTable": {
                         "id": "in.c-application-testing.cashier-data",
                         "uri": "https:\/\/connection.keboola.com\/v2\/storage\/tables\/in.c-application-testing.cashier-data",
@@ -8039,6 +8045,7 @@ attributes and information about the containing bucket. At least one of paramete
                     "isAlias": false,
                     "isAliasable": true,
                     "isTyped": false,
+                    "tableKind": "table",
                     "columns": [
                         "time_spent_in_shop",
                         "number_of_items"
@@ -8086,6 +8093,7 @@ attributes and information about the containing bucket. At least one of paramete
                     "isAlias": true,
                     "isAliasable": true,
                     "isTyped": false,
+                    "tableKind": "table",
                     "sourceTable": {
                         "id": "in.c-application-testing.cashier-data",
                         "uri": "https:\/\/connection.keboola.com\/v2\/storage\/tables\/in.c-application-testing.cashier-data",

--- a/tests/Backend/ExternalBuckets/SnowflakeRegisterBucketTest.php
+++ b/tests/Backend/ExternalBuckets/SnowflakeRegisterBucketTest.php
@@ -355,33 +355,8 @@ SQL
         $this->assertCount(1, $tables);
         $firstTable = $tables[0];
         $this->assertEquals('MY_LITTLE_EXT_TABLE', $firstTable['name']);
-        $tableMetadata = $firstTable['metadata'];
 
-        // remove dynamic stuff from metadata
-        foreach ($tableMetadata as &$item) {
-            unset($item['id'], $item['timestamp']);
-        }
-
-        // sort it to be able to compare it with static array
-        usort($tableMetadata, function ($a, $b) {
-            return strcmp($a['key'], $b['key']);
-        });
-
-        $this->assertSame(
-            [
-                [
-                    'key' => 'KBC.dataTypesEnabled',
-                    'value' => 'true',
-                    'provider' => 'storage',
-                ],
-                [
-                    'key' => 'KBC.external-bucket_table-type',
-                    'value' => 'external',
-                    'provider' => 'storage',
-                ],
-            ],
-            $tableMetadata
-        );
+        $this->assertSame($firstTable['tableKind'], 'external');
 
         $db->executeQuery(
             <<<SQL
@@ -396,34 +371,8 @@ SQL
         $this->assertCount(1, $tables);
         $firstTable = $tables[0];
         $this->assertEquals('MY_LITTLE_EXT_TABLE', $firstTable['name']);
-        $tableMetadata = $firstTable['metadata'];
 
-        // remove dynamic stuff from metadata
-        foreach ($tableMetadata as &$item) {
-            unset($item['id'], $item['timestamp']);
-        }
-
-        // sort it to be able to compare it with static array
-        usort($tableMetadata, function ($a, $b) {
-            return strcmp($a['key'], $b['key']);
-        });
-
-        $this->assertSame(
-            [
-                [
-                    'key' => 'KBC.dataTypesEnabled',
-                    'value' => 'true',
-                    'provider' => 'storage',
-                ],
-                [
-                    'key' => 'KBC.external-bucket_table-type',
-                    // external table has been replaced by table
-                    'value' => 'table',
-                    'provider' => 'storage',
-                ],
-            ],
-            $tableMetadata
-        );
+        $this->assertSame($firstTable['tableKind'], 'table');
     }
 
     public function testRegisterExternalDB(): void

--- a/tests/Backend/ExternalBuckets/SnowflakeRegisterBucketTest.php
+++ b/tests/Backend/ExternalBuckets/SnowflakeRegisterBucketTest.php
@@ -15,6 +15,7 @@ class SnowflakeRegisterBucketTest extends BaseExternalBuckets
     {
         parent::setUp();
     }
+
     public function testRegisterBucket(): void
     {
         $this->initEvents($this->_client);
@@ -291,6 +292,138 @@ class SnowflakeRegisterBucketTest extends BaseExternalBuckets
 
         // drop external bucket
         $this->_client->dropBucket($idOfBucket, ['force' => true, 'async' => true]);
+    }
+
+    public function testRegistrationOfExternalTable(): void
+    {
+        $this->dropBucketIfExists($this->_client, 'in.test-bucket-registration', true);
+        $this->initEvents($this->_client);
+
+        $ws = new Workspaces($this->_client);
+        // prepare workspace
+        $workspace = $ws->createWorkspace();
+
+        $db = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+
+        // doesn't matter that the data are not valid, we just need to create the table structure
+        $db->executeQuery(
+            <<<SQL
+CREATE OR REPLACE STAGE s3_stage URL = 's3://xxxx'
+    CREDENTIALS = ( AWS_KEY_ID = 'XXX' AWS_SECRET_KEY = 'YYY');
+SQL
+        );
+        $db->executeQuery(
+            <<<SQL
+CREATE OR REPLACE
+EXTERNAL TABLE MY_LITTLE_EXT_TABLE (
+    ID NUMBER(38,0) AS (VALUE:c1::INT),
+    FIRST_NAME VARCHAR(255) AS (VALUE:c2::STRING)
+    ) 
+    LOCATION=@s3_stage/data 
+    REFRESH_ON_CREATE = FALSE 
+    AUTO_REFRESH = FALSE 
+    FILE_FORMAT = (TYPE = CSV SKIP_HEADER=1 TRIM_SPACE=TRUE );
+SQL
+        );
+
+        // register workspace as external bucket including external table
+        $runId = $this->setRunId();
+        $idOfBucket = $this->_client->registerBucket(
+            'test-bucket-registration',
+            [$workspace['connection']['database'], $workspace['connection']['schema']],
+            'in',
+            'Iam in workspace',
+            'snowflake',
+            'Iam-your-workspace'
+        );
+        $assertCallback = function ($events) {
+            $this->assertCount(1, $events);
+        };
+        $query = new EventsQueryBuilder();
+        $query->setEvent('storage.bucketCreated')
+            ->setTokenId($this->tokenId)
+            ->setRunId($runId);
+        $this->assertEventWithRetries($this->_client, $assertCallback, $query);
+
+        // check external bucket
+        $bucket = $this->_client->getBucket($idOfBucket);
+        $this->assertTrue($bucket['hasExternalSchema']);
+        $this->assertSame($workspace['connection']['database'], $bucket['databaseName']);
+
+        // check table existence and metadata
+        $tables = $this->_client->listTables($idOfBucket);
+        $this->assertCount(1, $tables);
+        $firstTable = $tables[0];
+        $this->assertEquals('MY_LITTLE_EXT_TABLE', $firstTable['name']);
+        $tableMetadata = $firstTable['metadata'];
+
+        // remove dynamic stuff from metadata
+        foreach ($tableMetadata as &$item) {
+            unset($item['id'], $item['timestamp']);
+        }
+
+        // sort it to be able to compare it with static array
+        usort($tableMetadata, function ($a, $b) {
+            return strcmp($a['key'], $b['key']);
+        });
+
+        $this->assertSame(
+            [
+                [
+                    'key' => 'KBC.dataTypesEnabled',
+                    'value' => 'true',
+                    'provider' => 'storage',
+                ],
+                [
+                    'key' => 'KBC.external-bucket_table-type',
+                    'value' => 'external',
+                    'provider' => 'storage',
+                ],
+            ],
+            $tableMetadata
+        );
+
+        $db->executeQuery(
+            <<<SQL
+DROP TABLE MY_LITTLE_EXT_TABLE;
+SQL
+        );
+        $db->createTable('MY_LITTLE_EXT_TABLE', ['AMOUNT' => 'NUMBER', 'DESCRIPTION' => 'TEXT']);
+        $this->_client->refreshBucket($idOfBucket);
+
+        // check table existence and metadata
+        $tables = $this->_client->listTables($idOfBucket);
+        $this->assertCount(1, $tables);
+        $firstTable = $tables[0];
+        $this->assertEquals('MY_LITTLE_EXT_TABLE', $firstTable['name']);
+        $tableMetadata = $firstTable['metadata'];
+
+        // remove dynamic stuff from metadata
+        foreach ($tableMetadata as &$item) {
+            unset($item['id'], $item['timestamp']);
+        }
+
+        // sort it to be able to compare it with static array
+        usort($tableMetadata, function ($a, $b) {
+            return strcmp($a['key'], $b['key']);
+        });
+
+        $this->assertSame(
+            [
+                [
+                    'key' => 'KBC.dataTypesEnabled',
+                    'value' => 'true',
+                    'provider' => 'storage',
+                ],
+                [
+                    'key' => 'KBC.external-bucket_table-type',
+                    // external table has been replaced by table
+                    'value' => 'table',
+                    'provider' => 'storage',
+                ],
+            ],
+            $tableMetadata
+        );
     }
 
     public function testRegisterExternalDB(): void

--- a/tests/Backend/ExternalBuckets/SnowflakeRegisterBucketTest.php
+++ b/tests/Backend/ExternalBuckets/SnowflakeRegisterBucketTest.php
@@ -356,7 +356,7 @@ SQL
         $firstTable = $tables[0];
         $this->assertEquals('MY_LITTLE_EXT_TABLE', $firstTable['name']);
 
-        $this->assertSame($firstTable['tableKind'], 'external');
+        $this->assertSame($firstTable['tableType'], 'snowflake-external-table');
 
         $db->executeQuery(
             <<<SQL
@@ -372,7 +372,7 @@ SQL
         $firstTable = $tables[0];
         $this->assertEquals('MY_LITTLE_EXT_TABLE', $firstTable['name']);
 
-        $this->assertSame($firstTable['tableKind'], 'table');
+        $this->assertSame($firstTable['tableType'], 'table');
     }
 
     public function testRegisterExternalDB(): void


### PR DESCRIPTION
Jira: CT-910

- Check that you can register a bucket including external table. 
- Add `tableKind` to api doc

Storage backend: https://github.com/keboola/storage-backend/pull/70 
Connection: https://github.com/keboola/connection/pull/4401
SAPI: https://github.com/keboola/storage-api-php-client/pull/1060

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
