### PR TITLE
PST-1006 Allow disabling retries on 503 Maintenance response

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1436,31 +1436,6 @@ parameters:
 			path: src/Keboola/StorageApi/Exception.php
 
 		-
-			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:create\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Keboola/StorageApi/HandlerStack.php
-
-		-
-			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:create\\(\\) has parameter \\$options with no type specified\\.$#"
-			count: 1
-			path: src/Keboola/StorageApi/HandlerStack.php
-
-		-
-			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:createDefaultDecider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Keboola/StorageApi/HandlerStack.php
-
-		-
-			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:createDefaultDecider\\(\\) has parameter \\$maxRetries with no type specified\\.$#"
-			count: 1
-			path: src/Keboola/StorageApi/HandlerStack.php
-
-		-
-			message: "#^Method Keboola\\\\StorageApi\\\\HandlerStack\\:\\:createExponentialDelay\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Keboola/StorageApi/HandlerStack.php
-
-		-
 			message: "#^Method Keboola\\\\StorageApi\\\\MaintenanceException\\:\\:__construct\\(\\) has parameter \\$reason with no type specified\\.$#"
 			count: 1
 			path: src/Keboola/StorageApi/MaintenanceException.php

--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -79,6 +79,8 @@ class Client
 
     private $backoffMaxTries = 11;
 
+    private bool $retryOnMaintenance = true;
+
     private $awsRetries = self::DEFAULT_RETRIES_COUNT;
 
     private $awsDebug = false;
@@ -134,6 +136,7 @@ class Client
      *     - url: (required) Storage API URL
      *     - userAgent: custom user agent
      *     - backoffMaxTries: backoff maximum number of attempts
+     *     - retryOnMaintenance: if client should retry request when server is in maintenance
      *     - awsRetries: number of aws client retries
      *     - logger: instance of Psr\Log\LoggerInterface
      *     - jobPollRetryDelay: callable method which determines wait period for job polling
@@ -158,6 +161,10 @@ class Client
 
         if (isset($config['backoffMaxTries'])) {
             $this->backoffMaxTries = (int) $config['backoffMaxTries'];
+        }
+
+        if (isset($config['retryOnMaintenance'])) {
+            $this->retryOnMaintenance = (bool) $config['retryOnMaintenance'];
         }
 
         if (isset($config['awsRetries'])) {
@@ -188,6 +195,7 @@ class Client
     {
         $handlerStack = HandlerStack::create([
             'backoffMaxTries' => $this->backoffMaxTries,
+            'retryOnMaintenance' => $this->retryOnMaintenance,
             'handler' => $config['handler'] ?? null,
         ]);
 

--- a/tests-unit/Client/MaintenanceTest.php
+++ b/tests-unit/Client/MaintenanceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\UnitTest\Client;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
+use PHPUnit\Framework\TestCase;
+
+class MaintenanceTest extends TestCase
+{
+    public function testMaintenanceResponseIsRetriedByDefault(): void
+    {
+        $mockHandler = new MockHandler([
+            new Response(503),
+            new Response(200, [], 'ok'),
+        ]);
+
+        $client = new Client([
+            'token' => '123-foo',
+            'url' => 'http://example.com',
+            'handler' => $mockHandler,
+        ]);
+
+        $response = $client->apiGet('/');
+        self::assertSame('ok', $response);
+    }
+
+    public function testMaintenanceRetryCanBeDisabled(): void
+    {
+        $mockHandler = new MockHandler([
+            new Response(503),
+            new Response(200, [], 'ok'),
+        ]);
+
+        $client = new Client([
+            'retryOnMaintenance' => false,
+            'token' => '123-foo',
+            'url' => 'http://example.com',
+            'handler' => $mockHandler,
+        ]);
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Maintenance');
+
+        $client->apiGet('/');
+    }
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-1006

Pridani nove config option `retryOnMaintenance`, default `true` pro zachvani BC. Pokud je nastavene na `false`, nedela se pri `503` response retry.

Pokud je projekt disablovany, nechceme se v `job-queue-daemon` zdrzovat retries. Takovy projekt nam staci proste skipnout a vratime se k nemu v dalsi iteraci.