### PR TITLE
Deprecate bucket description

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1041,7 +1041,7 @@ existing bucket from another project (see below).
             + in
             + out
         + Default: in
-    + description (optional) - Bucket description.
+    + description (optional) - Bucket description. **deprecated**
     + backend (optional, enum[string]) - Bucket backend type; the default value is determined by the project settings.
         + Members
             + snowflake


### PR DESCRIPTION
Jira: CT-1867
KBC: XXX

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] New client method(s) support branches, or they are listed in BranchAwareClient 
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

---

just note that bucket description as field is deprecated
