### PR TITLE
Ct 1138 dont create new brach every run

### DIFF
--- a/tests/Backend/CommonPart1/BucketsTest.php
+++ b/tests/Backend/CommonPart1/BucketsTest.php
@@ -194,12 +194,7 @@ class BucketsTest extends StorageApiTestCase
         $this->assertEventWithRetries($this->_testClient, $assertCallback, $query);
 
         $bucketEvents = $this->_testClient->listBucketEvents($bucketId);
-        if ($devBranchType === ClientProvider::DEFAULT_BRANCH) {
-            // there are already events in production
-            $this->assertGreaterThan(2, $bucketEvents);
-        } else {
-            $this->assertCount(2, $bucketEvents);
-        }
+        $this->assertGreaterThan(2, $bucketEvents);
         $this->assertSame('storage.tablesListed', $bucketEvents[0]['event']);
         $this->assertSame('storage.bucketCreated', $bucketEvents[1]['event']);
         $this->assertNotEmpty($bucketEvents[0]['idBranch']);

--- a/tests/ClientProvider/TestSetupHelper.php
+++ b/tests/ClientProvider/TestSetupHelper.php
@@ -42,10 +42,10 @@ class TestSetupHelper
         string $devBranchType,
         string $userRole
     ): array {
-        $hasProjectProtectedDefaultbranch = in_array($userRole, ['reviewer', 'developer', 'production-manager']);
+        $hasProjectProtectedDefaultBranch = in_array($userRole, ['reviewer', 'developer', 'production-manager']);
 
         $client = $clientProvider->getDefaultClient();
-        if ($hasProjectProtectedDefaultbranch) {
+        if ($hasProjectProtectedDefaultBranch) {
             // default branch is protected, we need privileged client for production cleanup
             $client = $clientProvider->getDefaultClient(['token' => STORAGE_API_DEFAULT_BRANCH_TOKEN]);
         }

--- a/tests/ClientProvider/TestSetupHelper.php
+++ b/tests/ClientProvider/TestSetupHelper.php
@@ -120,9 +120,9 @@ class TestSetupHelper
             },
         );
 
-        $branch = reset($branchesCreatedByThisTestMethod) ?: null;
+        $branch = reset($branchesCreatedByThisTestMethod);
 
-        if ($branch === null) {
+        if ($branch === false) {
             $branch = $devBranches->createBranch($branchName);
         }
 


### PR DESCRIPTION
Jira: CT-1138
KBC: XXX

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

Tag presiel [tu](https://dev.azure.com/keboola-dev/Connection%20build/_build/results?buildId=39296&view=results)  komplet zeleny.


Changes:
- typo
- zacal som reusovat branche
- unikatne nazvy bucketov pre paratesty
