### PR TITLE
CT-1332 PK is not required anymore

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2362,7 +2362,7 @@ If there is no column datatype specified (column.definition.type or column.baset
 
 + Attributes
     + name (required) - New table name
-    + primaryKeysNames[] (required, string) - has to be subset of column names
+    + primaryKeysNames[] (string) - has to be subset of column names
     + columns[] (required) - definition of table columns
        + name (required, string) - column name
        + definition (object) - column settings

--- a/tests/Backend/Bigquery/TableDefinitionOperationsTest.php
+++ b/tests/Backend/Bigquery/TableDefinitionOperationsTest.php
@@ -283,7 +283,6 @@ INSERT INTO %s.`test_Languages3` (`id`, `struct`, `bytes`, `geography`, `json`) 
 
         $tableDefinition = [
             'name' => 'my-new-table-for_data_preview',
-            'primaryKeysNames' => [],
             'columns' => [
                 [
                     'name' => 'id',

--- a/tests/Backend/Exasol/TableDefinitionOperationsTest.php
+++ b/tests/Backend/Exasol/TableDefinitionOperationsTest.php
@@ -567,7 +567,6 @@ class TableDefinitionOperationsTest extends StorageApiTestCase
 
         $tableDefinition = [
             'name' => 'my-new-table-non-typed',
-            'primaryKeysNames' => [],
             'columns' => [
                 [
                     'name' => 'id',

--- a/tests/Backend/Snowflake/ImportTypedTableTest.php
+++ b/tests/Backend/Snowflake/ImportTypedTableTest.php
@@ -128,7 +128,6 @@ class ImportTypedTableTest extends ParallelWorkspacesTestCase
 
         $payload = [
             'name' => 'with-empty',
-            'primaryKeysNames' => [],
             'columns' => [
                 ['name' => 'col', 'definition' => ['type' => 'NUMBER']],
                 ['name' => 'str', 'definition' => ['type' => 'VARCHAR']],

--- a/tests/Backend/Synapse/CreateTableTest.php
+++ b/tests/Backend/Synapse/CreateTableTest.php
@@ -242,7 +242,6 @@ class CreateTableTest extends StorageApiTestCase
         }
 
         $definition = self::TABLE_DEFINITION;
-        $definition['primaryKeysNames'] = [];
         $definition['distribution'] = [
             'type' => 'ROUND_ROBIN',
             'distributionColumnsNames' => [],

--- a/tests/Backend/Teradata/TableDefinitionOperationsTest.php
+++ b/tests/Backend/Teradata/TableDefinitionOperationsTest.php
@@ -715,7 +715,6 @@ class TableDefinitionOperationsTest extends StorageApiTestCase
         // create table without primary keys
         $data = [
             'name' => 'my_new_table_no_primary_keys',
-            'primaryKeysNames' => [],
             'columns' => [
                 [
                     'name' => 'id',


### PR DESCRIPTION
Jira: CT-1332
KBC:  https://github.com/keboola/connection/pull/4912

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

V par testoch som zmazal to posielanie prazdneho pola, nech sa to testuje ;) 
