### PR TITLE
php-datatypes starts return INTEGER instead of INT64

### DIFF
--- a/tests/Backend/SOX/PullTableTest.php
+++ b/tests/Backend/SOX/PullTableTest.php
@@ -336,7 +336,7 @@ class PullTableTest extends StorageApiTestCase
                 $this->assertSame('38,0', $defs[0]->getColumnDefinition()->getLength());
                 break;
             case self::BACKEND_BIGQUERY:
-                $this->assertSame('INT64', $defs[0]->getColumnDefinition()->getType());
+                $this->assertSame('INTEGER', $defs[0]->getColumnDefinition()->getType());
                 $this->assertNull($defs[0]->getColumnDefinition()->getLength());
                 break;
             default:


### PR DESCRIPTION
Jira: CT-1328
KBC: XXX

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
