### PR TITLE
GCP-408 GCS reupload

### DIFF
--- a/src/Keboola/StorageApi/GCSUploader.php
+++ b/src/Keboola/StorageApi/GCSUploader.php
@@ -79,6 +79,7 @@ class GCSUploader
     ): array {
         $failedUploads = [];
         foreach ($preparedSlices as $filePath => $blobName) {
+            // we have to download each blob as we can't list blobs
             $blob = $bucket->object($blobName);
             if (($blob->name() === $blobName) && (string) $blob->info()['size'] !== (string) filesize($filePath)) {
                 $this->logger->warning(sprintf(
@@ -141,6 +142,7 @@ class GCSUploader
             $this->upload($bucket, $key, $chunk);
         }
 
+        // Check and re-upload slices based on file size check
         $failedUploads = $this->getFailedUploads($preparedSlices, $this->gcsClient->bucket($bucket));
         $currentRetry = 1;
         while (count($failedUploads) !== 0) {

--- a/tests/ClientTestCase.php
+++ b/tests/ClientTestCase.php
@@ -6,10 +6,18 @@ use Keboola\StorageApi\BranchAwareClient;
 use Keboola\StorageApi\Client;
 use Keboola\Test\ClientProvider\TestSetupHelper;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ClientTestCase extends TestCase
 {
     use \PHPUnitRetry\RetryTrait;
+
+    public function getLogger(): ConsoleLogger
+    {
+        return new ConsoleLogger(new ConsoleOutput(OutputInterface::VERBOSITY_DEBUG));
+    }
 
     /**
      * @return Client
@@ -20,6 +28,7 @@ class ClientTestCase extends TestCase
             $options['token'],
             $options['url']
         );
+        $options['logger'] = $this->getLogger();
         return new Client($options);
     }
 
@@ -45,6 +54,7 @@ class ClientTestCase extends TestCase
 
     /**
      * in SOX-related tests, it is considered as production manager client
+     *
      * @return Client
      */
     public function getDefaultClient()


### PR DESCRIPTION
Jira: GCP-408
KBC: XXX

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

---

Testoval sem to tak, že sem na GCSUploader L143 (hned za upload všech slices)
Vložil tento kód aby podělal některý slice.

```php
$blobToCorrupt = $preparedSlices[array_rand($preparedSlices)];
$this->logger->warning(sprintf('Corrupting blob %s', $blobToCorrupt));
$this->gcsClient->bucket($bucket)->upload(
    fopen('data://text/plain;base64,' . base64_encode('test'), 'rb'),
    [
        'name' => $blobToCorrupt,
    ]
);
```