### PR TITLE
CT-1238 fix expected order of keys

### DIFF
--- a/tests/Backend/CommonPart1/BranchStorageTest.php
+++ b/tests/Backend/CommonPart1/BranchStorageTest.php
@@ -55,7 +55,7 @@ class BranchStorageTest extends StorageApiTestCase
             $job['creatorToken']['id'],
             $job['creatorToken']['description'],
         );
-        $this->assertSame(
+        $this->assertEqualsCanonicalizing(
             [
                 'status' => 'waiting',
                 'tableId' => null,
@@ -120,7 +120,7 @@ class BranchStorageTest extends StorageApiTestCase
             $jobDone['results']['creatorToken']['id'],
             $jobDone['results']['creatorToken']['name'],
         );
-        $this->assertSame(
+        $this->assertEqualsCanonicalizing(
             [
                 'status' => 'success',
                 'tableId' => null,
@@ -167,7 +167,7 @@ class BranchStorageTest extends StorageApiTestCase
             $br['creatorToken']['name'],
         );
 
-        $this->assertSame(
+        $this->assertEqualsCanonicalizing(
             [
                 'name' => $branchName . '2',
                 'isDefault' => false,

--- a/tests/Backend/CommonPart1/BranchStorageTest.php
+++ b/tests/Backend/CommonPart1/BranchStorageTest.php
@@ -134,8 +134,8 @@ class BranchStorageTest extends StorageApiTestCase
                 ],
                 'results' => [
                     'name' => $branchName,
-                    'description' => '',
                     'isDefault' => false,
+                    'description' => '',
                     'creatorToken' => [
                     ],
                 ],
@@ -170,8 +170,8 @@ class BranchStorageTest extends StorageApiTestCase
         $this->assertSame(
             [
                 'name' => $branchName . '2',
-                'description' => '',
                 'isDefault' => false,
+                'description' => '',
                 'creatorToken' => [
                 ],
             ],

--- a/tests/Common/DevBranchesTest.php
+++ b/tests/Common/DevBranchesTest.php
@@ -57,8 +57,14 @@ class DevBranchesTest extends StorageApiTestCase
 
         $this->assertCount(3, $adminDevBranches->listBranches());
 
-        $this->assertSame($branch, $adminDevBranches->getBranch($branch['id']));
-        $this->assertSame($guestBranch, $adminDevBranches->getBranch($guestBranch['id']));
+        $this->assertEqualsCanonicalizing(
+            $branch,
+            $adminDevBranches->getBranch($branch['id']),
+        );
+        $this->assertEqualsCanonicalizing(
+            $guestBranch,
+            $adminDevBranches->getBranch($guestBranch['id']),
+        );
 
         $adminDevBranches->deleteBranch($branch['id']);
         $adminDevBranches->deleteBranch($guestBranch['id']);
@@ -205,7 +211,10 @@ class DevBranchesTest extends StorageApiTestCase
 
         $this->assertCount(3, $branches->listBranches());
 
-        $this->assertSame($branch, $branches->getBranch($branch['id']));
+        $this->assertEqualsCanonicalizing(
+            $branch,
+            $branches->getBranch($branch['id']),
+        );
 
         try {
             $branches->deleteBranch($branch['id']);


### PR DESCRIPTION
Jira: CT-1238
KBC: https://github.com/keboola/connection/pull/4834

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
