### PR TITLE
test(scheduled task): Creation time with milliseconds

### DIFF
--- a/tests/Backend/ExternalBuckets/ScheduledTasksTest.php
+++ b/tests/Backend/ExternalBuckets/ScheduledTasksTest.php
@@ -58,7 +58,8 @@ class ScheduledTasksTest extends StorageApiTestCase
             self::EXISTING_BUCKET_NAME,
         );
 
-        $started = new DateTime();
+        // To avoid collision with $createdAt which has only seconds precision.
+        $started = new DateTime('now - 1 second');
 
         // Schedule task for non-existing bucket
         $exception = null;


### PR DESCRIPTION
Jira: −
KBC: keboola/connection#6086

Before asking for review make sure that:

## Checklist

- [-] New client method(s) has tests
- [-] New client method(s) support branches, or they are listed in BranchAwareClient 
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

--- 

Fix test to be stable. There was a problem with comparison of timestamp with different precision (seconds vs. milliseconds).