### PR TITLE
feat: Make BackendConfiguration properties accessible from outside

### DIFF
--- a/src/Keboola/StorageApi/Options/BackendConfiguration.php
+++ b/src/Keboola/StorageApi/Options/BackendConfiguration.php
@@ -6,16 +6,10 @@ namespace Keboola\StorageApi\Options;
 
 class BackendConfiguration
 {
-    private ?string $context;
-
-    private ?string $size;
-
     public function __construct(
-        ?string $context = null,
-        ?string $size = null
+        public readonly ?string $context = null,
+        public readonly ?string $size = null
     ) {
-        $this->context = $context;
-        $this->size = $size;
     }
 
     /**


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-402

Change `BackendConfiguration` properties to `public readonly`. There is `public getBackendConfiguration()` method on the `Client`, but no way to get to properties values once the object is created (except exporting it as a JSON string).

## Checklist
- [X] New client method(s) has tests
- [X] New client method(s) support branches, or they are listed in BranchAwareClient 
- [X] Apiary file is updated

