### PR TITLE
chore(debian): Upgrade to Debian 11 (Bullseye)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_VERSION=8.1
 # the default env bellow is used when build pipeline sends "PHP_VERSION=" - the above default value is ignored in that case
-FROM php:${PHP_VERSION:-8.1}-cli-buster AS dev
+FROM php:${PHP_VERSION:-8.1}-cli-bullseye AS dev
 MAINTAINER Martin Halamicek <martin@keboola.com>
 ENV DEBIAN_FRONTEND noninteractive
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
@@ -22,7 +22,7 @@ ENV LANG=C.UTF-8
 RUN apt-get update -q \
     && apt-get install gnupg -y --no-install-recommends \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update -q \
     && ACCEPT_EULA=Y apt-get install \
         unzip \


### PR DESCRIPTION
Jira: −
KBC: −

Before asking for review make sure that:

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

---

## Why upgrade?

Because `apt update` stopped working. 
<img width="1334" height="465" alt="image" src="https://github.com/user-attachments/assets/222f89e7-c578-442d-b57e-0eff4290b454" />

Because Buster repositories were moved to archive - https://lists.debian.org/debian-devel-announce/2025/06/msg00001.html.

And PHP image for Buster is no longed updated (last push 2 years ago) - https://hub.docker.com/layers/library/php/8.1-cli-buster/images/sha256-f1d4b7f30ea4a06fd9dedb26c43ab18a698bccde5c3476293afeed2dbc81a290.

Which means that `/etc/apt/sources.list` in PHP image contains wrong URLs to repositories. They start with `deb.` but should already start `archive.`.

So the easiest way how to solve it was to upgrade to Bullseye which use in other PHP app and libs.

**What label should it have?**


