### PR TITLE
[on-hold] CT-1326 test that generates the deprecation logs

### DIFF
--- a/tests/Backend/CommonPart1/BucketsTest.php
+++ b/tests/Backend/CommonPart1/BucketsTest.php
@@ -240,6 +240,20 @@ class BucketsTest extends StorageApiTestCase
         $this->_testClient->dropBucket($bucket['id']);
     }
 
+    /**
+     * @dataProvider provideComponentsClientTypeBasedOnSuite
+     */
+    public function testCannotCreateBucketWithDot(): void
+    {
+        $bucketName = 'test.bucket';
+        $this->expectExceptionMessage(
+            'Invalid data - name: \'test.bucket\' contains not allowed characters. '
+            .'Only alphanumeric characters dash and underscores are allowed.',
+        );
+        $this->expectException(ClientException::class);
+        $this->_testClient->createBucket($bucketName, self::STAGE_IN);
+    }
+
     private function assertBucketWithColumnMetadata(array $bucket): void
     {
         self::assertArrayHasKey('tables', $bucket);

--- a/tests/Backend/CommonPart1/CreateTableTest.php
+++ b/tests/Backend/CommonPart1/CreateTableTest.php
@@ -250,6 +250,20 @@ class CreateTableTest extends StorageApiTestCase
         }
     }
 
+    public function testBucketWithUnsupportedCharactersInNameShouldNotBeValid(): void
+    {
+        try {
+            $this->_client->createTableAsync(
+                $this->getTestBucketId() . '.rubbish',
+                'languages',
+                new CsvFile(__DIR__ . '/../../_data/languages.csv'),
+            );
+            $this->fail('Bucket with dot in name should not be valid');
+        } catch (\Keboola\StorageApi\ClientException $e) {
+            $this->assertEquals('storage.buckets.notFound', $e->getStringCode());
+        }
+    }
+
     public function testTableWithEmptyColumnNamesShouldNotBeCreated(): void
     {
         try {

--- a/tests/Common/MetadataTest.php
+++ b/tests/Common/MetadataTest.php
@@ -84,6 +84,17 @@ class MetadataTest extends StorageApiTestCase
         $testMetadata = [$md, $md2];
 
         $provider = self::TEST_PROVIDER;
+
+        // test bucket id with dot
+        try {
+            $metadatas = $metadataApi->postBucketMetadata($bucketId . '.rubbish', $provider, $testMetadata);
+            $this->fail('Bucket id with dot should not be allowed');
+        } catch (ClientException $e) {
+            $this->assertEquals('storage.buckets.notFound', $e->getStringCode());
+            $this->assertMatchesRegularExpression('/Bucket in.c-API-tests-[a-zA-Z0-9]+\.rubbish not found/', $e->getMessage());
+            $this->assertEquals(404, $e->getCode());
+        }
+
         $metadatas = $metadataApi->postBucketMetadata($bucketId, $provider, $testMetadata);
 
         $this->assertEquals(2, count($metadatas));
@@ -228,6 +239,20 @@ class MetadataTest extends StorageApiTestCase
         $testMetadata = [$md, $md2];
 
         $provider = self::TEST_PROVIDER;
+
+        // test table id with dot
+        try {
+            $metadataApi->postTableMetadata($tableId . '.rubbish', $provider, $testMetadata);
+            $this->fail('Table id with dot should not be allowed');
+        } catch (ClientException $e) {
+            $this->assertEquals('storage.tables.notFound', $e->getStringCode());
+            $this->assertMatchesRegularExpression(
+                '/The table "test_table\.rubbish" was not found in the bucket'
+                . ' "in.c-API-tests-[a-zA-Z0-9]+" in the project "\d+"/',
+                $e->getMessage(),
+            );
+            $this->assertEquals(404, $e->getCode());
+        }
 
         $metadatas = $metadataApi->postTableMetadata($tableId, $provider, $testMetadata);
 
@@ -697,6 +722,19 @@ class MetadataTest extends StorageApiTestCase
         $testMetadata = [$md, $md2];
 
         $provider = self::TEST_PROVIDER;
+
+        // test column dot id
+        try {
+            $metadataApi->postColumnMetadata($columnId . '.rubbish', $provider, $testMetadata);
+            $this->fail('Column id with dot should not be allowed');
+        } catch (ClientException $e) {
+            $this->assertEquals('storage.columns.notFound', $e->getStringCode());
+            $this->assertMatchesRegularExpression(
+                '/The column "in.c-API-tests-[a-zA-Z0-9]+.test_table.id.rubbish" was not found/',
+                $e->getMessage(),
+            );
+            $this->assertEquals(404, $e->getCode());
+        }
 
         $metadatas = $metadataApi->postColumnMetadata($columnId, $provider, $testMetadata);
 


### PR DESCRIPTION
Jira: CT-1326
KBC: https://github.com/keboola/connection/pull/4937

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
