### PR TITLE
CT-2016 New Workspaces::executeQuery

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -5767,6 +5767,66 @@ Only for BigQuery workspace
               }
             }
 
+## Execute Query [/v2/storage/branch/{branch_id}/workspaces/{workspace_id}/query]
+### Execute Query [POST]
+
+Executes a native Snowflake SQL query in given workspace directly without any validation or checks. Query can contain
+only one SQL statement per request. Every request is new Snowflake session. Response has a different format for SELECT
+query, non-SELECT query and failed query.
+
++ Parameters
+    + branch_id (required) - Id of the development branch
+    + workspace_id (required, number)
+
++ Attributes
+    + query (required, string) - Snowflake SQL query
+
+
++ Request (application/json)
+    + Headers
+        X-StorageApi-Token: your_token
+
+    + Body
+        {
+            "query": "SELECT * FROM table_name"
+        }
+
++ Response 200 (application/json)
+
+    + Body
+        // Executing query (SELECT)
+        {
+            "status": "ok",
+            "data":  {
+                "columns": [
+                    "ID",
+                    "NAME"
+                ],
+                "rows": [
+                    {
+                        "ID": '8',
+                        "NAME": "Lisa Simpson",
+                    },
+                    {
+                        "ID": '10',
+                        "NAME": "Bart Simpson",
+                    }
+                ]
+            }
+        }
+
+        // Executing statement (non-SELECT)
+        {
+            "status": "ok",
+            "message": "5 rows affected."
+        }
+
+        // Execution failed (Snowflake error message)
+        {
+            "status": "error",
+            "message": "An exception occurred while executing a query: SQL compilation error: error line 1 at position 7 invalid identifier 'BIRTHDATE'"
+        }
+
 ## Data Structures
 
 ### Workspace

--- a/src/Keboola/StorageApi/Workspaces.php
+++ b/src/Keboola/StorageApi/Workspaces.php
@@ -189,6 +189,19 @@ class Workspaces
         return (int) $job['id'];
     }
 
+    public function executeQuery(int $id, string $query): array
+    {
+        $result = $this->client->apiPostJson(
+            "workspaces/{$id}/query",
+            [
+                'query' => $query,
+            ],
+        );
+        assert(is_array($result));
+
+        return $result;
+    }
+
     public static function addCredentialsToWorkspaceResponse(array $workspaceResponse, array $resetPasswordResponse): array
     {
         if ($workspaceResponse['type'] === 'file') {

--- a/tests/Backend/Bigquery/WorkspacesQueryTest.php
+++ b/tests/Backend/Bigquery/WorkspacesQueryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Keboola\Test\Backend\Bigquery;
+
+use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\Workspaces;
+use Keboola\Test\Backend\WorkspaceConnectionTrait;
+use Keboola\Test\Backend\WorkspaceCredentialsAssertTrait;
+use Keboola\Test\Backend\Workspaces\ParallelWorkspacesTestCase;
+
+class WorkspacesQueryTest extends ParallelWorkspacesTestCase
+{
+    use WorkspaceConnectionTrait;
+    use WorkspaceCredentialsAssertTrait;
+
+    public function testWorkspaceQuery(): void
+    {
+        $defaultBranchId = $this->getDefaultBranchId($this);
+        $branchClient = $this->getBranchAwareDefaultClient($defaultBranchId);
+        $workspaces = new Workspaces($branchClient);
+        $workspace = $this->initTestWorkspace(
+            forceRecreate: true,
+        );
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Only Snowflake workspace is allowed to execute custom query.');
+        $workspaces->executeQuery($workspace['id'], 'SHOW TABLES');
+    }
+}

--- a/tests/Backend/Snowflake/WorkspacesQueryTest.php
+++ b/tests/Backend/Snowflake/WorkspacesQueryTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Keboola\Test\Backend\Snowflake;
+
+use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\Workspaces;
+use Keboola\TableBackendUtils\Escaping\Snowflake\SnowflakeQuote;
+use Keboola\Test\Backend\WorkspaceConnectionTrait;
+use Keboola\Test\Backend\WorkspaceCredentialsAssertTrait;
+use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
+use Keboola\Test\Backend\Workspaces\ParallelWorkspacesTestCase;
+use PDO;
+
+class WorkspacesQueryTest extends ParallelWorkspacesTestCase
+{
+    use WorkspaceConnectionTrait;
+    use WorkspaceCredentialsAssertTrait;
+
+    private const TABLE = 'CREW';
+    private const NON_EXISTING_WORKSPACE_ID = 2147483647;
+
+    public function testWorkspaceQuery(): void
+    {
+        $defaultBranchId = $this->getDefaultBranchId($this);
+        $branchClient = $this->getBranchAwareDefaultClient($defaultBranchId);
+        $workspaces = new Workspaces($branchClient);
+        $workspace = $this->initTestWorkspace(
+            forceRecreate: true,
+        );
+        $workspaceId = $workspace['id'];
+        $backend = WorkspaceBackendFactory::createWorkspaceBackend($workspace);
+
+        // Workspace not found
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage(sprintf('Workspace "%d" not found.', self::NON_EXISTING_WORKSPACE_ID));
+        $workspaces->executeQuery(self::NON_EXISTING_WORKSPACE_ID, 'SHOW TABLES');
+
+        // Create new table
+        $this->assertEmpty($backend->getTables());
+        $createTable = $workspaces->executeQuery(
+            $workspaceId,
+            sprintf(
+                'CREATE OR REPLACE TABLE %s (ID INT, NAME VARCHAR(32))',
+                SnowflakeQuote::quoteSingleIdentifier(self::TABLE),
+            ),
+        );
+        $this->assertSame(
+            $createTable,
+            [
+                'status' => 'ok',
+                'message' => 'Statement executed successfully.',
+            ],
+        );
+
+        /** @var list<string> $tables */
+        $tables = $backend->getTables();
+        $this->assertCount(1, $tables);
+
+        // Insert data
+        $insert = $workspaces->executeQuery(
+            $workspaceId,
+            sprintf(
+                "INSERT INTO %s VALUES (13, 'Scoop'), (42, 'Bob The Builder')",
+                SnowflakeQuote::quoteSingleIdentifier(self::TABLE),
+            ),
+        );
+        $this->assertSame(
+            $insert,
+            [
+                'status' => 'ok',
+                'message' => '2 rows affected.',
+            ],
+        );
+
+        // Select data
+        $select = $workspaces->executeQuery(
+            $workspaceId,
+            sprintf(
+                'SELECT * FROM %s',
+                SnowflakeQuote::quoteSingleIdentifier(self::TABLE),
+            ),
+        );
+        $this->assertSame(
+            $select,
+            [
+                'status' => 'ok',
+                'data' => [
+                    'columns' => [
+                        'ID',
+                        'NAME',
+                    ],
+                    'rows' => [
+                        0 => [
+                            'ID' => '13',
+                            'NAME' => 'Scoop',
+                        ],
+                        1 => [
+                            'ID' => '42',
+                            'NAME' => 'Bob The Builder',
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        // Select empty
+        $selectEmpty = $workspaces->executeQuery(
+            $workspaceId,
+            sprintf(
+                'SELECT * FROM %s WHERE ID = 666',
+                SnowflakeQuote::quoteSingleIdentifier(self::TABLE),
+            ),
+        );
+        $this->assertSame(
+            $selectEmpty,
+            [
+                'status' => 'ok',
+                'data' => [
+                    'columns' => [],
+                    'rows' => [],
+                ],
+            ],
+        );
+
+        // Alter table
+        $alterTable = $workspaces->executeQuery(
+            $workspaceId,
+            sprintf(
+                'ALTER TABLE %s ADD COLUMN IS_VEHICLE BOOLEAN DEFAULT FALSE;',
+                SnowflakeQuote::quoteSingleIdentifier(self::TABLE),
+            ),
+        );
+        $this->assertSame(
+            $alterTable,
+            [
+                'status' => 'ok',
+                'message' => 'Statement executed successfully.',
+            ],
+        );
+        $cols = $backend->getTableColumns(self::TABLE);
+        $this->assertSame(['ID', 'NAME', 'IS_VEHICLE'], $cols);
+
+        // Update data
+        $update = $workspaces->executeQuery(
+            $workspaceId,
+            sprintf(
+                'UPDATE %s SET IS_VEHICLE = TRUE WHERE ID = 13',
+                SnowflakeQuote::quoteSingleIdentifier(self::TABLE),
+            ),
+        );
+        $this->assertSame(
+            $update,
+            [
+                'status' => 'ok',
+                'message' => '1 rows affected.',
+            ],
+        );
+        $updated = $backend->fetchAll(self::TABLE, PDO::FETCH_ASSOC, 'ID');
+        $this->assertSame(
+            [
+                'ID' => '13',
+                'NAME' => 'Scoop',
+                'IS_VEHICLE' => '1',
+            ],
+            $updated[0],
+        );
+
+        $workspaces->executeQuery(
+            $workspaceId,
+            sprintf(
+                'DELETE FROM %s WHERE ID = 42',
+                SnowflakeQuote::quoteSingleIdentifier(self::TABLE),
+            ),
+        );
+        $this->assertSame(1, $backend->countRows(self::TABLE));
+
+        // Error
+        $update = $workspaces->executeQuery(
+            $workspaceId,
+            'SELECT * FROM BLACK_HOLE',
+        );
+        $this->assertSame(
+            $update,
+            [
+                'status' => 'error',
+                'message' => "An exception occurred while executing a query: SQL compilation error:\nObject 'BLACK_HOLE' does not exist or not authorized.",
+            ],
+        );
+    }
+}


### PR DESCRIPTION
- Calls endpoint "workspaces/{$id}/query" with custom Snowflake query.

Jira: CT-2016
KBC: keboola/connection#5559

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] New client method(s) support branches, or they are listed in BranchAwareClient 
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
