### PR TITLE
CT-1974 Remove support for `valuesByTableInStorage` option.

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4287,12 +4287,9 @@ This request is [asynchronous](#introduction/synchronous-and-asynchronous-calls)
                 + ne - Not equals  - case be used with multiple values
             + Default: eq
         + values[] (required, array) - array of variables to compare
-        + valuesByTableInWorkspace (optional) - Available with project feature `delete-rows-by-reference`. Exclusive with `values` and `valuesByTableInStorage` (just one param possible). Snowflake only.
+        + valuesByTableInWorkspace (optional) - Available with project feature `delete-rows-by-reference`. Exclusive with `values` (just one param possible). Snowflake only.
             + workspaceId (number) - ID of workspace (returned by Storage API)
             + table (string) - Exact name of table present in the workspace when doing this API call
-            + column (string) - Name of the column, which values (all rows) will be used as values to DELETE rows by. Datatype of this column has to match with datatype of the column specified in root of this API call.
-        + valuesByTableInStorage (optional) - Available with project feature `delete-rows-by-reference`. Exclusive with `values` and `valuesByTableInWorkspace` (just one param possible). Snowflake only.
-            + tableId - Storage ID of table (e.g. `in-c.bucketName.users`). It has to be present in Storage doing this API call
             + column (string) - Name of the column, which values (all rows) will be used as values to DELETE rows by. Datatype of this column has to match with datatype of the column specified in root of this API call.
 
         + dataType (optional, enum[string]) - Not supported for Redshift - for comparing (`[gt|lt|le|ge]`) numeric values you have to specify data type. BigQuery supports all listed types and converts them to BigQuery equivalent in the background

--- a/tests/Backend/CommonPart1/DeleteRowsTest.php
+++ b/tests/Backend/CommonPart1/DeleteRowsTest.php
@@ -383,7 +383,7 @@ class DeleteRowsTest extends ParallelWorkspacesTestCase
             $this->fail('Should fail because of invalid column type');
         } catch (ClientException $e) {
             $this->assertSame('Cannot use column "ID" to delete by. Column types do not match. Type is "NUMBER" but expected type is "VARCHAR".', $e->getMessage());
-            $this->assertSame('storage.tables.validation.invalidColumnToDeleteBy', $e->getStringCode());
+            $this->assertSame('storage.tables.invalidColumnToDeleteBy', $e->getStringCode());
         }
 
         // test non-existing column
@@ -403,7 +403,7 @@ class DeleteRowsTest extends ParallelWorkspacesTestCase
             $this->fail('Should fail because of column does not exist');
         } catch (ClientException $e) {
             $this->assertSame('Cannot use column "NOTEXISTING" to delete by. Column does not exist.', $e->getMessage());
-            $this->assertSame('storage.tables.validation.invalidColumnToDeleteBy', $e->getStringCode());
+            $this->assertSame('storage.tables.invalidColumnToDeleteBy', $e->getStringCode());
         }
 
         // test non-existing workspace

--- a/tests/Backend/CommonPart1/DeleteRowsTest.php
+++ b/tests/Backend/CommonPart1/DeleteRowsTest.php
@@ -10,7 +10,6 @@
 namespace Keboola\Test\Backend\CommonPart1;
 
 use Keboola\StorageApi\ClientException;
-use Keboola\StorageApi\Workspaces;
 use Keboola\Test\Backend\Workspaces\Backend\WorkspaceBackendFactory;
 use Keboola\Test\Backend\Workspaces\ParallelWorkspacesTestCase;
 use Keboola\Csv\CsvFile;
@@ -81,14 +80,13 @@ class DeleteRowsTest extends ParallelWorkspacesTestCase
         $this->assertArrayEqualsSorted($expectedTableContent, $parsedData, 0);
     }
 
-    // because BQ/exa does not support valuesByTableInStorage / valuesByTableInWorkspace yet/. Tmp fix
+    // because BQ/exa does not support valuesByTableInWorkspace yet/. Tmp fix
     private function isBigqueryOrExasolWithNewDeleteRows(string $backendName, array $filterParams): bool
     {
         return in_array($backendName, ['bigquery', 'exasol']) &&
             array_key_exists('whereFilters', $filterParams) &&
             count($filterParams['whereFilters']) > 0 &&
-            (array_key_exists('valuesByTableInStorage', $filterParams['whereFilters'][0]) || array_key_exists('valuesByTableInWorkspace', $filterParams['whereFilters'][0])
-            );
+            (array_key_exists('valuesByTableInWorkspace', $filterParams['whereFilters'][0]));
     }
 
     public function testDeleteRowsMissingValuesShouldReturnUserError(): void
@@ -306,52 +304,6 @@ class DeleteRowsTest extends ParallelWorkspacesTestCase
                         'klara',
                         'PRG',
                         'female',
-                    ],
-                    [
-                        '4',
-                        'miro',
-                        'BRA',
-                        'male',
-                    ],
-                    [
-                        '5',
-                        'hidden',
-                        '',
-                        'male',
-                    ],
-                ],
-            ],
-            'where filter: valuesByTableInStorage' => [
-                [
-                    'whereFilters' => [
-                        [
-                            'column' => 'city',
-                            'valuesByTableInStorage' => [
-                                'tableId' => 'table',
-                                'column' => 'city',
-                            ],
-                        ],
-                    ],
-                ],
-                // no rows should be deleted because valuesByTableInStorage doesn't do anything yet
-                [
-                    [
-                        '1',
-                        'martin',
-                        'PRG',
-                        'male',
-                    ],
-                    [
-                        '2',
-                        'klara',
-                        'PRG',
-                        'female',
-                    ],
-                    [
-                        '3',
-                        'ondra',
-                        'VAN',
-                        'male',
                     ],
                     [
                         '4',


### PR DESCRIPTION
Jira: CT-1974
KBC:  https://github.com/keboola/connection/pull/5598

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] New client method(s) support branches, or they are listed in BranchAwareClient 
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)
