### PR TITLE
CT-1118 Add and test import with importAsNull

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -9605,6 +9605,7 @@ Requesting changes will remove all approvals and move the Merge request to `deve
 ### CreateTableDefinitionAsyncFile(CreateTableDefinitionAsyncBase)
 
 + dataFileId (required, number) - Id of the file stored in [File Uploads](#reference/files)
++ importAsNull (optional, array[string]) - (Snowflake and BigQuery only) Array of string values that should be imported as NULL values. The default value is `['']`. Some other common values you might consider are `'\N'` or `'null'`. **Currently only single value is allowed**, but it still must be sent as array to allow future expansion.
 
 ### CreateTableDefinitionAsyncWorkspace(CreateTableDefinitionAsyncBase)
 

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -856,6 +856,11 @@ class Client
      */
     public function createTableAsync($bucketId, $name, CsvFile $csvFile, $options = [])
     {
+        $importAsNull = null;
+        if (isset($options['importAsNull'])) {
+            $importAsNull = $options['importAsNull'];
+        }
+
         $options = [
             'bucketId' => $bucketId,
             'name' => $name,
@@ -868,6 +873,10 @@ class Client
             'columns' => isset($options['columns']) ? $options['columns'] : null,
             'syntheticPrimaryKeyEnabled' => isset($options['syntheticPrimaryKeyEnabled']) ? $options['syntheticPrimaryKeyEnabled'] : null,
         ];
+
+        if ($importAsNull) {
+            $options['importAsNull'] = $importAsNull;
+        }
 
         // upload file
         $fileId = $this->uploadFile(

--- a/tests/Backend/CommonPart1/ImportExportCommonTest.php
+++ b/tests/Backend/CommonPart1/ImportExportCommonTest.php
@@ -413,6 +413,7 @@ class ImportExportCommonTest extends StorageApiTestCase
         // test invalid option
         try {
             $this->_client->createTableAsync($this->getTestBucketId(), 'importAsNull', $importFile, ['importAsNull' => ['french', '\N']]);
+            $this->fail('Should have failed');
         } catch (ClientException $e) {
             $this->assertEquals('validation.failed', $e->getStringCode());
             $this->assertStringContainsString(

--- a/tests/Backend/CommonPart1/ImportExportCommonTest.php
+++ b/tests/Backend/CommonPart1/ImportExportCommonTest.php
@@ -9,6 +9,7 @@
 
 namespace Keboola\Test\Backend\CommonPart1;
 
+use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\GetFileOptions;
@@ -402,6 +403,21 @@ class ImportExportCommonTest extends StorageApiTestCase
         } catch (ClientException $e) {
             $this->assertEquals('storage.fileNotUploaded', $e->getStringCode());
         }
+    }
+
+    public function testImportAsNull(): void
+    {
+        $filePath = __DIR__ . '/../../_data/languages.csv';
+        $importFile = new CsvFile($filePath);
+        $tableId = $this->_client->createTableAsync($this->getTestBucketId(), 'importAsNull', $importFile, ['importAsNull' => ['french']]);
+
+        $data = $this->_client->getTableDataPreview($tableId) ;
+        $data = Client::parseCsv($data);
+
+        $arrayWithFrenchRowOnly = array_values(array_filter($data, fn ($row) => $row['id'] == 24));
+        $this->assertCount(1, $arrayWithFrenchRowOnly);
+        // CSV will not return null, but an empty string - but importantly, not the word "french"
+        $this->assertSame('', $arrayWithFrenchRowOnly[0]['name']);
     }
 
     public function testImportWithoutHeaders(): void

--- a/tests/Backend/CommonPart1/ImportExportCommonTest.php
+++ b/tests/Backend/CommonPart1/ImportExportCommonTest.php
@@ -409,6 +409,18 @@ class ImportExportCommonTest extends StorageApiTestCase
     {
         $filePath = __DIR__ . '/../../_data/languages.csv';
         $importFile = new CsvFile($filePath);
+
+        // test invalid option
+        try {
+            $this->_client->createTableAsync($this->getTestBucketId(), 'importAsNull', $importFile, ['importAsNull' => ['french', '\N']]);
+        } catch (ClientException $e) {
+            $this->assertEquals('validation.failed', $e->getStringCode());
+            $this->assertStringContainsString(
+                'This collection should contain exactly 1 element.',
+                $e->getMessage(),
+            );
+        }
+
         $tableId = $this->_client->createTableAsync($this->getTestBucketId(), 'importAsNull', $importFile, ['importAsNull' => ['french']]);
 
         $data = $this->_client->getTableDataPreview($tableId) ;


### PR DESCRIPTION
Jira: CT-1118
Connection PR: https://github.com/keboola/connection/pull/4902
SAPI PR: https://github.com/keboola/storage-api-php-client/pull/1296
StorageBackend PR: https://github.com/keboola/storage-backend/pull/136
Driver PR: https://github.com/keboola/php-storage-driver-bigquery/pull/123

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

![image](https://github.com/keboola/storage-api-php-client/assets/642928/bbaca71a-3698-438f-8e98-4f4fcfcf9235)
