### PR TITLE
[workspaces] Unify loghinType conditions, resetCredentials method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_VERSION=8.1
 # the default env bellow is used when build pipeline sends "PHP_VERSION=" - the above default value is ignored in that case
-FROM php:${PHP_VERSION:-8.1}-cli-buster as dev
+FROM php:${PHP_VERSION:-8.1}-cli-buster AS dev
 MAINTAINER Martin Halamicek <martin@keboola.com>
 ENV DEBIAN_FRONTEND noninteractive
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
 		"keboola/phpunit-retry-annotations": "^0.5",
 		"keboola/retry": "^0.5.0",
 		"keboola/table-backend-utils": ">=2.9.0",
-		"phpcompatibility/php-compatibility": "dev-develop",
 		"phpstan/phpstan": "^1",
 		"phpstan/phpstan-phpunit": "^1.0",
 		"phpunit/phpunit": "^7.0|^8.0|^9.0",
@@ -58,13 +57,11 @@
     },
 	"scripts": {
 		"phpcs": "phpcs -n .",
-		"phpcs-compatibility": "phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility && phpcs --ignore=*vendor/*,*cache/* -n . --standard=PHPCompatibility --runtime-set testVersion 8.1-8.3",
 		"phpcbf": "phpcbf -n .",
 		"phpstan": "phpstan analyse --no-progress --level=max . -c phpstan.neon",
 		"tests": "phpunit --testsuite=unit",
 		"ci": [
 			"@phpcs",
-			"@phpcs-compatibility",
 			"@phpstan",
 			"@tests"
 		]

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 		"keboola/phpunit-retry-annotations": "^0.5",
 		"keboola/retry": "^0.5.0",
 		"keboola/table-backend-utils": ">=2.9.0",
-		"phpcompatibility/php-compatibility": "*",
+		"phpcompatibility/php-compatibility": "dev-develop",
 		"phpstan/phpstan": "^1",
 		"phpstan/phpstan-phpunit": "^1.0",
 		"phpunit/phpunit": "^7.0|^8.0|^9.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   tests: &base
     build:
@@ -57,8 +56,8 @@ services:
 
 networks:
   default:
-    external:
       name: connection_api-tests
+      external: true
 
 volumes:
   tools-cache:

--- a/src/Keboola/StorageApi/Components.php
+++ b/src/Keboola/StorageApi/Components.php
@@ -336,8 +336,7 @@ class Components
             $url .= '?' . http_build_query(['async' => true]);
         }
 
-        $ws = new Workspaces($this->client);
-        return $ws->decorateWorkspaceCreateWithCredentials(
+        return (new Workspaces($this->client))->decorateWorkspaceCreateWithCredentials(
             $options,
             function (array $options) use ($url) {
                 $workspaceResponse = $this->client->apiPostJson(

--- a/src/Keboola/StorageApi/WorkspaceLoginType.php
+++ b/src/Keboola/StorageApi/WorkspaceLoginType.php
@@ -11,4 +11,22 @@ enum WorkspaceLoginType: string
     case SNOWFLAKE_LEGACY_SERVICE_PASSWORD = 'snowflake-legacy-service';
     case SNOWFLAKE_PERSON_KEYPAIR = 'snowflake-person-keypair';
     case SNOWFLAKE_SERVICE_KEYPAIR = 'snowflake-service-keypair';
+
+    public function isPasswordLogin(): bool
+    {
+        return match ($this) {
+            self::DEFAULT,
+            self::SNOWFLAKE_LEGACY_SERVICE_PASSWORD => true,
+            default => false,
+        };
+    }
+
+    public function isKeyPairLogin(): bool
+    {
+        return match ($this) {
+            self::SNOWFLAKE_PERSON_KEYPAIR,
+            self::SNOWFLAKE_SERVICE_KEYPAIR => true,
+            default => false,
+        };
+    }
 }

--- a/src/Keboola/StorageApi/Workspaces.php
+++ b/src/Keboola/StorageApi/Workspaces.php
@@ -220,8 +220,10 @@ class Workspaces
         return $workspaceResponse;
     }
 
-    public static function addCredentialsToWorkspaceResponse(array $workspaceResponse, array $resetPasswordResponse): array
-    {
+    public static function addCredentialsToWorkspaceResponse(
+        array $workspaceResponse,
+        array $resetPasswordResponse,
+    ): array {
         if ($workspaceResponse['type'] === 'file') {
             $secret = 'connectionString';
         } elseif ($workspaceResponse['connection']['backend'] === 'bigquery') {
@@ -264,7 +266,8 @@ class Workspaces
 
     /**
      * @return array{
-     *     password?: string
+     *     password?: string,
+     *     credentials?: array<mixed>,
      * }
      */
     public function resetCredentials(

--- a/src/Keboola/StorageApi/Workspaces/ResetCredentialsRequest.php
+++ b/src/Keboola/StorageApi/Workspaces/ResetCredentialsRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StorageApi\Workspaces;
+
+class ResetCredentialsRequest
+{
+    public function __construct(
+        public readonly ?string $publicKey = null,
+    ) {
+    }
+}

--- a/tests/Backend/Snowflake/WorkspacesLoginTypesTest.php
+++ b/tests/Backend/Snowflake/WorkspacesLoginTypesTest.php
@@ -55,7 +55,7 @@ class WorkspacesLoginTypesTest extends ParallelWorkspacesTestCase
     public function testWorkspaceCreate(
         WorkspaceLoginType|null $loginType,
         bool $async,
-        string $expectedLoginType
+        string $expectedLoginType,
     ): void {
         $this->initEvents($this->workspaceSapiClient);
 
@@ -275,5 +275,115 @@ class WorkspacesLoginTypesTest extends ParallelWorkspacesTestCase
         $workspace['connection']['privateKey'] = $key->getPrivateKey();
         $backendKey1_3 = WorkspaceBackendFactory::createWorkspaceForSnowflakeDbal($workspace);
         $backendKey1_3->getDb()->executeQuery('SELECT 1');
+    }
+
+    public static function provideLoginTypesWithPasswordCredentials(): iterable
+    {
+        yield 'no loginType' => [
+            'loginType' => null,
+        ];
+
+        yield 'password loginType' => [
+            'loginType' => WorkspaceLoginType::DEFAULT,
+        ];
+    }
+
+    /** @dataProvider provideLoginTypesWithPasswordCredentials */
+    public function testResetPasswordCredentials(?WorkspaceLoginType $loginType): void
+    {
+        $workspaces = $this->createPartialMock(Workspaces::class, [
+            'getWorkspace',
+            'resetWorkspacePassword',
+            'setPublicKey',
+        ]);
+        $workspaces->expects(self::once())
+            ->method('getWorkspace')
+            ->with('123')
+            ->willReturn([
+                'connection' => [
+                    'loginType' => $loginType?->value,
+                ],
+            ]);
+        $workspaces->expects(self::once())
+            ->method('resetWorkspacePassword')
+            ->with('123')
+            ->willReturn([
+                'password' => 'new-password',
+            ]);
+        $workspaces->expects(self::never())->method('setPublicKey');
+
+        $result = $workspaces->resetCredentials('123', new Workspaces\ResetCredentialsRequest());
+        self::assertSame([
+            'password' => 'new-password',
+        ], $result);
+    }
+
+    public function testResetKeyPairCredentials(): void
+    {
+        $workspaces = $this->createPartialMock(Workspaces::class, [
+            'getWorkspace',
+            'resetWorkspacePassword',
+            'setPublicKey',
+        ]);
+        $workspaces->expects(self::once())
+            ->method('getWorkspace')
+            ->with('123')
+            ->willReturn([
+                'connection' => [
+                    'loginType' => WorkspaceLoginType::SNOWFLAKE_PERSON_KEYPAIR->value,
+                ],
+            ]);
+        $workspaces->expects(self::never())->method('resetWorkspacePassword');
+        $workspaces->expects(self::once())
+            ->method('setPublicKey')
+            ->with('123', new Workspaces\SetPublicKeyRequest(publicKey: 'publicKey'));
+
+        $result = $workspaces->resetCredentials('123', new Workspaces\ResetCredentialsRequest(publicKey: 'publicKey'));
+        self::assertSame([], $result);
+    }
+
+    public static function provideInvalidResetCredentialsRequestParameters(): iterable
+    {
+        yield 'password loginType with publicKey' => [
+            'loginType' => WorkspaceLoginType::DEFAULT,
+            'request' => new Workspaces\ResetCredentialsRequest(
+                publicKey: 'publicKey',
+            ),
+            'expectedError' => 'Workspace with login type "default" does not support "publicKey" credentials.',
+        ];
+
+        yield 'keypair loginType without publicKey' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
+            'request' => new Workspaces\ResetCredentialsRequest(),
+            'expectedError' => 'Workspace with login type "snowflake-service-keypair" requires "publicKey" credentials.',
+        ];
+    }
+
+    /** @dataProvider provideInvalidResetCredentialsRequestParameters */
+    public function testResetCredentialsWithInvalidParametersThrowsException(
+        WorkspaceLoginType $loginType,
+        Workspaces\ResetCredentialsRequest $request,
+        string $expectedError,
+    ): void {
+        $workspaces = $this->createPartialMock(Workspaces::class, [
+            'getWorkspace',
+            'resetWorkspacePassword',
+            'setPublicKey',
+        ]);
+        $workspaces->expects(self::once())
+            ->method('getWorkspace')
+            ->with('123')
+            ->willReturn([
+                'connection' => [
+                    'loginType' => $loginType->value,
+                ],
+            ]);
+        $workspaces->expects(self::never())->method('resetWorkspacePassword');
+        $workspaces->expects(self::never())->method('setPublicKey');
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage($expectedError);
+
+        $workspaces->resetCredentials('123', $request);
     }
 }

--- a/tests/WorkspaceLoginTypeTest.php
+++ b/tests/WorkspaceLoginTypeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Test;
+
+use Keboola\StorageApi\WorkspaceLoginType;
+use PHPUnit\Framework\TestCase;
+
+class WorkspaceLoginTypeTest extends TestCase
+{
+    public static function provideIsPasswordLoginTestData(): iterable
+    {
+        yield 'default' => [
+            'loginType' => WorkspaceLoginType::DEFAULT,
+            'isPasswordLogin' => true,
+        ];
+
+        yield 'snowflake-person-sso' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_PERSON_SSO,
+            'isPasswordLogin' => false,
+        ];
+
+        yield 'snowflake-legacy-service' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_LEGACY_SERVICE_PASSWORD,
+            'isPasswordLogin' => true,
+        ];
+
+        yield 'snowflake-person-keypair' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_PERSON_KEYPAIR,
+            'isPasswordLogin' => false,
+        ];
+
+        yield 'snowflake-service-keypair' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
+            'isPasswordLogin' => false,
+        ];
+    }
+
+    /** @dataProvider provideIsPasswordLoginTestData */
+    public function testIsPasswordLogin(WorkspaceLoginType $loginType, bool $isPasswordLogin): void
+    {
+        self::assertSame($isPasswordLogin, $loginType->isPasswordLogin());
+    }
+
+    public static function provideIsKeyPairLoginTestData(): iterable
+    {
+        yield 'default' => [
+            'loginType' => WorkspaceLoginType::DEFAULT,
+            'isKeyPairLogin' => false,
+        ];
+
+        yield 'snowflake-person-sso' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_PERSON_SSO,
+            'isKeyPairLogin' => false,
+        ];
+
+        yield 'snowflake-legacy-service' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_LEGACY_SERVICE_PASSWORD,
+            'isKeyPairLogin' => false,
+        ];
+
+        yield 'snowflake-person-keypair' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_PERSON_KEYPAIR,
+            'isKeyPairLogin' => true,
+        ];
+
+        yield 'snowflake-service-keypair' => [
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
+            'isKeyPairLogin' => true,
+        ];
+    }
+
+    /** @dataProvider provideIsKeyPairLoginTestData */
+    public function testIsKeyPairLogin(WorkspaceLoginType $loginType, bool $isKeyPairLogin): void
+    {
+        self::assertSame($isKeyPairLogin, $loginType->isKeyPairLogin());
+    }
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-258
Based on https://github.com/keboola/storage-api-php-client/pull/1495

Od generovani key-pair primo v SAPI clientovi jsem nakonec upustil. V nekterych situacich (staging workspace) by se to hodilo, jindy (SQL sandbox) zas ne a nechtel jsem to delat tak polomagicky nekdy.

Nechal jsem ale vytazeni te `decorateWorkspaceCreateWithCredentials` metody a pouziti v `Components::createConfigurationWorkspace()` i `Workspaces::createWorkspace()`, aby byly jednotny pravidla ohledne generovani password.

Jelikoz jsem neintegroval generovani key-pair, nebylo potreba zaviset na `keboola/key-generator` a tim padem ani zvedat min. podporovanou verzi PHP a neni tedy potreba delat major release :tada: 

Testy si @zajca rikal, ze bys poresil?