### PR TITLE
CT-1671 webalize/column-names now do not validate column names

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -8936,9 +8936,7 @@ and [buckets](https://keboola.docs.apiary.io/#reference/buckets/manage-bucket/bu
         }
 
 ### Webalize Column Names [POST /v2/storage/webalize/column-names]
-Webalize strings which you want to use as the column names for all API calls where the column name is used, for example:
-- [creating a table](https://keboola.docs.apiary.io/#reference/tables/create-table-definition/create-new-table-definition)
-- [adding a column](https://keboola.docs.apiary.io/#reference/tables/create-table-column/add-column-to-table)
+Webalize strings. Do not validate if you can use them in database column names.
 
 + Attributes
     + columnNames (required, array[string])

--- a/tests/Common/IndexTest.php
+++ b/tests/Common/IndexTest.php
@@ -121,6 +121,9 @@ class IndexTest extends StorageApiTestCase
                 '$$ some name $$',
                 '_MůjBucketíček',
                 'loremIpsumDolorSitAmetWhateverNextLoremIpsumDolorSitAmetloremIpsumDolorSitAmetWhateverNextLoremIpsumDolorSitAmet',
+                'oid',
+                base64_decode('AQIDBAUGBwgODxAREhMUFRYXGBkaGxwdHh9/'),
+                '----$$$$-----',
             ],
             [
                 'currency_EUR',
@@ -131,6 +134,9 @@ class IndexTest extends StorageApiTestCase
                 'some_name',
                 'MujBucketicek',
                 'loremIpsumDolorSitAmetWhateverNextLoremIpsumDolorSitAmetloremIps',
+                'oid',
+                '',
+                '',
             ],
         ];
     }
@@ -162,27 +168,6 @@ class IndexTest extends StorageApiTestCase
             'validation.failed',
             'Invalid request:
  - columnNames[0]: "This value should not be blank."',
-        ];
-        yield 'system column' => [
-            ['oid'],
-            422,
-            'storage.webalize.columnName.invalid',
-            'columnNames[0]: "oid" is a system column used by the database for internal purposes.',
-        ];
-        yield 'naughty string 1' => [
-            [base64_decode('AQIDBAUGBwgODxAREhMUFRYXGBkaGxwdHh9/')],
-            422,
-            'storage.webalize.columnName.invalid',
-            'columnNames[0]: "" contains not allowed characters. Only alphanumeric characters dash and underscores are allowed.',
-        ];
-        yield 'only special chars' => [
-            [
-                'new column',
-                '----$$$$-----',
-            ],
-            422,
-            'storage.webalize.columnName.invalid',
-            'columnNames[1]: "" contains not allowed characters. Only alphanumeric characters dash and underscores are allowed.',
         ];
     }
 }

--- a/tests/Common/IndexTest.php
+++ b/tests/Common/IndexTest.php
@@ -10,7 +10,6 @@
 namespace Keboola\Test\Common;
 
 use Generator;
-use Keboola\Filter\Exception\InvalidValueProvidedException;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\IndexOptions;
 use Keboola\Test\StorageApiTestCase;


### PR DESCRIPTION
Jira: [CT-1671](https://keboola.atlassian.net/browse/CT-1671)
KBC: https://github.com/keboola/connection/pull/5185

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)


[CT-1671]: https://keboola.atlassian.net/browse/CT-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ