### PR TITLE
fix: Make arguments with default `null` nullable explicitly

### DIFF
--- a/src/Keboola/StorageApi/Client.php
+++ b/src/Keboola/StorageApi/Client.php
@@ -265,7 +265,7 @@ class Client
      * API index with available components list
      * @return array
      */
-    public function indexAction(IndexOptions $options = null)
+    public function indexAction(?IndexOptions $options = null)
     {
         $url = '';
 
@@ -1896,8 +1896,11 @@ class Client
      * @return int - created file id
      * @throws ClientException
      */
-    public function uploadFile($filePath, FileUploadOptions $options, FileUploadTransferOptions $transferOptions = null)
-    {
+    public function uploadFile(
+        $filePath,
+        FileUploadOptions $options,
+        ?FileUploadTransferOptions $transferOptions = null,
+    ) {
         if (!is_readable($filePath)) {
             throw new ClientException('File is not readable: ' . $filePath, null, null, 'fileNotReadable');
         }
@@ -2039,7 +2042,7 @@ class Client
         array $prepareResult,
         $filePath,
         FileUploadOptions $newOptions,
-        FileUploadTransferOptions $transferOptions = null
+        ?FileUploadTransferOptions $transferOptions = null
     ) {
         $uploadParams = $prepareResult['uploadParams'];
         $s3options = [
@@ -2095,8 +2098,11 @@ class Client
      * @return int created file id
      * @throws ClientException
      */
-    public function uploadSlicedFile(array $slices, FileUploadOptions $options, FileUploadTransferOptions $transferOptions = null)
-    {
+    public function uploadSlicedFile(
+        array $slices,
+        FileUploadOptions $options,
+        ?FileUploadTransferOptions $transferOptions = null,
+    ) {
         if (!$options->getIsSliced()) {
             throw new ClientException('File is not sliced.');
         }
@@ -2213,7 +2219,7 @@ class Client
         array $preparedFileResult,
         array $slices,
         FileUploadOptions $newOptions,
-        FileUploadTransferOptions $transferOptions = null
+        ?FileUploadTransferOptions $transferOptions = null
     ) {
         $uploadParams = $preparedFileResult['uploadParams'];
         $options = [
@@ -2281,7 +2287,7 @@ class Client
         array $preparedFileResult,
         array $slices,
         FileUploadOptions $newOptions,
-        FileUploadTransferOptions $transferOptions = null
+        ?FileUploadTransferOptions $transferOptions = null,
     ): void {
         $uploadParams = $preparedFileResult['gcsUploadParams'];
         $refreshCallableWrapper = new RefreshFileCredentialsWrapper($this, $preparedFileResult['id']);
@@ -2306,7 +2312,7 @@ class Client
         );
     }
 
-    public function downloadFile($fileId, $destination, GetFileOptions $getOptions = null)
+    public function downloadFile($fileId, $destination, ?GetFileOptions $getOptions = null)
     {
         $getOptions = ($getOptions)? $getOptions : new GetFileOptions();
         $getOptions->setFederationToken(true);
@@ -2637,7 +2643,7 @@ class Client
      * @param string|int $fileId
      * @return array
      */
-    public function getFile($fileId, GetFileOptions $options = null)
+    public function getFile($fileId, ?GetFileOptions $options = null)
     {
         if (empty($fileId)) {
             throw new ClientException('File id cannot be empty');
@@ -2665,10 +2671,9 @@ class Client
     /**
      * List files
      *
-     * @param ListFilesOptions $options
      * @return array
      */
-    public function listFiles(ListFilesOptions $options = null)
+    public function listFiles(?ListFilesOptions $options = null)
     {
         return $this->apiGet('files?' . http_build_query($options ? $options->toArray() : []));
     }
@@ -3419,7 +3424,7 @@ class Client
                 $this->creds = $creds;
             }
 
-            public function fetchAuthToken(callable $httpHandler = null)
+            public function fetchAuthToken(?callable $httpHandler = null)
             {
                 return $this->creds;
             }

--- a/src/Keboola/StorageApi/Components.php
+++ b/src/Keboola/StorageApi/Components.php
@@ -118,7 +118,7 @@ class Components
         return $this->client->apiPostJson($this->branchPrefix . "components/{$componentId}/configs/{$configurationId}/reset-to-default");
     }
 
-    public function listComponents(ListComponentsOptions $options = null)
+    public function listComponents(?ListComponentsOptions $options = null)
     {
         if (!$options) {
             $options = new ListComponentsOptions();
@@ -178,7 +178,7 @@ class Components
         ));
     }
 
-    public function listConfigurationRows(ListConfigurationRowsOptions $options = null)
+    public function listConfigurationRows(?ListConfigurationRowsOptions $options = null)
     {
         if (!$options) {
             $options = new ListConfigurationRowsOptions();
@@ -187,7 +187,7 @@ class Components
             . "{$options->getConfigurationId()}/rows");
     }
 
-    public function listConfigurationWorkspaces(ListConfigurationWorkspacesOptions $options = null)
+    public function listConfigurationWorkspaces(?ListConfigurationWorkspacesOptions $options = null)
     {
         if (!$options) {
             $options = new ListConfigurationWorkspacesOptions();

--- a/src/Keboola/StorageApi/Downloader/GcsClientFactory.php
+++ b/src/Keboola/StorageApi/Downloader/GcsClientFactory.php
@@ -33,7 +33,7 @@ class GcsClientFactory
                 $this->creds = $creds;
             }
 
-            public function fetchAuthToken(callable $httpHandler = null)
+            public function fetchAuthToken(?callable $httpHandler = null)
             {
                 return $this->creds;
             }

--- a/src/Keboola/StorageApi/GCSUploader.php
+++ b/src/Keboola/StorageApi/GCSUploader.php
@@ -32,8 +32,8 @@ class GCSUploader
     public function __construct(
         array $options,
         RefreshFileCredentialsWrapper $refreshFileCredentialsWrapper,
-        LoggerInterface $logger = null,
-        FileUploadTransferOptions $transferOptions = null
+        ?LoggerInterface $logger = null,
+        ?FileUploadTransferOptions $transferOptions = null
     ) {
         $this->gcsClient = $this->initClient($options);
         $this->refreshFileCredentialsWrapper = $refreshFileCredentialsWrapper;
@@ -235,7 +235,7 @@ class GCSUploader
                 $this->creds = $creds;
             }
 
-            public function fetchAuthToken(callable $httpHandler = null)
+            public function fetchAuthToken(?callable $httpHandler = null)
             {
                 return $this->creds;
             }

--- a/src/Keboola/StorageApi/HandlerStack.php
+++ b/src/Keboola/StorageApi/HandlerStack.php
@@ -55,7 +55,7 @@ final class HandlerStack
         return function (
             $retries,
             RequestInterface $request,
-            ResponseInterface $response = null,
+            ?ResponseInterface $response = null,
             $error = null
         ) use (
             $maxRetries,

--- a/src/Keboola/StorageApi/S3Uploader.php
+++ b/src/Keboola/StorageApi/S3Uploader.php
@@ -35,7 +35,7 @@ class S3Uploader
      * @param S3Client $s3Client
      * @param FileUploadTransferOptions|null $transferOptions
      */
-    public function __construct(S3Client $s3Client, FileUploadTransferOptions $transferOptions = null, LoggerInterface $logger = null)
+    public function __construct(S3Client $s3Client, ?FileUploadTransferOptions $transferOptions = null, ?LoggerInterface $logger = null)
     {
         $this->s3Client = $s3Client;
         if (!$transferOptions) {
@@ -200,7 +200,7 @@ class S3Uploader
         $concurrency,
         $encryption = null,
         $name = null,
-        UploadState $state = null
+        ?UploadState $state = null
     ) {
         $uploaderOptions = [
             'Bucket' => $bucket,

--- a/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
+++ b/tests/Backend/Workspaces/ParallelWorkspacesTestCase.php
@@ -44,7 +44,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         array $options = [],
         bool $forceRecreate = false,
         bool $async = true,
-        Client $client = null
+        ?Client $client = null
     ): array {
         if ($backend) {
             $options['backend'] = $backend;
@@ -76,7 +76,7 @@ abstract class ParallelWorkspacesTestCase extends StorageApiTestCase
         return $workspaces->createWorkspace($options, $async);
     }
 
-    protected function deleteOldTestWorkspaces(Client $client = null): void
+    protected function deleteOldTestWorkspaces(?Client $client = null): void
     {
         if ($client === null) {
             $client = $this->_client;

--- a/tests/StorageApiTestCase.php
+++ b/tests/StorageApiTestCase.php
@@ -143,7 +143,7 @@ abstract class StorageApiTestCase extends ClientTestCase
      * @param $stage
      * @return string
      */
-    protected function initEmptyBucket($name, $stage, $description, Client $client = null)
+    protected function initEmptyBucket($name, $stage, $description, ?Client $client = null)
     {
         if (!$client) {
             $client = $this->_client;
@@ -205,7 +205,7 @@ abstract class StorageApiTestCase extends ClientTestCase
         }
     }
 
-    protected function initEmptyBucketWithDescription(string $stage, Client $client = null): string
+    protected function initEmptyBucketWithDescription(string $stage, ?Client $client = null): string
     {
         $description = $this->generateDescriptionForTestObject();
         $bucketName = $this->getTestBucketName($description);
@@ -459,7 +459,7 @@ abstract class StorageApiTestCase extends ClientTestCase
      * @return array
      * @throws \Exception
      */
-    protected function createWithFormDataAndWaitForEvent(Event $event, Client $sapiClient = null)
+    protected function createWithFormDataAndWaitForEvent(Event $event, ?Client $sapiClient = null)
     {
         $client = null !== $sapiClient ? $sapiClient : $this->_client;
 
@@ -481,7 +481,7 @@ abstract class StorageApiTestCase extends ClientTestCase
         }
     }
 
-    protected function createAndWaitForFile($path, FileUploadOptions $options, Client $sapiClient = null)
+    protected function createAndWaitForFile($path, FileUploadOptions $options, ?Client $sapiClient = null)
     {
         $client = $sapiClient ? $sapiClient : $this->_client;
 
@@ -514,7 +514,7 @@ abstract class StorageApiTestCase extends ClientTestCase
         }
     }
 
-    protected function createTableWithRandomData($tableName, $rows = 5, $columns = 10, $charsInCell = 20, string $bucketId = null)
+    protected function createTableWithRandomData($tableName, $rows = 5, $columns = 10, $charsInCell = 20, ?string $bucketId = null)
     {
         if ($bucketId === null) {
             $bucketId = $this->getTestBucketId();
@@ -846,7 +846,7 @@ abstract class StorageApiTestCase extends ClientTestCase
                 $this->creds = $creds;
             }
 
-            public function fetchAuthToken(callable $httpHandler = null)
+            public function fetchAuthToken(?callable $httpHandler = null)
             {
                 return $this->creds;
             }

--- a/tests/Utils/EventTesterUtils.php
+++ b/tests/Utils/EventTesterUtils.php
@@ -31,7 +31,7 @@ trait EventTesterUtils
      * @return array
      * @throws \Exception
      */
-    public function createAndWaitForEvent(Event $event, Client $sapiClient = null)
+    public function createAndWaitForEvent(Event $event, ?Client $sapiClient = null)
     {
         // @phpstan-ignore property.notFound
         $client = null !== $sapiClient ? $sapiClient : $this->_client;
@@ -78,7 +78,7 @@ trait EventTesterUtils
     /**
      * @return mixed
      */
-    protected function retryWithCallback(callable $apiCall, callable $callback = null)
+    protected function retryWithCallback(callable $apiCall, ?callable $callback = null)
     {
         sleep(2); // wait for ES to refresh
         $retryPolicy = new SimpleRetryPolicy(30);


### PR DESCRIPTION
Vzdalene related k https://keboola.atlassian.net/browse/PST-883

Explicitni nullable oznaceni vsech argumentu, kde je default `null`. V PHP 8.4 je tohle povazovany za deprecated.

```
Deprecated: {closure:Keboola\StorageApi\HandlerStack::createDefaultDecider():55}(): Implicitly marking parameter $response as nullable is deprecated, the explicit nullable type must be used instead in /code/apps/service-container/vendor/keboola/storage-api-client/src/Keboola/StorageApi/HandlerStack.php on line 62

Call Stack:
    0.0002     527552   1. {main}() /code/apps/service-container/vendor/bin/phpunit:0
    0.0004     540136   2. include('/code/apps/service-container/vendor/phpunit/phpunit/phpunit') /code/apps/service-container/vendor/bin/phpunit:122
    0.0081    2965216   3. PHPUnit\TextUI\Command::main($exit = ???) /code/apps/service-container/vendor/phpunit/phpunit/phpunit:107
...
```
