### PR TITLE
Fix: New versions of libs broke PHPStan

### DIFF
--- a/tests/Backend/ExternalBuckets/BigqueryRegisterBucketTest.php
+++ b/tests/Backend/ExternalBuckets/BigqueryRegisterBucketTest.php
@@ -12,6 +12,7 @@ use Google\Cloud\BigQuery\AnalyticsHub\V1\Listing\BigQueryDatasetSource;
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\Iam\V1\Binding;
 use Google\Cloud\Storage\StorageClient;
+use Google\Protobuf\RepeatedField;
 use Keboola\StorageApi\BranchAwareClient;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\GlobalSearchOptions;
@@ -1478,13 +1479,20 @@ SQL,
         $createdListing = $analyticHubClient->createListing($dataExchange->getName(), $listingId, $listing);
 
         $iamExchangerPolicy = $analyticHubClient->getIamPolicy($dataExchange->getName());
+
+        /**
+         * @todo May be removed after "google/common-protos" update.
+         * @var RepeatedField<Binding> $binding
+         */
         $binding = $iamExchangerPolicy->getBindings();
+
         // 3. Add permission to destination project
         $binding[] = new Binding([
             'role' => 'roles/analyticshub.subscriber',
             'members' => ['serviceAccount:' . BQ_DESTINATION_PROJECT_SERVICE_ACC_EMAIL],
         ]);
-        $iamExchangerPolicy->setBindings($binding);
+
+        $iamExchangerPolicy->setBindings($binding); // @phpstan-ignore-line
         $analyticHubClient->setIamPolicy($dataExchange->getName(), $iamExchangerPolicy);
 
         $parsedName = AnalyticsHubServiceClient::parseName($createdListing->getName());

--- a/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
+++ b/tests/Backend/Workspaces/WorkspacesSnowflakeTest.php
@@ -167,6 +167,10 @@ class WorkspacesSnowflakeTest extends ParallelWorkspacesTestCase
         $db = $this->getDbConnectionSnowflake($workspace['connection']);
 
         // check if schema is transient
+        /** @var list<array{
+         *     name: string,
+         *     options: string,
+         * }> $schemas */
         $schemas = $db->fetchAll('SHOW SCHEMAS');
 
         $workspaceSchema = null;


### PR DESCRIPTION
Jira: −
KBC: −

**Fixed PHPStan:**
- BigqueryRegisterBucketTest
  - Broke by google/protobuf v4.30.2 → v4.31.0 update
- WorkspacesSnowflakeTest
  - Broke by keboola/php-csv-db-import 6.0.0 → 6.1.0 update


```
Error: Cannot access an offset on Google\Protobuf\Internal\RepeatedField.
Error: Parameter #1 $value of method Keboola\Db\Import\Snowflake\AbstractConnection::quoteIdentifier() expects string, int|string|null given.
 ------ -------------------------------------------------------------------- 
  Line   tests/Backend/ExternalBuckets/BigqueryRegisterBucketTest.php        
 ------ -------------------------------------------------------------------- 
  1483   Cannot access an offset on Google\Protobuf\Internal\RepeatedField.  
 ------ -------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   tests/Backend/Workspaces/WorkspacesSnowflakeTest.php               
 ------ ------------------------------------------------------------------- 
  [18](https://github.com/keboola/storage-api-php-client/actions/runs/15116187372/job/42511989314?pr=1499#step:5:19)3    Parameter #1 $value of method                                      
         Keboola\Db\Import\Snowflake\AbstractConnection::quoteIdentifier()  
         expects string, int|string|null given.                             
 ------ ------------------------------------------------------------------- 

Error:  [ERROR] Found 2 errors                                                         

Script phpstan analyse --no-progress --level=max . -c phpstan.neon handling the phpstan event returned with error code 1
Script @phpstan was called via ci
Error: Process completed with exit code 1.
```