### PR TITLE
CT-1348 test dataSizeBytes, rowsCount on empty table

### DIFF
--- a/tests/Backend/Bigquery/TableDefinitionOperationsTest.php
+++ b/tests/Backend/Bigquery/TableDefinitionOperationsTest.php
@@ -218,6 +218,8 @@ INSERT INTO %s.`test_Languages3` (`id`, `struct`, `bytes`, `geography`, `json`) 
     public function testResponseDefinition(): void
     {
         $tableDetail = $this->_client->getTable($this->tableId);
+        $this->assertEquals(0, $tableDetail['dataSizeBytes']);
+        $this->assertEquals(0, $tableDetail['rowsCount']);
         $this->assertSame([
             'primaryKeysNames' => ['id'],
             'columns' => [

--- a/tests/Backend/Snowflake/TableDefinitionOperationsTest.php
+++ b/tests/Backend/Snowflake/TableDefinitionOperationsTest.php
@@ -60,6 +60,8 @@ class TableDefinitionOperationsTest extends ParallelWorkspacesTestCase
     public function testResponseDefinition(): void
     {
         $tableDetail = $this->_client->getTable($this->tableId);
+        $this->assertEquals(0, $tableDetail['dataSizeBytes']);
+        $this->assertEquals(0, $tableDetail['rowsCount']);
         $this->assertSame([
             'primaryKeysNames' => ['id'],
             'columns' => [


### PR DESCRIPTION
Jira: CT-1348
KBC: https://github.com/keboola/connection/pull/4931

Before asking for review make sure that:

## Checklist

- [ ] New client method(s) has tests
- [ ] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
