### PR TITLE
CT-1331 do not expect error when having no datatype anymore

### DIFF
--- a/tests/Backend/Bigquery/TableDefinitionOperationsTest.php
+++ b/tests/Backend/Bigquery/TableDefinitionOperationsTest.php
@@ -996,6 +996,7 @@ INSERT INTO %s.`test_Languages3` (`id`, `struct`, `bytes`, `geography`, `json`) 
 
         $data = $this->_client->getTableDataPreview($tableId, $params);
         if ($params['format'] === 'json') {
+            /* @phpstan-ignore-next-line */
             $this->assertCount($expectedNumberOfRows, $data['rows']);
         } else {
             // format = rfc returns CSV; header is skipped by default in parseCsv

--- a/tests/Backend/Bigquery/TableDefinitionOperationsTest.php
+++ b/tests/Backend/Bigquery/TableDefinitionOperationsTest.php
@@ -6,6 +6,7 @@ use Generator;
 use Google\Cloud\BigQuery\BigQueryClient;
 use Keboola\Csv\CsvFile;
 use Keboola\Datatype\Definition\Bigquery;
+use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Metadata;
 use Keboola\StorageApi\Options\FileUploadOptions;
@@ -985,7 +986,7 @@ INSERT INTO %s.`test_Languages3` (`id`, `struct`, `bytes`, `geography`, `json`) 
     /**
      * @dataProvider wrongDatatypeFilterProvider
      */
-    public function testColumnTypesInTableDefinition(array $params, string $expectExceptionMessage): void
+    public function testColumnTypesInTableDefinition(array $params, int $expectedNumberOfRows = 0): void
     {
         $bucketId = $this->getTestBucketId();
 
@@ -993,9 +994,14 @@ INSERT INTO %s.`test_Languages3` (`id`, `struct`, `bytes`, `geography`, `json`) 
 
         $this->_client->writeTableAsync($tableId, $this->getTestCsv());
 
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage($expectExceptionMessage);
-        $this->_client->getTableDataPreview($tableId, $params);
+        $data = $this->_client->getTableDataPreview($tableId, $params);
+        if ($params['format'] === 'json') {
+            $this->assertCount($expectedNumberOfRows, $data['rows']);
+        } else {
+            // format = rfc returns CSV; header is skipped by default in parseCsv
+            $data = Client::parseCsv($data);
+            $this->assertCount($expectedNumberOfRows, $data);
+        }
     }
 
     public function wrongDatatypeFilterProvider(): Generator
@@ -1113,7 +1119,7 @@ INSERT INTO %s.`test_Languages3` (`id`, `struct`, `bytes`, `geography`, `json`) 
         $client->runQuery(
             $client->query(
                 sprintf(
-                    'INSERT INTO `%s`.`my_new_table_with_nulls` VALUES (1, null);',
+                    'INSERT INTO `%s`.`my_new_table_with_nulls` VALUES (1, NULL);',
                     $dataset,
                 ),
             ),
@@ -1749,59 +1755,6 @@ INSERT INTO %s.`test_prices` (`id`, `price`) VALUES (1, \'too expensive\') ;',
             'REAL' => 42.1,
             'DECIMAL' => 42.3,
         ];
-    }
-
-    public function testIllogicalComparisonInFilterWithBool(): void
-    {
-        $bucketId = $this->getTestBucketId();
-
-        $columns = [
-            [
-                'name' => 'id',
-                'definition' => [
-                    'type' => 'INT64',
-                    'nullable' => false,
-                ],
-            ],
-        ];
-        $types = ['BOOL'];
-
-        foreach ($types as $type) {
-            $columns[] = [
-                'name' => $type,
-                'definition' => [
-                    'type' => $type,
-                    'nullable' => true,
-                ],
-            ];
-        }
-
-        $data = [
-            'name' => 'test_table',
-            'primaryKeysNames' => ['id'],
-            'columns' => $columns,
-        ];
-
-        $tableId = $bucketId . '.' . 'test_table';
-        if (!$this->_client->tableExists($tableId)) {
-            $tableId = $this->_client->createTableDefinition($bucketId, $data);
-        }
-
-        try {
-            $this->_client->getTableDataPreview($tableId, [
-                'format' => 'json',
-                'whereFilters' => [
-                    [
-                        'column' => 'BOOL',
-                        'operator' => 'eq',
-                        'values' => [false],
-                    ],
-                ],
-            ]);
-            $this->fail('should fail');
-        } catch (ClientException $e) {
-            $this->assertEquals('Invalid filter value, expected:"BOOL", actual:"STRING".', $e->getMessage());
-        }
     }
 
     public function testUpdateTableDefinition(): void

--- a/tests/Backend/Bigquery/TestExportDataProvidersTrait.php
+++ b/tests/Backend/Bigquery/TestExportDataProvidersTrait.php
@@ -121,7 +121,7 @@ trait TestExportDataProvidersTrait
                         ],
                     ],
                 ],
-                'Invalid filter value, expected:"INT64", actual:"STRING".',
+                1,
             ];
 
             yield 'wrong number ' . $format => [
@@ -135,7 +135,6 @@ trait TestExportDataProvidersTrait
                         ],
                     ],
                 ],
-                'Invalid filter value, expected:"NUMERIC", actual:"STRING".',
             ];
 
             yield 'wrong float ' . $format => [
@@ -149,7 +148,6 @@ trait TestExportDataProvidersTrait
                         ],
                     ],
                 ],
-                'Invalid filter value, expected:"FLOAT64", actual:"STRING".',
             ];
 
             yield 'wrong datetime ' . $format => [
@@ -164,11 +162,11 @@ trait TestExportDataProvidersTrait
                         ],
                     ],
                 ],
-                'Invalid datetime string "2022-02-31"; while executing the filter on column \'column_datetime\'; Column \'column_int\'', // non-existing date
             ];
 
             yield 'wrong boolean ' . $format => [
                 [
+                    'format' => $format,
                     'whereFilters' => [
                         [
                             'column' => 'column_boolean',
@@ -177,7 +175,6 @@ trait TestExportDataProvidersTrait
                         ],
                     ],
                 ],
-                'Invalid filter value, expected:"BOOL", actual:"STRING".',
             ];
 
             yield 'wrong date ' . $format => [
@@ -191,11 +188,11 @@ trait TestExportDataProvidersTrait
                         ],
                     ],
                 ],
-                'Invalid date: \'12:00:00.000\'; while executing the filter on column \'column_date\'; Column \'column_int\'',
             ];
 
             yield 'wrong time ' . $format => [
                 [
+                    'format' => $format,
                     'whereFilters' => [
                         [
                             'column' => 'column_time',
@@ -204,7 +201,6 @@ trait TestExportDataProvidersTrait
                         ],
                     ],
                 ],
-                'Invalid time string "1989-08-31"; while executing the filter on column \'column_time\'; Column \'column_int\'',
             ];
 
             yield 'wrong timestamp ' . $format => [
@@ -218,7 +214,6 @@ trait TestExportDataProvidersTrait
                         ],
                     ],
                 ],
-                'Invalid timestamp: \'xxx\'; while executing the filter on column \'column_timestamp\'; Column \'column_int\'',
             ];
         }
     }


### PR DESCRIPTION
Jira : [CT-1331](https://keboola.atlassian.net/browse/CT-1331)
KBC: https://github.com/keboola/connection/pull/4919
BQ driver: https://github.com/keboola/php-storage-driver-bigquery/pull/126 ✅
SAPI: https://github.com/keboola/storage-api-php-client/pull/1308

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

jen fixuju testy a testuju ten usecase


[CT-1331]: https://keboola.atlassian.net/browse/CT-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ