### PR TITLE
drop case which wont work on uuid only enabled stack

### DIFF
--- a/tests/Common/TableEventsTest.php
+++ b/tests/Common/TableEventsTest.php
@@ -29,16 +29,6 @@ class TableEventsTest extends StorageApiTestCase
             ->setComponent('dummy')
             ->setMessage('dummy'), $this->_client);
 
-        // sinceId id (int)
-        $events = $this->_client->listTableEvents(
-            $tableId,
-            [
-                'sinceId' => $lastEvent['id'],
-            ],
-        );
-        $this->assertCount(3, $events);
-        $this->assertEventUuid($events[0]);
-
         // sinceId uuid
         $events = $this->_client->listTableEvents(
             $tableId,


### PR DESCRIPTION
https://keboolaglobal.slack.com/archives/C055RTFCJ6M/p1754423990827229?thread_ts=1754419529.598909&cid=C055RTFCJ6M

Jira: CT-XXX
KBC: XXX

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] New client method(s) support branches, or they are listed in BranchAwareClient 
- [x] Apiary file is updated

## Release

  - [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

---
ci stack was enabled uuid only, this case is no longer valid and there is no stack without uuid only now.